### PR TITLE
feat(policy): gated lead-recovery create_agent for supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ paseo-pi-team/
 
 | Profile | `PASEO_PI_ROLE` | Tool policy (mặc định, chỉnh sau khi chạy `/team-tools`) |
 |---|---|---|
-| `pi-supervisor` | `supervisor` | `read` + `mcp` (chỉ gọi monitoring qua proxy: `list_agents`, `get_agent_status`, `get_agent_activity`, `send_agent_prompt`). Không `write`/`edit`, không tạo agent/workspace. |
+| `pi-supervisor` | `supervisor` | `read` + `mcp` (qua proxy: `list_agents`, `get_agent_status`, `get_agent_activity`, `send_agent_prompt` + `create_agent` **recovery-only** — argument-guarded: `pi-lead/...` provider + `labels.purpose ∈ {recovery,bootstrap}` + `labels.recovery_for` + `settings.thinkingOptionId`; mọi shape khác bị chặn fail-closed). Không `write`/`edit`, không workspace, không peer, không discovery. |
 | `pi-lead` | `lead` | Mặc định tối thiểu: Pi `read`/`bash` + `mcp`/`mcp_script` + Paseo `discovery`/`workspace`/`monitoring`/`orchestration`/`permissions` (qua proxy, target guard fail-closed). `write`/`edit` chỉ khi `PASEO_TEAM_LEAD_WRITE=1` (ghi trong WORKSPACE_PROTOCOL của repo nếu Lead được tự implement tiny task). |
 | `pi-peer` | `peer` | `MODE: write` → `read`/`write`/`edit`/`bash`. `MODE: read-only` (mặc định, fail-closed) → `read`/`bash`. Không bao giờ có `mcp` hoặc Paseo orchestration tools. |
 

--- a/extensions/paseo-team-policy.ts
+++ b/extensions/paseo-team-policy.ts
@@ -100,18 +100,36 @@ const PI_WRITE = ["read", "write", "edit", "bash"];
 /** pi-mcp-adapter proxy tools — Paseo tools are reached through the `mcp` tool. */
 const MCP_TOOLS = ["mcp", "mcp_script"];
 
-/**
- * Paseo tools the supervisor may call through the MCP proxy. Fail-closed:
- * anything else in the catalog (terminals, workspace scripts, schedules,
- * discovery, orchestration, permissions, ...) is blocked. send_agent_prompt
- * is allowed so the supervisor can deliver observations to the Lead.
- */
-const SUPERVISOR_ALLOWED_MCP_TARGETS: string[] = [
+/** Monitoring-only Paseo tools — the supervisor's default surface. */
+const SUPERVISOR_MONITORING_TARGETS: string[] = [
 	"list_agents",
 	"get_agent_status",
 	"get_agent_activity",
 	"send_agent_prompt",
 ];
+
+/**
+ * Paseo tools the supervisor may call through the MCP proxy. Fail-closed:
+ * anything else in the catalog (terminals, workspace scripts, schedules,
+ * discovery, orchestration, permissions, ...) is blocked. send_agent_prompt
+ * is allowed so the supervisor can deliver observations to the Lead.
+ * create_agent is the SINGLE orchestration exception — a gated lead-recovery
+ * action whose arguments are validated by supervisorCreateAgentBlockReason.
+ * Raw orchestration (peers, workspaces, discovery, arbitrary model choice)
+ * stays blocked.
+ */
+const SUPERVISOR_ALLOWED_MCP_TARGETS: string[] = [
+	...SUPERVISOR_MONITORING_TARGETS,
+	"create_agent",
+];
+
+/**
+ * Stricter set for the mcp_script backstop scan: create_agent is excluded
+ * because a script's arguments cannot be statically verified (the arg guard
+ * only runs on direct `mcp` proxy calls). Supervisor mcp_script is already
+ * hard-denied at the policy level — this is defense in depth only.
+ */
+const SUPERVISOR_MCP_SCRIPT_TARGETS: string[] = SUPERVISOR_MONITORING_TARGETS;
 
 /**
  * Match a possibly-prefixed proxy tool name against known Paseo tool names.
@@ -306,6 +324,71 @@ export function mcpAllowedTargets(role: TeamRole): string[] {
 	}
 }
 
+/** Extract create_agent args from an mcp proxy input ({ tool, args }). */
+function extractCreateAgentArgs(input: unknown): unknown {
+	if (typeof input !== "object" || input === null) return null;
+	const args = (input as Record<string, unknown>).args;
+	if (typeof args === "string") {
+		try {
+			return JSON.parse(args);
+		} catch {
+			return null;
+		}
+	}
+	return args ?? null;
+}
+
+const SUPERVISOR_RECOVERY_PURPOSES = new Set(["recovery", "bootstrap"]);
+
+/**
+ * Argument-level gate for supervisor create_agent through the MCP proxy.
+ * The supervisor may create exactly ONE kind of agent: a successor Lead
+ * (`pi-lead/<pi-provider>/<model-id>`), flagged recovery/bootstrap with a
+ * project id and an explicit thinking level. Anything else — peers, other
+ * providers, missing labels, missing thinking, malformed args — is blocked
+ * fail-closed. The labels land on the created agent, so `paseo agent ls`
+ * shows exactly why it exists (audit trail).
+ */
+export function supervisorCreateAgentBlockReason(
+	input: unknown,
+): string | null {
+	const args = extractCreateAgentArgs(input);
+	if (typeof args !== "object" || args === null) {
+		return "Supervisor create_agent requires an args object (provider, labels, settings). Refusing fail-closed.";
+	}
+	const rec = args as Record<string, unknown>;
+	const provider = typeof rec.provider === "string" ? rec.provider : "";
+	// pi-lead/<pi-provider>/<model-id>; model ids may contain slashes
+	// (Paseo splits at the first slash only), so just require both segments.
+	if (!/^pi-lead\/[^/]+\/[^/]+/.test(provider)) {
+		return `Supervisor create_agent is lead-recovery only: provider must be "pi-lead/<pi-provider>/<model-id>" (got "${provider || "<missing>"}"). Peers and other providers are created by the Lead, never by the Supervisor.`;
+	}
+	const labels = rec.labels;
+	if (typeof labels !== "object" || labels === null) {
+		return "Supervisor create_agent requires labels to prove this is a gated recovery action.";
+	}
+	const labelMap = labels as Record<string, unknown>;
+	const purpose = labelMap.purpose;
+	if (
+		typeof purpose !== "string" ||
+		!SUPERVISOR_RECOVERY_PURPOSES.has(purpose)
+	) {
+		return `Supervisor create_agent labels.purpose must be "recovery" or "bootstrap" (got "${typeof purpose === "string" ? purpose : "<missing>"}").`;
+	}
+	const recoveryFor = labelMap.recovery_for;
+	if (typeof recoveryFor !== "string" || recoveryFor.trim().length === 0) {
+		return "Supervisor create_agent labels.recovery_for (project id) is required.";
+	}
+	const thinking =
+		typeof rec.settings === "object" && rec.settings !== null
+			? (rec.settings as Record<string, unknown>).thinkingOptionId
+			: undefined;
+	if (typeof thinking !== "string" || thinking.trim().length === 0) {
+		return "Supervisor create_agent requires settings.thinkingOptionId (no daemon-default model — route from the approved Lead route).";
+	}
+	return null;
+}
+
 /**
  * Decide whether an `mcp` proxy call is allowed for a role.
  * Returns a block reason, or null when allowed.
@@ -322,9 +405,13 @@ export function mcpBlockReason(role: TeamRole, input: unknown): string | null {
 	const target = classification.target ?? "";
 	if (!matchesPaseoToolName(target, mcpAllowedTargets(role))) {
 		if (role === "supervisor") {
-			return `Supervisor may only call monitoring tools through MCP (list_agents, get_agent_status, get_agent_activity, send_agent_prompt). "${target}" is blocked — send an observation to the Lead instead.`;
+			return `Supervisor may only call monitoring tools through MCP (list_agents, get_agent_status, get_agent_activity, send_agent_prompt) plus a gated lead-recovery create_agent. "${target}" is blocked — send an observation to the Lead instead.`;
 		}
 		return `"${target}" is not in the ${role} MCP allowlist (discovery, workspace, monitoring, orchestration, permissions).`;
+	}
+	if (role === "supervisor" && matchesPaseoToolName(target, ["create_agent"])) {
+		const argBlock = supervisorCreateAgentBlockReason(input);
+		if (argBlock) return argBlock;
 	}
 	return null;
 }
@@ -357,7 +444,13 @@ export function mcpScriptBlockReason(
 	role: TeamRole,
 	code: string,
 ): string | null {
-	const allowed = mcpAllowedTargets(role);
+	// Supervisor: mcp_script can't be argument-guarded, so its scan keeps the
+	// stricter monitoring-only set (create_agent excluded). mcp_script is
+	// already hard-denied for the supervisor at the policy level anyway.
+	const allowed =
+		role === "supervisor"
+			? SUPERVISOR_MCP_SCRIPT_TARGETS
+			: mcpAllowedTargets(role);
 	for (const _match of code.matchAll(MCP_SCRIPT_DYNAMIC_CALL_RE)) {
 		return `mcp_script invokes an MCP tool through a non-literal target (variable, expression or computed key) — the ${role} allowlist cannot verify it, so the call is blocked fail-closed. Use a literal tool name: tools.call("<allowed_tool>", ...) or tools.<allowed_tool>().`;
 	}

--- a/prompts/supervisor.md
+++ b/prompts/supervisor.md
@@ -116,6 +116,28 @@ Mỗi lần quan sát:
 - Human hỏi Lead liên tục khiến Lead mất coordination attention.
 - Agent chết nhưng scope được giao lại khi trạng thái Git cũ chưa rõ.
 
+## Lead recovery authority
+
+Bạn sở hữu MỘT quyền orchestration duy nhất, fail-closed: tạo successor
+Lead khi Lead hiện tại không recover được (đã có evidence nhiều vòng quan
+sát, không phải suspected mechanism). Extension chặn mọi create_agent không
+đúng shape — đây là path duy nhất bạn có thể tạo agent:
+
+- `provider` PHẢI là `pi-lead/<pi-provider>/<model-id>` — tuyệt đối không
+  tạo pi-peer/pi-supervisor hay provider khác;
+- `labels.purpose` PHẢI là `recovery` hoặc `bootstrap`;
+- `labels.recovery_for` PHẢI là project id bạn quản lý;
+- `settings.thinkingOptionId` BẮT BUỘC — route từ
+  `~/.paseo-pi-team/cluster-routing.local.json` (không bao giờ bỏ model/
+  thinking để daemon tự chọn).
+
+Bạn KHÔNG được: tạo workspace mới, chọn model/host ngoài route đã duyệt,
+archive/cancel Lead cũ trước khi successor ACK — archive Lead cũ là quyết
+định của Human.
+
+Successor Lead mặc định được tạo dưới agent track của bạn; nếu cần thành
+root agent, đề xuất Human chạy `paseo agent detach <id>` (đảo ngược được).
+
 ## Tool boundary
 
 Chỉ dùng các monitoring operation được allowlist:
@@ -124,9 +146,11 @@ Chỉ dùng các monitoring operation được allowlist:
 - `get_agent_status`
 - `get_agent_activity`
 - `send_agent_prompt`
+- `create_agent` (CHỈ theo **Lead recovery authority** ở trên — argument
+guard của extension chặn mọi shape khác)
 
-Không dùng terminal, workspace mutation, provider mutation, agent creation
-hoặc permission response.
+Không dùng terminal, workspace mutation, provider mutation, permission
+response hoặc bất kỳ orchestration nào khác.
 
 ## Output contract
 
@@ -157,6 +181,16 @@ SUPERVISOR_DECISION:                 # chỉ khi bạn quyết định thay Huma
   FOLLOWED_UP: yes | no              # đã quan sát hệ quả chưa
 
 CONFIDENCE: low | medium | high
+```
+
+Khi tạo successor Lead (recovery), thêm block này:
+
+```text
+LEAD_RECOVERY:
+  TRIGGER_EVIDENCE:          # observation đã chứng minh Lead không recover được
+  SUCCESSOR_REF:             # agent ref sau khi create_agent
+  HANDOFF_BUNDLE:            # evidence + context chuyển cho successor trong initialPrompt
+  OLD_LEAD_ARCHIVE:          # human_action — KHÔNG tự archive, KHÔNG cancel
 ```
 
 Quy ước:

--- a/test/policy.test.mts
+++ b/test/policy.test.mts
@@ -511,12 +511,12 @@ assert.equal(isSupervisorAllowedMcpTarget("list_agents"), true);
 assert.equal(isSupervisorAllowedMcpTarget("paseo_list_agents"), true);
 assert.equal(isSupervisorAllowedMcpTarget("get_agent_status"), true);
 assert.equal(isSupervisorAllowedMcpTarget("send_agent_prompt"), true);
-assert.equal(isSupervisorAllowedMcpTarget("create_agent"), false);
 assert.equal(
-	isSupervisorAllowedMcpTarget("paseo_create_agent"),
-	false,
-	"prefixed form",
+	isSupervisorAllowedMcpTarget("create_agent"),
+	true,
+	"create_agent is the single orchestration exception at target level; args are gated by supervisorCreateAgentBlockReason",
 );
+assert.equal(isSupervisorAllowedMcpTarget("paseo_create_agent"), true);
 assert.equal(
 	isSupervisorAllowedMcpTarget("create_terminal"),
 	false,
@@ -553,9 +553,104 @@ assert.match(
 	mcpBlockReason("supervisor", { tool: "create_terminal" }) ?? "",
 	/monitoring tools/,
 );
+// Supervisor create_agent: the TARGET is allowed, but the ARGS are the gate
+// (fail-closed). Only a gated lead-recovery create passes.
+const recoveryCreateArgs = {
+	provider: "pi-lead/Minnyat/gpt-5.6-sol",
+	labels: { purpose: "recovery", recovery_for: "content-analysis" },
+	settings: { thinkingOptionId: "high" },
+};
+assert.equal(
+	mcpBlockReason("supervisor", {
+		tool: "create_agent",
+		args: recoveryCreateArgs,
+	}),
+	null,
+	"gated recovery create_agent passes",
+);
+assert.equal(
+	mcpBlockReason("supervisor", {
+		tool: "paseo_create_agent",
+		args: {
+			...recoveryCreateArgs,
+			labels: { purpose: "bootstrap", recovery_for: "pod-product" },
+		},
+	}),
+	null,
+	"prefixed form + bootstrap purpose passes",
+);
+assert.equal(
+	mcpBlockReason("supervisor", {
+		tool: "create_agent",
+		args: JSON.stringify(recoveryCreateArgs),
+	}),
+	null,
+	"string args are parsed like object args",
+);
+// Every deviation is blocked fail-closed.
 assert.match(
-	mcpBlockReason("supervisor", { tool: "paseo_create_agent" }) ?? "",
-	/blocked/,
+	mcpBlockReason("supervisor", { tool: "create_agent" }) ?? "",
+	/args object/,
+	"missing args → block",
+);
+assert.match(
+	mcpBlockReason("supervisor", {
+		tool: "create_agent",
+		args: { ...recoveryCreateArgs, provider: "pi-peer/Minnyat/gpt-5.4" },
+	}) ?? "",
+	/pi-lead/,
+	"peer provider → block",
+);
+assert.match(
+	mcpBlockReason("supervisor", {
+		tool: "create_agent",
+		args: { ...recoveryCreateArgs, provider: "pi-lead" },
+	}) ?? "",
+	/pi-lead/,
+	"role provider without model → block",
+);
+assert.match(
+	mcpBlockReason("supervisor", {
+		tool: "create_agent",
+		args: { ...recoveryCreateArgs, labels: undefined },
+	}) ?? "",
+	/labels/,
+	"missing labels → block",
+);
+assert.match(
+	mcpBlockReason("supervisor", {
+		tool: "create_agent",
+		args: {
+			...recoveryCreateArgs,
+			labels: { purpose: "engineer", recovery_for: "x" },
+		},
+	}) ?? "",
+	/purpose/,
+	"non-recovery purpose → block",
+);
+assert.match(
+	mcpBlockReason("supervisor", {
+		tool: "create_agent",
+		args: { ...recoveryCreateArgs, labels: { purpose: "recovery" } },
+	}) ?? "",
+	/recovery_for/,
+	"missing project id → block",
+);
+assert.match(
+	mcpBlockReason("supervisor", {
+		tool: "create_agent",
+		args: { ...recoveryCreateArgs, settings: {} },
+	}) ?? "",
+	/thinkingOptionId/,
+	"missing thinking → block",
+);
+assert.match(
+	mcpBlockReason("supervisor", {
+		tool: "create_agent",
+		args: JSON.stringify("{not json"),
+	}) ?? "",
+	/args object/,
+	"unparseable string args → block",
 );
 // Fail-closed on unclassifiable input.
 assert.ok(


### PR DESCRIPTION
## Vấn đề

Supervisor không có khả năng tạo Lead mới trong tình huống recovery — deep-dive design (`docs/demonthorn-agent-orchestration-deep-dive.md`, dòng 346/418) mô tả Supervisor được tạo Lead mới + bounded handoff khi Lead cũ không recover được, nhưng implementation không có bất kỳ cơ chế nào (kể cả bản có Human approve).

## Giải pháp (tối giản, fail-closed)

Supervisor có **đúng MỘT** orchestration exception: `create_agent` cho successor Lead recovery. Không registry, không wrapper tool mới, không lifecycle extension.

**Cơ chế** (`extensions/paseo-team-policy.ts`):
- `SUPERVISOR_ALLOWED_MCP_TARGETS` + `create_agent` (monitoring + `send_agent_prompt` giữ nguyên); raw orchestration (peer/workspace/discovery/terminal/permission) vẫn bị chặn.
- `supervisorCreateAgentBlockReason` — argument-level gate trong `mcpBlockReason`, chặn fail-closed mọi shape sai:
  - `provider` phải `pi-lead/<pi-provider>/<model-id>` (regex — chặn cả pi-peer);
  - `labels.purpose ∈ {recovery, bootstrap}`;
  - `labels.recovery_for` = project id (audit trail trên chính agent tạo ra);
  - `settings.thinkingOptionId` bắt buộc (không daemon-default model);
  - hỗ trợ args dạng object lẫn JSON string; input hỏng → block.
- `mcp_script` giữ scan monitoring-only cho supervisor (args không verify tĩnh được) — defense in depth.

**Prompt** (`prompts/supervisor.md`): section `## Lead recovery authority`, cập nhật Tool boundary, block `LEAD_RECOVERY` trong output contract. Archive/cancel Lead cũ giữ cho Human.

## Verify

- `node test/policy.test.mts` — passed (10 case fail-closed mới: peer provider, thiếu model/labels/purpose/recovery_for/thinking, args hỏng + pass case recovery/bootstrap, object/string args)
- `node test/model-routing.test.mjs` — passed
- `npx tsc --noEmit -p tsconfig.json` — OK
- Smoke-load extension với `PASEO_PI_ROLE=supervisor` — role prompt inject đúng

## Known caveat

Successor Lead mặc định tạo dưới agent track của Supervisor (Paseo agent-scoped `create_agent` tạo subagent; detached root cần legacy schema sắp hết hạn). Để thành root agent: Human chạy `paseo agent detach <id>` (1 lệnh, đảo ngược được) — ghi rõ trong prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a tightly controlled Lead recovery workflow that can create a successor agent through approved recovery requests.
  - Recovery requests now require valid provider, project, purpose, target, and routing details.
  - Added clear recovery handoff information, including successor references and required Human follow-up.

- **Bug Fixes**
  - Invalid, incomplete, or unauthorized agent-creation requests are now blocked by default.
  - Monitoring access remains restricted, with other orchestration actions prohibited.

- **Documentation**
  - Updated supervisor guidance to describe the recovery-only agent creation process and restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->