### PR TITLE
fix(review): capability-based OCR compatibility + mechanical reviewer worktree invariant

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,14 @@ Recovery bắt buộc: kiểm tra activity, pending permission, daemon/remote he
 ## OpenCodeReview delegation (Phase 1)
 
 `paseo-ocr-reviewer` is a strictly read-only Reviewer Peer skill. The
-installer automatically installs and verifies the pinned OCR CLI
-`@alibaba-group/open-code-review@1.8.10`; OCR is not an
+installer automatically installs and verifies the OCR CLI
+`@alibaba-group/open-code-review` (capability-based: any installed release at
+or above the verified `1.8.10` baseline that passes the delegation capability
+probe is accepted as-is and never downgraded; when OCR is absent or
+incompatible the installer installs the pinned `1.9.2`). OCR is not an
 agent/provider or second control plane: it deterministically selects files and
 resolves rules, while the Pi Reviewer performs reasoning on the exact candidate
-SHA. The installer runs `scripts/ocr-setup.mjs` to install/verify the pinned CLI;
+SHA. The installer runs `scripts/ocr-setup.mjs` to install/verify the CLI;
 check it manually with `ocr version` (PowerShell:
 `Get-Command ocr`; Unix-like shells: `command -v ocr`) and use delegation mode,
 not `ocr review`. See [`docs/ocr-integration.md`](docs/ocr-integration.md).
@@ -121,11 +124,15 @@ The optional deterministic preflight emits a normalized manifest:
 node scripts/ocr-review.mjs --repo <repo> --base <base-sha> --candidate <candidate-sha>
 ```
 
-It pins OCR `1.8.10`, probes `delegate preview/rule` capabilities, and blocks
-candidate mismatch, dirty/mutated workspaces, unavailable/unsupported OCR,
-malformed selection/rules, and incomplete rule coverage. Its manifest includes
-candidate-tree/workspace entry-exit state and deterministic digests. It never
-edits Git state or calls an LLM.
+It probes `delegate preview/rule` capabilities (recording the OCR version as
+provenance, preferring `--format json` when the installed release supports it)
+and blocks candidate mismatch, non-worktree review workspaces
+(`REVIEW_WORKSPACE_NOT_WORKTREE` — the reviewer must run in a linked git
+worktree, never a primary checkout or standalone clone), dirty/mutated
+workspaces, unavailable/incompatible OCR, malformed selection/rules, and
+incomplete rule coverage. Its manifest includes candidate-tree/workspace
+entry-exit state and deterministic digests. It never edits Git state or calls
+an LLM.
 
 ## Cài đặt
 
@@ -149,7 +156,9 @@ Script copy:
 
 Installer tự kiểm tra `agent-browser --version`, `agent-browser doctor --offline --quick`,
 bundled skill (`agent-browser skills path agent-browser`) và các MCP config chuẩn.
-Nếu thiếu, installer sẽ cài OCR `@alibaba-group/open-code-review@1.8.10`,
+Nếu thiếu, installer sẽ cài OCR `@alibaba-group/open-code-review` (bản pin
+hiện tại `1.9.2`; bản đã cài `>= 1.8.10` qua được capability probe thì giữ
+nguyên, không downgrade),
 `npm install -g agent-browser`, chạy `agent-browser install`
 (`--with-deps` trên Linux), copy skill, rồi merge entry `agent-browser` vào
 `~/.pi/agent/mcp.json` mà không ghi đè server khác. Chạy lại installer là an toàn.

--- a/docs/multi-host.md
+++ b/docs/multi-host.md
@@ -77,6 +77,8 @@ node scripts/remote-paseo.mjs models --host-id <id> --provider pi-peer
 node scripts/remote-paseo.mjs workspaces --host-id <id>
 node scripts/remote-paseo.mjs workspace-create --host-id <id> --path <path-on-remote> \
   --isolation local|worktree --title <t>
+# reviewer workspace: --disposition independent-reviewer ép --isolation worktree,
+# từ chối local (REVIEW_ISOLATION_INVALID); worktree fail → BLOCKED: REVIEW_WORKTREE_UNAVAILABLE
 node scripts/remote-paseo.mjs run --host-id <id> \
   --provider pi-peer/<pi-provider>/<model-id> --thinking <level> \
   --workspace <wks-id> --title <t> --brief <task-file>

--- a/docs/ocr-integration.md
+++ b/docs/ocr-integration.md
@@ -8,17 +8,25 @@ an OCR agent/provider.
 
 ## Prerequisites
 
-The role-pack installers automatically install and verify the pinned OCR CLI
-`@alibaba-group/open-code-review@1.8.10`. If you are not using an installer,
-install it manually with the command in the next section. The wrapper still
-fails closed on missing or unsupported versions.
+The role-pack installers automatically install and verify the OCR CLI
+`@alibaba-group/open-code-review`. Compatibility is capability-based: any
+installed release at or above the verified `1.8.10` baseline that passes the
+delegation capability probe (`ocr delegate preview|rule --help` exposing
+`--repo`/`--from`) is accepted as-is and never downgraded. When OCR is absent,
+too old, or capability-broken, the installer installs the pinned `1.9.2`. If
+you are not using an installer, install it manually with the command in the
+next section. The wrapper still fails closed on missing OCR or a real
+capability/schema incompatibility.
 
 - Git `>= 2.41` (current upstream requirement);
 - Node.js/npm when installing the npm distribution;
 - Pi and Paseo configured for this role pack;
 - the `paseo-ocr-reviewer` skill installed;
-- a clean fresh reviewer workspace at the assigned candidate SHA;
-- the OCR CLI (the current verified npm distribution is v1.8.10).
+- a clean fresh reviewer workspace at the assigned candidate SHA, created as a
+  **linked git worktree** from the source repository (worktree isolation) —
+  the wrapper rejects a primary checkout or standalone clone with
+  `REVIEW_WORKSPACE_NOT_WORKTREE`;
+- the OCR CLI (verified releases: v1.8.10 through v1.9.2).
 
 Detect the platform and shell rather than assuming one:
 
@@ -40,15 +48,18 @@ Unix-like shell:    ocr version
 If it is unavailable and you are not running the role-pack installer, use the official npm distribution:
 
 ```bash
-npm install -g @alibaba-group/open-code-review@1.8.10
+npm install -g @alibaba-group/open-code-review@1.9.2
 ocr version
 ```
 
-The tested Phase 1 contract is OCR `open-code-review v1.8.10`. The verified
-machine is Windows with Git Bash, Node `v25.9.0`, npm `11.12.1`, and Git
-`2.53.0.windows.2`. The wrapper rejects other OCR versions with
-`OCR_VERSION_UNSUPPORTED`. Do not copy this machine's paths into configuration. No API key or secret is
-required by delegation mode, and no secret belongs in this repository.
+The verified baseline contract is OCR `open-code-review v1.8.10`; `v1.9.2` is
+verified end-to-end on Windows with Git Bash, Node `v25.9.0`, npm `11.12.1`,
+and Git `2.53.0.windows.2`. The wrapper treats the version as provenance and
+blocks only on a real incompatibility (`OCR_CAPABILITY_MISSING`,
+`OCR_OUTPUT_SCHEMA_UNSUPPORTED`); the installer refuses to leave an install
+below the baseline (`OCR_VERSION_UNSUPPORTED`). Do not copy this machine's
+paths into configuration. No API key or secret is required by delegation mode,
+and no secret belongs in this repository.
 
 ## Delegation smoke test
 
@@ -69,10 +80,11 @@ $candidate = git rev-parse <candidate-ref>
 ocr delegate preview --from $base --to $candidate
 ```
 
-The verified npm CLI v1.8.10 rejects `--format` and emits structured Markdown;
-upstream `main` documents JSON output, so verify the installed version before
-adding that flag. If the preview includes reviewable paths, resolve their rules
-with the exact paths returned by OCR:
+The v1.8.10 CLI rejects `--format` and emits structured Markdown; v1.9.x
+supports `--format json`. The wrapper probes the installed CLI and requests
+JSON when available, normalizing both forms against one schema. If the preview
+includes reviewable paths, resolve their rules with the exact paths returned
+by OCR:
 
 ```bash
 ocr delegate rule <path-1> <path-2>

--- a/examples/reviewer-task.md
+++ b/examples/reviewer-task.md
@@ -72,8 +72,11 @@ CONSTRAINTS:
 - Run the deterministic wrapper from the installed support directory:
   `node <PASEO_TEAM_SCRIPTS_DIR>/ocr-review.mjs --repo <review-repo> --base <base-sha> --candidate <assigned-candidate-sha>`.
   Any direct OCR diagnostic must use the same `--repo`, `--from <base-sha>`,
-  and `--to <assigned-candidate-sha>` values. The verified v1.8.10 CLI emits
-  structured Markdown; normalize it only through the deterministic wrapper.
+  and `--to <assigned-candidate-sha>` values. The wrapper probes the installed
+  CLI (Markdown on v1.8.10, `--format json` on 1.9.x) and normalizes both
+  forms; normalize only through the deterministic wrapper. It also verifies
+  the review workspace is a linked git worktree
+  (`BLOCKED: REVIEW_WORKSPACE_NOT_WORKTREE` otherwise).
 - Account for every OCR `reviewable_files` item as reviewed or skipped with a concrete reason.
 - Do NOT normalize, edit, or fix the candidate to make tests pass.
 

--- a/extensions/paseo-team-policy.ts
+++ b/extensions/paseo-team-policy.ts
@@ -427,8 +427,8 @@ export function mcpAllowedTargets(role: TeamRole): string[] {
 	}
 }
 
-/** Extract create_agent args from an mcp proxy input ({ tool, args }). */
-function extractCreateAgentArgs(input: unknown): unknown {
+/** Extract tool args from an mcp proxy input ({ tool, args }). */
+function extractMcpArgs(input: unknown): unknown {
 	if (typeof input !== "object" || input === null) return null;
 	const args = (input as Record<string, unknown>).args;
 	if (typeof args === "string") {
@@ -455,7 +455,7 @@ const SUPERVISOR_RECOVERY_PURPOSES = new Set(["recovery", "bootstrap"]);
 export function supervisorCreateAgentBlockReason(
 	input: unknown,
 ): string | null {
-	const args = extractCreateAgentArgs(input);
+	const args = extractMcpArgs(input);
 	if (typeof args !== "object" || args === null) {
 		return "Supervisor create_agent requires an args object (provider, labels, settings). Refusing fail-closed.";
 	}
@@ -488,6 +488,42 @@ export function supervisorCreateAgentBlockReason(
 			: undefined;
 	if (typeof thinking !== "string" || thinking.trim().length === 0) {
 		return "Supervisor create_agent requires settings.thinkingOptionId (no daemon-default model — route from the approved Lead route).";
+	}
+	return null;
+}
+
+/**
+ * Argument-level gate for Lead create_workspace through the MCP proxy —
+ * Layer 1 of the reviewer isolation invariant (Layer 2 is the runtime
+ * assertLinkedWorktree gate in ocr-review.mjs, which rejects any
+ * non-worktree workspace with REVIEW_WORKSPACE_NOT_WORKTREE).
+ *
+ * MCP create_workspace args carry no disposition field, so reviewer intent
+ * is declared through the workspace naming convention the Lead skill
+ * mandates: reviewer workspaces are titled/slugged with "review". The gate
+ * enforces:
+ *   - isolation is explicit and valid ("local" | "worktree") — never a
+ *     daemon default;
+ *   - a review-marked workspace (title/worktreeSlug containing "review")
+ *     MUST use worktree isolation; local is the exact anti-pattern the
+ *     runtime gate rejects, so it is blocked before creation.
+ */
+export function leadCreateWorkspaceBlockReason(input: unknown): string | null {
+	const args = extractMcpArgs(input);
+	if (typeof args !== "object" || args === null) {
+		return 'Lead create_workspace requires an args object with an explicit isolation ("local" or "worktree"). Refusing fail-closed.';
+	}
+	const rec = args as Record<string, unknown>;
+	const isolation =
+		typeof rec.isolation === "string" ? rec.isolation.trim() : "";
+	if (isolation !== "local" && isolation !== "worktree") {
+		return `create_workspace requires explicit isolation "local" or "worktree" (got "${isolation || "<missing>"}") — never rely on a daemon default.`;
+	}
+	const markers = [rec.title, rec.worktreeSlug].filter(
+		(value): value is string => typeof value === "string",
+	);
+	if (isolation !== "worktree" && markers.some((value) => /review/i.test(value))) {
+		return 'An independent-reviewer workspace must use isolation "worktree" (a linked git worktree from the source repository). If the worktree cannot be created, report BLOCKED: REVIEW_WORKTREE_UNAVAILABLE — never fall back to a local workspace.';
 	}
 	return null;
 }
@@ -562,6 +598,10 @@ export function mcpBlockReason(role: TeamRole, input: unknown): string | null {
 	}
 	if (role === "supervisor" && matchesPaseoToolName(target, ["create_agent"])) {
 		const argBlock = supervisorCreateAgentBlockReason(input);
+		if (argBlock) return argBlock;
+	}
+	if (role === "lead" && matchesPaseoToolName(target, ["create_workspace"])) {
+		const argBlock = leadCreateWorkspaceBlockReason(input);
 		if (argBlock) return argBlock;
 	}
 	return null;

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -75,7 +75,7 @@ Write-Host "  support default -> `$env:PI_CODING_AGENT_DIR\extensions\paseo-team
 Write-Host "  env override is optional; no user-profile mutation is required"
 Write-Host ""
 Write-Host "Next steps:"
-Write-Host "  1. The installer checked/installed OCR v1.8.10, agent-browser CLI, Chrome runtime, skill and Pi MCP config."
+Write-Host "  1. The installer checked/installed OCR (capability-probed; >= v1.8.10 kept as-is, pinned v1.9.2 when repairing), agent-browser CLI, Chrome runtime, skill and Pi MCP config."
 Write-Host "  2. Verify OCR if needed: Get-Command ocr; ocr version"
 Write-Host "  3. Install the MCP adapter (PINNED version - Paseo tools depend on it):"
 Write-Host "     pi install npm:pi-mcp-adapter@2.19.0"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -76,7 +76,7 @@ echo "  support default -> \${PI_CODING_AGENT_DIR:-\$HOME/.pi/agent}/extensions/
 echo "  env override is optional; no shell profile mutation is required"
 echo ""
 echo "Next steps:"
-echo "  1. The installer checked/installed OCR v1.8.10, agent-browser CLI, Chrome runtime, skill and Pi MCP config."
+echo "  1. The installer checked/installed OCR (capability-probed; >= v1.8.10 kept as-is, pinned v1.9.2 when repairing), agent-browser CLI, Chrome runtime, skill and Pi MCP config."
 echo "  2. Verify OCR if needed: command -v ocr; ocr version"
 echo "  3. Install the MCP adapter (PINNED version — Paseo tools depend on it):"
 echo "     pi install npm:pi-mcp-adapter@2.19.0"

--- a/scripts/ocr-review.mjs
+++ b/scripts/ocr-review.mjs
@@ -9,7 +9,12 @@ import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, isAbsolute, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const OCR_SUPPORTED_VERSION = "1.8.10";
+// Oldest OCR release whose delegation contract was verified end-to-end.
+// Compatibility is decided at run time by capability/schema probes; the
+// version string is provenance recorded in the manifest, never an equality
+// gate. (OCR_VERSION_UNSUPPORTED remains a valid code for consumers — the
+// installer throws it when even a repair install cannot reach this baseline.)
+export const OCR_BASELINE_VERSION = "1.8.10";
 export const OCR_WRAPPER_VERSION = "1";
 export const OCR_ERROR_CODES = Object.freeze([
   "USAGE",
@@ -17,6 +22,7 @@ export const OCR_ERROR_CODES = Object.freeze([
   "OCR_CAPABILITY_MISSING",
   "OCR_OUTPUT_SCHEMA_UNSUPPORTED",
   "NOT_GIT_REPOSITORY",
+  "REVIEW_WORKSPACE_NOT_WORKTREE",
   "CANDIDATE_SHA_MISMATCH",
   "DIRTY_REVIEW_WORKSPACE",
   "OCR_UNAVAILABLE",
@@ -328,6 +334,37 @@ function validateRuleCoverage(reviewableFiles, groups) {
   if (missing.length > 0 || unrelated.length > 0) fail("RULES_INVALID", "rule output does not exactly match reviewable files", { missing, unrelated });
 }
 
+/**
+ * The reviewer isolation invariant: the review workspace must be a LINKED git
+ * worktree (created with `git worktree add` / Paseo `--isolation worktree`),
+ * never the primary checkout or a standalone clone. In a linked worktree
+ * `--git-dir` points under `<source>/.git/worktrees/<name>` and differs from
+ * `--git-common-dir`; in a primary checkout or clone the two are identical.
+ * A clean clone at the right SHA must NOT pass this gate.
+ */
+export function assertLinkedWorktree(repo) {
+  const gitDir = git(repo, ["rev-parse", "--git-dir"], "NOT_GIT_REPOSITORY", "could not read the Git directory");
+  const commonDir = git(repo, ["rev-parse", "--git-common-dir"], "NOT_GIT_REPOSITORY", "could not read the Git common directory");
+  const resolvePath = (path) => {
+    const absolute = isAbsolute(path) ? path : join(repo, path);
+    try {
+      return realpathSync(absolute);
+    } catch {
+      return absolute;
+    }
+  };
+  const resolvedGitDir = resolvePath(gitDir);
+  const resolvedCommonDir = resolvePath(commonDir);
+  if (resolvedGitDir === resolvedCommonDir) {
+    fail(
+      "REVIEW_WORKSPACE_NOT_WORKTREE",
+      "review workspace is a primary checkout or standalone clone, not a linked git worktree — create the reviewer workspace with worktree isolation from the source repository",
+      { gitDir: resolvedGitDir },
+    );
+  }
+  return { gitDir: resolvedGitDir, gitCommonDir: resolvedCommonDir };
+}
+
 function readGitState(repo, candidate) {
   const head = git(repo, ["rev-parse", "HEAD"], "NOT_GIT_REPOSITORY", "could not read Git HEAD");
   const status = git(repo, ["status", "--porcelain"], "NOT_GIT_REPOSITORY", "could not inspect Git status");
@@ -374,10 +411,11 @@ function main(options) {
   const repoCheck = runCommand(["rev-parse", "--is-inside-work-tree"], { cwd: options.repo });
   if (!repoCheck.ok || repoCheck.stdout.trim() !== "true") fail("NOT_GIT_REPOSITORY", `not inside a Git worktree: ${options.repo}`);
 
+  const worktree = assertLinkedWorktree(options.repo);
   const entryState = verifyReviewWorkspace(options.repo, options.candidate, undefined, "entry");
   if (options.verify) {
     const verified = verifyReviewWorkspace(options.repo, options.candidate, options.tree);
-    return { schema: "paseo.ocr-review-verification/v1", candidate_sha: verified.head, candidate_tree_sha: verified.tree, clean: verified.clean };
+    return { schema: "paseo.ocr-review-verification/v1", candidate_sha: verified.head, candidate_tree_sha: verified.tree, clean: verified.clean, linked_worktree: true };
   }
   git(options.repo, ["rev-parse", "--verify", `${options.base}^{commit}`], "GIT_REF_INVALID", `review base is not a valid commit: ${options.base}`);
   const actualMergeBase = git(options.repo, ["merge-base", options.base, options.candidate], "GIT_REF_INVALID", "could not calculate Git merge-base");
@@ -388,13 +426,21 @@ function main(options) {
   const ocrVersion = versionResult.stdout.trim().split(/\r?\n/)[0] ?? "";
   const ocrVersionNumber = parseOcrVersion(ocrVersion);
   if (!ocrVersionNumber) fail("OCR_OUTPUT_SCHEMA_UNSUPPORTED", "ocr version output did not contain a supported version string");
-  if (ocrVersionNumber !== OCR_SUPPORTED_VERSION) fail("OCR_VERSION_UNSUPPORTED", `OCR version ${ocrVersionNumber} is not the tested ${OCR_SUPPORTED_VERSION}`, { supported: OCR_SUPPORTED_VERSION, observed: ocrVersionNumber });
+  // Compatibility is capability/schema-based: the version number is recorded
+  // as provenance only. The probes below and the strict normalizers decide
+  // whether this OCR is usable; a version that differs from the tested
+  // baseline is not, by itself, a blocker.
+  let formatJsonCapable = true;
   for (const command of ["preview", "rule"]) {
     const helpResult = runCommand(["delegate", command, "--help"], { cwd: options.repo, executable: ocr, timeoutMs: 30_000 });
     if (!helpResult.ok || !helpResult.stdout.includes("--repo") || !helpResult.stdout.includes("--from")) fail("OCR_CAPABILITY_MISSING", `OCR delegate ${command} capability is missing or unrecognized`);
+    if (!helpResult.stdout.includes("--format")) formatJsonCapable = false;
   }
+  // Prefer machine-readable output when this OCR advertises --format; older
+  // releases (e.g. 1.8.10) reject the flag and emit the parseable Markdown.
+  const formatArgs = formatJsonCapable ? ["--format", "json"] : [];
 
-  const previewResult = runCommand(["delegate", "preview", "--repo", options.repo, "--from", options.base, "--to", options.candidate], { cwd: options.repo, executable: ocr, timeoutMs: 120_000 });
+  const previewResult = runCommand(["delegate", "preview", "--repo", options.repo, "--from", options.base, "--to", options.candidate, ...formatArgs], { cwd: options.repo, executable: ocr, timeoutMs: 120_000 });
   const preview = normalizePreview(parseStructuredOutput(previewResult, "PREVIEW_FAILED", "PREVIEW_INVALID", "OCR preview", parsePreviewText));
   if (preview.mode !== "range") fail("PREVIEW_INVALID", `expected range preview, got ${preview.mode}`);
   if (preview.from !== options.base) fail("PREVIEW_INVALID", "preview.from does not equal requested base", { expected: options.base, observed: preview.from });
@@ -404,7 +450,7 @@ function main(options) {
 
   let ruleGroups = [];
   if (preview.reviewable_files.length > 0) {
-    const ruleArgs = ["delegate", "rule", "--repo", options.repo, "--from", options.base, "--to", options.candidate, ...preview.reviewable_files.map((entry) => entry.path)];
+    const ruleArgs = ["delegate", "rule", "--repo", options.repo, "--from", options.base, "--to", options.candidate, ...formatArgs, ...preview.reviewable_files.map((entry) => entry.path)];
     const rulesResult = runCommand(ruleArgs, { cwd: options.repo, executable: ocr, timeoutMs: 120_000 });
     ruleGroups = normalizeRules(parseStructuredOutput(rulesResult, "RULES_FAILED", "RULES_INVALID", "OCR rule", parseRulesText));
     validateRuleCoverage(preview.reviewable_files, ruleGroups);
@@ -429,6 +475,7 @@ function main(options) {
       wrapper_version: "1",
       wrapper_commit_sha: wrapperCommit,
       ocr_version: ocrVersionNumber,
+      ocr_output_format: formatJsonCapable ? "json" : "text",
     },
     scope: {
       discovered_count: preview.reviewable_files.length + preview.excluded_files.length,
@@ -446,6 +493,8 @@ function main(options) {
       head_exit: exitState.head,
       clean_entry: entryState.clean,
       clean_exit: exitState.clean,
+      linked_worktree: true,
+      git_dir: worktree.gitDir,
     },
     // Backward-compatible top-level fields for simple consumers.
     base_sha: options.base,
@@ -463,7 +512,7 @@ function main(options) {
 }
 
 function help() {
-  return `ocr-review.mjs — deterministic OpenCodeReview delegation preflight\n\nUsage:\n  node scripts/ocr-review.mjs --base <sha> --candidate <sha> [--repo <path>]\n  node scripts/ocr-review.mjs --verify --candidate <sha> --tree <tree-sha> [--repo <path>]\n\nChecks the exact clean HEAD, runs ocr delegate preview/rule in range mode, and\nemits a normalized manifest. --verify performs the post-review HEAD/status/tree\ncheck. It never edits code, changes Git state, or calls an LLM.`;
+  return `ocr-review.mjs — deterministic OpenCodeReview delegation preflight\n\nUsage:\n  node scripts/ocr-review.mjs --base <sha> --candidate <sha> [--repo <path>]\n  node scripts/ocr-review.mjs --verify --candidate <sha> --tree <tree-sha> [--repo <path>]\n\nRequires the review workspace to be a LINKED git worktree (worktree\nisolation), checks the exact clean HEAD, probes OCR delegation capabilities\n(version is provenance, not a gate), runs ocr delegate preview/rule in range\nmode, and emits a normalized manifest. --verify performs the post-review\nHEAD/status/tree check. It never edits code, changes Git state, or calls an LLM.`;
 }
 
 export function isMainModule(entry = process.argv[1], moduleUrl = import.meta.url) {

--- a/scripts/ocr-setup.mjs
+++ b/scripts/ocr-setup.mjs
@@ -1,18 +1,53 @@
 #!/usr/bin/env node
-// Install and verify the pinned OpenCodeReview CLI used by ocr-review.mjs.
+// Install and verify the OpenCodeReview CLI used by ocr-review.mjs.
 // The installer owns this dependency; failures are fatal and never reported
 // as a successful role-pack installation.
+//
+// Compatibility is capability-based, not version-equality-based: any installed
+// OCR at or above the verified minimum that passes the delegation capability
+// probe is accepted as-is. The pinned version is only what gets installed when
+// OCR is absent, too old, or fails the probe — a newer working release is
+// never downgraded just because its version differs.
 
 import { spawnSync } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 export const OCR_NPM_PACKAGE = "@alibaba-group/open-code-review";
-export const OCR_SUPPORTED_VERSION = "1.8.10";
+// Installed when OCR is absent, older than the minimum, or capability-broken.
+export const OCR_PINNED_VERSION = "1.9.2";
+// Oldest release whose delegation contract was verified end-to-end (1.8.10).
+export const OCR_MINIMUM_VERSION = "1.8.10";
 
 export function parseOcrVersion(output) {
   const match = String(output).match(/open-code-review v(\d+\.\d+\.\d+)/i);
   return match?.[1] ?? null;
+}
+
+/** Numeric semver compare over major.minor.patch; returns -1 | 0 | 1. */
+export function compareOcrVersions(a, b) {
+  const pa = String(a).split(".").map(Number);
+  const pb = String(b).split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const delta = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (delta !== 0) return delta < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * Probe the delegation surface ocr-review.mjs depends on: `ocr delegate
+ * preview|rule` must exist and accept `--repo`/`--from`. This — not the
+ * version string — decides whether an installed OCR is usable.
+ */
+export function probeDelegateCapability(run) {
+  for (const command of ["preview", "rule"]) {
+    const help = run("ocr", ["delegate", command, "--help"]);
+    if (!help.ok || !help.stdout.includes("--repo") || !help.stdout.includes("--from")) {
+      return { ok: false, command };
+    }
+  }
+  return { ok: true };
 }
 
 function defaultRun(command, args) {
@@ -39,19 +74,23 @@ function defaultRun(command, args) {
 }
 
 export function ensureOcr({ run = defaultRun } = {}) {
-  const expected = OCR_SUPPORTED_VERSION;
   let versionResult = run("ocr", ["version"]);
   let version = versionResult.ok ? parseOcrVersion(versionResult.stdout) : null;
 
-  if (version === expected) {
+  if (
+    version &&
+    compareOcrVersions(version, OCR_MINIMUM_VERSION) >= 0 &&
+    probeDelegateCapability(run).ok
+  ) {
     return { installed: false, version, output: versionResult.stdout };
   }
-  // A different installed version is repaired by installing the pinned
-  // package; the post-install probe below remains the authority.
+  // OCR is absent, below the verified minimum, or capability-broken: repair by
+  // installing the pinned package; the post-install probe below remains the
+  // authority.
   const installResult = run("npm", [
     "install",
     "-g",
-    `${OCR_NPM_PACKAGE}@${expected}`,
+    `${OCR_NPM_PACKAGE}@${OCR_PINNED_VERSION}`,
     "--no-audit",
     "--no-fund",
   ]);
@@ -63,9 +102,15 @@ export function ensureOcr({ run = defaultRun } = {}) {
 
   versionResult = run("ocr", ["version"]);
   version = versionResult.ok ? parseOcrVersion(versionResult.stdout) : null;
-  if (version !== expected) {
-    const error = new Error(`OCR_VERSION_UNSUPPORTED: installed OCR did not report ${expected}`);
+  if (!version || compareOcrVersions(version, OCR_MINIMUM_VERSION) < 0) {
+    const error = new Error(`OCR_VERSION_UNSUPPORTED: installed OCR did not report a version >= ${OCR_MINIMUM_VERSION}`);
     error.code = "OCR_VERSION_UNSUPPORTED";
+    throw error;
+  }
+  const capability = probeDelegateCapability(run);
+  if (!capability.ok) {
+    const error = new Error(`OCR_CAPABILITY_MISSING: installed OCR does not expose \`ocr delegate ${capability.command}\` with --repo/--from`);
+    error.code = "OCR_CAPABILITY_MISSING";
     throw error;
   }
   return { installed: true, version, output: versionResult.stdout };

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -120,9 +120,17 @@ function summarizeMessages() {
 		warn("ocr-cli", "ocr CLI unavailable — independent-reviewer OCR workflow is blocked (install @alibaba-group/open-code-review)");
 	} else {
 		const versionLine = ocr.stdout.trim().split(/\r?\n/)[0] || "";
-		const supported = /^open-code-review v1\.8\.10(?:\b|\s)/i.test(versionLine);
-		if (supported) pass("ocr-cli", versionLine);
-		else warn("ocr-cli", `${versionLine || "installed"} — tested contract is open-code-review v1.8.10; reviewer wrapper will fail closed`);
+		const parsed = versionLine.match(/open-code-review v(\d+)\.(\d+)\.(\d+)/i);
+		// Compatibility is capability-based; the version only gates a warning
+		// when it is below the verified 1.8.10 baseline or unparseable.
+		const meetsBaseline =
+			parsed &&
+			(Number(parsed[1]) > 1 ||
+				(Number(parsed[1]) === 1 &&
+					(Number(parsed[2]) > 8 ||
+						(Number(parsed[2]) === 8 && Number(parsed[3]) >= 10))));
+		if (meetsBaseline) pass("ocr-cli", versionLine);
+		else warn("ocr-cli", `${versionLine || "installed"} — below the verified open-code-review v1.8.10 baseline; reviewer wrapper capability probes will fail closed`);
 		for (const command of ["preview", "rule"]) {
 			const help = tryExec("ocr", ["delegate", command, "--help"]);
 			if (help.ok && help.stdout.includes("--repo") && help.stdout.includes("--from")) pass(`ocr-capability:${command}`, "delegate capability available");

--- a/scripts/remote-paseo.mjs
+++ b/scripts/remote-paseo.mjs
@@ -84,6 +84,7 @@ export const REMOTE_ERROR_CODES = Object.freeze([
 	"CLI_ERROR",
 	"PROMPT_TOO_LONG",
 	"REVIEW_ISOLATION_INVALID",
+	"REVIEW_WORKTREE_UNAVAILABLE",
 ]);
 
 export class RemoteError extends Error {
@@ -1047,10 +1048,20 @@ function main() {
 	const payload = basePayload(command, hostInfo);
 	if (!result.ok) {
 		payload.ok = false;
-		payload.code = "CLI_ERROR";
-		payload.message =
-			result.error ||
-			`paseo ${command} failed with exit ${result.status} (stderr redacted)`;
+		// A failed reviewer worktree creation is the specific blocker the Lead
+		// skill keys recovery on — surface it as REVIEW_WORKTREE_UNAVAILABLE, not
+		// a generic CLI_ERROR. There is no fallback to a local workspace.
+		const reviewerWorkspaceCreate =
+			command === "workspace-create" &&
+			typeof parsed.disposition === "string" &&
+			parsed.disposition.trim() === "independent-reviewer";
+		payload.code = reviewerWorkspaceCreate
+			? "REVIEW_WORKTREE_UNAVAILABLE"
+			: "CLI_ERROR";
+		payload.message = reviewerWorkspaceCreate
+			? `reviewer worktree workspace could not be created on host "${hostInfo.hostId}" — report BLOCKED: REVIEW_WORKTREE_UNAVAILABLE; never fall back to a local/standalone workspace (${result.error || `paseo exit ${result.status}`})`
+			: result.error ||
+				`paseo ${command} failed with exit ${result.status} (stderr redacted)`;
 		if (result.stdout) payload.data = result.stdout;
 		emit(payload, 2);
 	}

--- a/scripts/remote-paseo.mjs
+++ b/scripts/remote-paseo.mjs
@@ -24,7 +24,8 @@
 //   models           --host-id <id> --provider <role>   paseo provider models
 //   workspaces       --host-id <id>                     paseo workspace ls
 //   workspace-create --host-id <id> --path <p> [--isolation local|worktree]
-//                    [--title <t>] [--project <id>]
+//                    [--disposition <d>] [--title <t>] [--project <id>]
+//                    (disposition independent-reviewer forces worktree isolation)
 //   agents           --host-id <id> [--all]             paseo ls -g
 //   run              --host-id <id> --provider <role-provider>/<pi-provider>/<model-id>
 //                    --thinking <level> [--workspace <wks>] [--title <t>]
@@ -82,6 +83,7 @@ export const REMOTE_ERROR_CODES = Object.freeze([
 	"ENDPOINT_UNSAFE",
 	"CLI_ERROR",
 	"PROMPT_TOO_LONG",
+	"REVIEW_ISOLATION_INVALID",
 ]);
 
 export class RemoteError extends Error {
@@ -175,7 +177,7 @@ const COMMAND_FLAG_KEYS = {
 	providers: ["hostId"],
 	models: ["hostId", "provider"],
 	workspaces: ["hostId"],
-	"workspace-create": ["hostId", "path", "isolation", "title", "project"],
+	"workspace-create": ["hostId", "path", "isolation", "disposition", "title", "project"],
 	agents: ["hostId", "all"],
 	run: [
 		"hostId",
@@ -194,6 +196,15 @@ const COMMAND_FLAG_KEYS = {
 	archive: ["agentRef"],
 	send: ["agentRef", "prompt", "promptFile", "wait", "noWait"],
 };
+
+// The V3 brief disposition vocabulary (see templates/TASK_BRIEF_V3.md).
+export const WORKSPACE_DISPOSITIONS = Object.freeze([
+	"repository-scout",
+	"documentation-researcher",
+	"solution-architect",
+	"engineer",
+	"independent-reviewer",
+]);
 
 const GLOBAL_FLAG_KEYS = new Set(["cluster", "dryRun", "json", "help"]);
 const BOOLEAN_KEYS = new Set([...BOOLEAN_FLAGS].map(toCamelCase));
@@ -520,8 +531,42 @@ export function buildArgv(command, opts, endpoint) {
 			}
 			const argv = ["workspace", "create", ...ep];
 			argv.push("--path", opts.path.trim());
-			if (typeof opts.isolation === "string" && opts.isolation.trim() !== "") {
-				argv.push("--isolation", opts.isolation.trim());
+			const isolation =
+				typeof opts.isolation === "string" && opts.isolation.trim() !== ""
+					? opts.isolation.trim()
+					: "";
+			if (isolation && isolation !== "local" && isolation !== "worktree") {
+				throw usageError(
+					`--isolation must be "local" or "worktree" (got "${isolation}")`,
+				);
+			}
+			const disposition =
+				typeof opts.disposition === "string" ? opts.disposition.trim() : "";
+			// Fail closed on typos: a misspelled reviewer disposition must never
+			// silently skip the worktree enforcement below.
+			if (disposition && !WORKSPACE_DISPOSITIONS.includes(disposition)) {
+				throw usageError(
+					`--disposition must be one of ${WORKSPACE_DISPOSITIONS.join(", ")} (got "${disposition}")`,
+				);
+			}
+			let effectiveIsolation = isolation;
+			// Reviewer isolation is an invariant, not a preference: an
+			// independent-reviewer workspace is ALWAYS a git worktree. If the
+			// worktree cannot be created on the target host, the caller reports
+			// BLOCKED: REVIEW_WORKTREE_UNAVAILABLE — it never falls back to a
+			// local/standalone workspace that ocr-review.mjs would reject anyway.
+			if (disposition === "independent-reviewer") {
+				if (isolation && isolation !== "worktree") {
+					throw new RemoteError(
+						"REVIEW_ISOLATION_INVALID",
+						`an independent-reviewer workspace requires --isolation worktree (got "${isolation}"); if a worktree cannot be created, report BLOCKED: REVIEW_WORKTREE_UNAVAILABLE instead of falling back`,
+						{ disposition, isolation },
+					);
+				}
+				effectiveIsolation = "worktree";
+			}
+			if (effectiveIsolation) {
+				argv.push("--isolation", effectiveIsolation);
 			}
 			if (typeof opts.title === "string" && opts.title.trim() !== "") {
 				argv.push("--title", opts.title.trim());
@@ -797,7 +842,9 @@ Commands:
   models           --host-id <id> --provider <role-provider>
   workspaces       --host-id <id>
   workspace-create --host-id <id> --path <path> [--isolation local|worktree]
-                   [--title <t>] [--project <id>]
+                   [--disposition <d>] [--title <t>] [--project <id>]
+                   --disposition independent-reviewer forces --isolation worktree
+                   (reviewer isolation is an invariant; local is rejected)
   agents           --host-id <id> [--all]
   run              --host-id <id> --provider <role-provider>/<pi-provider>/<model-id>
                    --thinking <level> --workspace <wks-id> [--title <t>]

--- a/skills/paseo-ocr-reviewer/SKILL.md
+++ b/skills/paseo-ocr-reviewer/SKILL.md
@@ -48,6 +48,7 @@ Before invoking OCR, run:
 ```text
 git rev-parse HEAD
 git status --porcelain
+git rev-parse --git-dir --git-common-dir
 ocr version
 ```
 
@@ -70,6 +71,22 @@ If `git status --porcelain` is non-empty, stop with:
 STATUS: BLOCKED
 REASON: DIRTY_REVIEW_WORKSPACE
 ```
+
+The review workspace MUST be a **linked git worktree** created from the source
+repository (worktree isolation), never the Engineer's primary checkout or a
+standalone clone/project. In a linked worktree `git rev-parse --git-dir`
+resolves under `<source>/.git/worktrees/<name>` and differs from
+`--git-common-dir`; if the two resolve to the same directory, stop with:
+
+```text
+STATUS: BLOCKED
+REASON: REVIEW_WORKSPACE_NOT_WORKTREE
+```
+
+A clean clone at the exact candidate SHA does NOT satisfy this gate — the
+wrapper enforces it mechanically. Ask the Lead for a workspace created with
+worktree isolation; if one cannot be created, the Lead reports
+`BLOCKED: REVIEW_WORKTREE_UNAVAILABLE` rather than falling back.
 
 If OCR is missing or `ocr version` fails, stop with:
 
@@ -94,12 +111,11 @@ If a direct OCR command is needed for diagnosis, it MUST use the same exact
 `--repo`, `--from <REVIEW_BASE_SHA>`, and `--to <ASSIGNED_CANDIDATE_SHA>` values;
 never use a task-body candidate that differs from the authority candidate.
 
-Use the repository's actual installed OCR syntax. Upstream `main` documents a
-JSON format flag, but the verified npm CLI `open-code-review v1.8.10` rejects
-`--format` and emits the delegation preview as structured Markdown. The
-role-pack wrapper parses that output and normalizes it; if a future installed
-version accepts `--format json`, JSON may be used after verifying its schema.
-The current preview still supplies:
+Use the repository's actual installed OCR syntax. The wrapper probes the
+installed CLI's capabilities at run time: releases that advertise `--format`
+(1.9.x and later) are invoked with `--format json`, while older releases
+(e.g. 1.8.10) emit structured Markdown that the wrapper parses and normalizes.
+Both forms are validated against the same strict schema. The preview supplies:
 
 ```text
 mode
@@ -113,9 +129,12 @@ excluded file entries + reasons
 The returned `merge_base` is authoritative for the range diff. Do not replace
 OCR's selection with `git diff --name-only`. If OCR preview fails or returns
 invalid/incomplete output, report a blocker/diagnostic and do not claim a review.
-The tested Phase 1 contract is OCR `1.8.10`; capability/version drift is a
-blocker (`OCR_VERSION_UNSUPPORTED`, `OCR_CAPABILITY_MISSING`, or
-`OCR_OUTPUT_SCHEMA_UNSUPPORTED`).
+Compatibility is capability/schema-based: the wrapper records the OCR version
+as provenance and blocks only on a REAL incompatibility
+(`OCR_CAPABILITY_MISSING` or `OCR_OUTPUT_SCHEMA_UNSUPPORTED`); a version newer
+than the tested `1.8.10` baseline is not, by itself, a blocker. The installer
+still throws `OCR_VERSION_UNSUPPORTED` when even a repair install cannot reach
+that baseline.
 
 The installed support directory contains the deterministic wrapper:
 
@@ -178,9 +197,10 @@ For direct diagnosis only, `ocr delegate rule` must receive the exact
 OCR-selected paths; normal review execution uses the wrapper above.
 ```
 
-The verified v1.8.10 output is structured Markdown with `Rule Group` headers,
-`Applies to` paths, and rule content. The wrapper parses it; newer JSON output
-may be used only after capability/schema verification. In either form, map
+Older CLIs (e.g. v1.8.10) emit structured Markdown with `Rule Group` headers,
+`Applies to` paths, and rule content; format-capable CLIs emit the equivalent
+JSON. The wrapper detects which form the installed CLI supports, requests
+JSON when available, and normalizes both to one schema. In either form, map
 each rule group to every listed path. For a large review, batch by
 shared rule or diff size, while retaining one coverage identity per
 `(path,status)`. If a selected file is absent from rule resolution, stop or

--- a/skills/paseo-team-lead/SKILL.md
+++ b/skills/paseo-team-lead/SKILL.md
@@ -127,7 +127,14 @@ This is the exact failure mode the cluster config exists to prevent.
    `<role-provider>/<pi-provider>/<model-id>` (Paseo splits at the FIRST
    slash only, so multi-slash model IDs like `openrouter/vendor/name` work).
    Thinking goes in `settings.thinkingOptionId` — never inside the model string.
-8. Create the workspace when needed (worktree isolation for writers).
+8. Create the workspace when needed. Worktree isolation is required for
+   writers AND is a hard invariant for the independent reviewer: a reviewer
+   workspace is ALWAYS a git worktree created from the source repository at
+   the exact candidate SHA — never `local` isolation, a standalone clone, or
+   a new project. If the worktree cannot be created, report
+   `BLOCKED: REVIEW_WORKTREE_UNAVAILABLE`; there is no fallback (the
+   reviewer wrapper mechanically rejects non-worktree workspaces with
+   `REVIEW_WORKSPACE_NOT_WORKTREE`).
 9. Call `create_agent` with the exact provider string + thinking. NEVER omit
    the model to inherit a daemon default.
 10. Call `get_agent_status` and bounded-poll `snapshot.runtimeInfo.model` and
@@ -166,6 +173,12 @@ local one. In the commands below, `<id>` is the HOST_ID from
    ID has no meaning on the Mac:
    `node <PASEO_TEAM_SCRIPTS_DIR>/remote-paseo.mjs workspaces --host-id <id>`
    `node <PASEO_TEAM_SCRIPTS_DIR>/remote-paseo.mjs workspace-create --host-id <id> --path <path-on-remote> --isolation local|worktree --title <t>`
+   For an independent-reviewer workspace, pass
+   `--disposition independent-reviewer`: the wrapper then forces
+   `--isolation worktree` and rejects `--isolation local`
+   (`REVIEW_ISOLATION_INVALID`). If worktree creation fails on the remote
+   host, report `BLOCKED: REVIEW_WORKTREE_UNAVAILABLE` — never fall back to
+   a local/standalone workspace for review.
 7. Create the agent on the remote daemon (background by default; add
    `--wait-timeout <dur>` to wait for completion):
    `node <PASEO_TEAM_SCRIPTS_DIR>/remote-paseo.mjs run --host-id <id> --provider <role-provider>/<pi-provider>/<model-id> --thinking <level> --workspace <wks> --title <t> --brief <brief-file>`
@@ -253,8 +266,13 @@ After implementation:
    candidate is automatically refused by the independent reviewer and must be
    corrected in the same Engineer session before review.
 2. Create a fresh read-only Reviewer Peer (`MODE: read-only`,
-   `DISPOSITION: independent-reviewer`) in a **fresh workspace** checked out
-   at the exact candidate SHA — not the Engineer's own working tree. Route it
+   `DISPOSITION: independent-reviewer`) in a **fresh git worktree** created
+   from the source repository and checked out at the exact candidate SHA —
+   not the Engineer's own working tree, and not a standalone clone or new
+   project (workspace `--isolation worktree`; remote path:
+   `workspace-create ... --disposition independent-reviewer`). If the
+   worktree cannot be created, this step is
+   `BLOCKED: REVIEW_WORKTREE_UNAVAILABLE` — no fallback. Route the Reviewer
    with `MODEL_CLASS: REVIEW_HIGH` and load `paseo-ocr-reviewer`.
 3. Require the Reviewer to run `git rev-parse HEAD`, `git status --porcelain`,
    and `ocr version`, then verify `observed HEAD == ASSIGNED_CANDIDATE_SHA == REVIEW_CANDIDATE_SHA`.

--- a/skills/paseo-team-lead/SKILL.md
+++ b/skills/paseo-team-lead/SKILL.md
@@ -135,6 +135,12 @@ This is the exact failure mode the cluster config exists to prevent.
    `BLOCKED: REVIEW_WORKTREE_UNAVAILABLE`; there is no fallback (the
    reviewer wrapper mechanically rejects non-worktree workspaces with
    `REVIEW_WORKSPACE_NOT_WORKTREE`).
+   Local MCP `create_workspace` calls MUST pass an explicit
+   `isolation: "local" | "worktree"` (the policy extension rejects a
+   missing/invalid value), and a reviewer workspace MUST carry the naming
+   convention `title: "review:<TASK_ID>"` (or a `worktreeSlug` containing
+   `review`) with `isolation: "worktree"` — the policy extension blocks a
+   review-marked workspace that requests local isolation.
 9. Call `create_agent` with the exact provider string + thinking. NEVER omit
    the model to inherit a daemon default.
 10. Call `get_agent_status` and bounded-poll `snapshot.runtimeInfo.model` and

--- a/test/fixtures/fake-ocr.mjs
+++ b/test/fixtures/fake-ocr.mjs
@@ -5,16 +5,28 @@ const mode = process.env.OCR_FIXTURE_MODE ?? "";
 const file = process.env.OCR_FIXTURE_FILE ?? "src/reviewed.js";
 
 if (args.includes("version")) {
-  console.log(mode === "old-version" ? "open-code-review v1.8.9 (fixture)" : "open-code-review v1.8.10 (fixture)");
+  if (mode === "old-version") console.log("open-code-review v1.8.9 (fixture)");
+  else if (mode === "format-capable") console.log("open-code-review v1.9.2 (fixture)");
+  else console.log("open-code-review v1.8.10 (fixture)");
   process.exit(0);
 }
 if (args.includes("--help")) {
   if (mode === "missing-capability") {
     console.log("delegate command help without required flags");
+  } else if (mode === "format-capable") {
+    console.log("--repo <path> --from <ref> --to <ref> --format <text|json>");
   } else {
     console.log("--repo <path> --from <ref> --to <ref>");
   }
   process.exit(0);
+}
+// A format-capable OCR must actually be invoked with --format json.
+if (mode === "format-capable" && (args.includes("preview") || args.includes("rule"))) {
+  const flagIndex = args.indexOf("--format");
+  if (flagIndex === -1 || args[flagIndex + 1] !== "json") {
+    console.error("fixture: expected --format json in argv");
+    process.exit(1);
+  }
 }
 if (args.includes("preview")) {
   if (mode === "preview-malformed") {

--- a/test/fixtures/fake-paseo.mjs
+++ b/test/fixtures/fake-paseo.mjs
@@ -28,6 +28,15 @@ if (argv.includes("--fail")) {
 	process.exit(1);
 }
 
+if (
+	argv[0] === "workspace" &&
+	argv[1] === "create" &&
+	process.env.FAKE_PASEO_WORKSPACE_CREATE_FAIL === "1"
+) {
+	console.error("fatal: could not create worktree: disk full");
+	process.exit(1);
+}
+
 if (argv[0] === "run") {
 	if (process.env.FAKE_PASEO_NO_AGENT_ID === "1") {
 		console.log(JSON.stringify({ status: "running" }));

--- a/test/ocr-integrity.test.mjs
+++ b/test/ocr-integrity.test.mjs
@@ -64,6 +64,26 @@ assert.match(ocrSetup, /1\.8\.10/);
 assert.match(ocrSetup, /OCR_INSTALL_FAILED/);
 assert.match(ocrSkill, /MUST NOT:[\s\S]*edit product code[\s\S]*commit[\s\S]*push[\s\S]*merge[\s\S]*deploy/);
 
+// OCR compatibility is capability-based, never a version-equality gate.
+assert.match(ocrSetup, /probeDelegateCapability/);
+assert.match(ocrSetup, /OCR_PINNED_VERSION/);
+assert.match(ocrSetup, /OCR_MINIMUM_VERSION/);
+assert.doesNotMatch(ocrReview, /version\s*!==\s*OCR_/, "review wrapper has no version-equality gate");
+assert.match(ocrReview, /OCR_CAPABILITY_MISSING/);
+assert.match(ocrReview, /--format/);
+
+// Reviewer worktree isolation is a mechanical invariant end-to-end.
+const remotePaseo = read("scripts/remote-paseo.mjs");
+assert.match(ocrReview, /assertLinkedWorktree/);
+assert.match(ocrReview, /REVIEW_WORKSPACE_NOT_WORKTREE/);
+assert.match(ocrReview, /--git-common-dir/);
+assert.match(ocrSkill, /REVIEW_WORKSPACE_NOT_WORKTREE/);
+assert.match(ocrSkill, /REVIEW_WORKTREE_UNAVAILABLE/);
+assert.match(leadSkill, /REVIEW_WORKTREE_UNAVAILABLE/);
+assert.match(leadSkill, /--disposition independent-reviewer/);
+assert.match(remotePaseo, /REVIEW_ISOLATION_INVALID/);
+assert.match(remotePaseo, /independent-reviewer/);
+
 // OCR metadata stays outside the V3 authority marker block.
 const authorityBlock = brief.split("PASEO_TEAM_TASK_V3_BEGIN")[1].split("PASEO_TEAM_TASK_V3_END")[0];
 assert.doesNotMatch(authorityBlock, /OCR_MODE|OCR_ENGINE|OCR_BASE_SHA|REVIEW_BASE_SHA|REVIEW_CANDIDATE_SHA/);

--- a/test/ocr-integrity.test.mjs
+++ b/test/ocr-integrity.test.mjs
@@ -83,6 +83,13 @@ assert.match(leadSkill, /REVIEW_WORKTREE_UNAVAILABLE/);
 assert.match(leadSkill, /--disposition independent-reviewer/);
 assert.match(remotePaseo, /REVIEW_ISOLATION_INVALID/);
 assert.match(remotePaseo, /independent-reviewer/);
+assert.match(remotePaseo, /REVIEW_WORKTREE_UNAVAILABLE/);
+
+// Layer-1 local guard: the policy extension gates MCP create_workspace args.
+const policyExtension = read("extensions/paseo-team-policy.ts");
+assert.match(policyExtension, /leadCreateWorkspaceBlockReason/);
+assert.match(policyExtension, /REVIEW_WORKTREE_UNAVAILABLE/);
+assert.match(leadSkill, /review:<TASK_ID>/);
 
 // OCR metadata stays outside the V3 authority marker block.
 const authorityBlock = brief.split("PASEO_TEAM_TASK_V3_BEGIN")[1].split("PASEO_TEAM_TASK_V3_END")[0];

--- a/test/ocr-review.test.mjs
+++ b/test/ocr-review.test.mjs
@@ -15,7 +15,8 @@ import { fileURLToPath } from "node:url";
 
 import {
   OCR_ERROR_CODES,
-  OCR_SUPPORTED_VERSION,
+  OCR_BASELINE_VERSION,
+  assertLinkedWorktree,
   normalizePreview,
   normalizeRules,
   parsePreviewText,
@@ -35,20 +36,28 @@ function git(repo, ...args) {
   return execFileSync(GIT, args, { cwd: repo, encoding: "utf8" }).trim();
 }
 
+// The review workspace invariant: the wrapper only accepts a LINKED git
+// worktree, so the default fixture is a source repo plus a detached worktree
+// checked out at the candidate SHA. `source` is the primary checkout used by
+// the negative isolation tests.
 function makeRepo() {
-  const repo = mkdtempSync(join(tmpdir(), "paseo-ocr-review-"));
-  git(repo, "init", "-q");
-  git(repo, "config", "user.email", "test@example.invalid");
-  git(repo, "config", "user.name", "OCR Test");
-  mkdirSync(join(repo, "src"));
-  writeFileSync(join(repo, "src", "reviewed.js"), "export const value = 1;\n");
-  git(repo, "add", ".");
-  git(repo, "commit", "-qm", "initial");
-  const base = git(repo, "rev-parse", "HEAD");
-  writeFileSync(join(repo, "src", "reviewed.js"), "export const value = 2;\n");
-  git(repo, "commit", "-qam", "candidate");
-  const candidate = git(repo, "rev-parse", "HEAD");
-  return { repo, base, candidate };
+  const root = mkdtempSync(join(tmpdir(), "paseo-ocr-review-"));
+  const source = join(root, "source");
+  mkdirSync(source);
+  git(source, "init", "-q");
+  git(source, "config", "user.email", "test@example.invalid");
+  git(source, "config", "user.name", "OCR Test");
+  mkdirSync(join(source, "src"));
+  writeFileSync(join(source, "src", "reviewed.js"), "export const value = 1;\n");
+  git(source, "add", ".");
+  git(source, "commit", "-qm", "initial");
+  const base = git(source, "rev-parse", "HEAD");
+  writeFileSync(join(source, "src", "reviewed.js"), "export const value = 2;\n");
+  git(source, "commit", "-qam", "candidate");
+  const candidate = git(source, "rev-parse", "HEAD");
+  const repo = join(root, "review-worktree");
+  git(source, "worktree", "add", "-q", "--detach", repo, candidate);
+  return { repo, source, base, candidate };
 }
 
 function runWrapper(repo, base, candidate, extraEnv = {}) {
@@ -157,10 +166,11 @@ for (const code of [
   "OCR_UNAVAILABLE",
   "PREVIEW_INVALID",
   "RULES_INVALID",
+  "REVIEW_WORKSPACE_NOT_WORKTREE",
 ]) {
   assert.ok(OCR_ERROR_CODES.includes(code), `exports ${code}`);
-assert.equal(OCR_SUPPORTED_VERSION, "1.8.10");
 }
+assert.equal(OCR_BASELINE_VERSION, "1.8.10");
 
 // Ref inputs must be full immutable SHAs, not branch names or shell-like values.
 {
@@ -170,12 +180,57 @@ assert.equal(OCR_SUPPORTED_VERSION, "1.8.10");
   assert.equal(result.json.code, "USAGE");
 }
 
-// Capability/version failures are distinct and fail before selection.
-for (const [mode, code] of [["old-version", "OCR_VERSION_UNSUPPORTED"], ["missing-capability", "OCR_CAPABILITY_MISSING"]]) {
+// A missing delegate capability fails before selection.
+{
   const { repo, base, candidate } = makeRepo();
-  const result = runWrapper(repo, base, candidate, { OCR_FIXTURE_MODE: mode });
-  assert.equal(result.status, 2, mode);
-  assert.equal(result.json.code, code, mode);
+  const result = runWrapper(repo, base, candidate, { OCR_FIXTURE_MODE: "missing-capability" });
+  assert.equal(result.status, 2);
+  assert.equal(result.json.code, "OCR_CAPABILITY_MISSING");
+}
+
+// Version drift alone is NOT a blocker: compatibility is capability/schema
+// based and the version is recorded as provenance only.
+{
+  const { repo, base, candidate } = makeRepo();
+  const result = runWrapper(repo, base, candidate, { OCR_FIXTURE_MODE: "old-version" });
+  assert.equal(result.status, 0, result.stdout);
+  assert.equal(result.json.harness.ocr_version, "1.8.9");
+  assert.equal(result.json.harness.ocr_output_format, "text");
+}
+
+// A format-capable OCR is invoked with --format json (the fixture rejects the
+// invocation otherwise) and the manifest records the machine-readable format.
+{
+  const { repo, base, candidate } = makeRepo();
+  const result = runWrapper(repo, base, candidate, { OCR_FIXTURE_MODE: "format-capable" });
+  assert.equal(result.status, 0, result.stdout);
+  assert.equal(result.json.harness.ocr_version, "1.9.2");
+  assert.equal(result.json.harness.ocr_output_format, "json");
+}
+
+// The reviewer isolation invariant: a primary checkout is rejected even when
+// clean and at the exact candidate SHA.
+{
+  const { source, base, candidate } = makeRepo();
+  const result = runWrapper(source, base, candidate);
+  assert.equal(result.status, 2);
+  assert.equal(result.json.code, "REVIEW_WORKSPACE_NOT_WORKTREE");
+}
+
+// A standalone CLONE at the exact candidate SHA is also rejected — HEAD and
+// cleanliness alone must never satisfy the isolation gate.
+{
+  const { source, base, candidate } = makeRepo();
+  const clone = join(mkdtempSync(join(tmpdir(), "paseo-ocr-clone-")), "clone");
+  execFileSync(GIT, ["clone", "-q", source, clone], { encoding: "utf8" });
+  git(clone, "checkout", "-q", candidate);
+  const result = runWrapper(clone, base, candidate);
+  assert.equal(result.status, 2);
+  assert.equal(result.json.code, "REVIEW_WORKSPACE_NOT_WORKTREE");
+  assert.throws(
+    () => assertLinkedWorktree(clone),
+    (error) => error.code === "REVIEW_WORKSPACE_NOT_WORKTREE",
+  );
 }
 
 // Candidate SHA must match current HEAD before OCR is invoked.
@@ -219,6 +274,7 @@ for (const [mode, code] of [["old-version", "OCR_VERSION_UNSUPPORTED"], ["missin
   assert.equal(result.json.review.candidate_sha, candidate);
   assert.equal(result.json.review.candidate_tree_sha.length, 40);
   assert.equal(result.json.workspace.clean_entry, true);
+  assert.equal(result.json.workspace.linked_worktree, true);
   assert.equal(result.json.scope.selected_count, 1);
   assert.equal(result.json.scope.excluded_count, 0);
   assert.equal(result.json.scope.discovered_count, 1);

--- a/test/ocr-setup.test.mjs
+++ b/test/ocr-setup.test.mjs
@@ -1,60 +1,129 @@
 import assert from "node:assert/strict";
-import { OCR_NPM_PACKAGE, OCR_SUPPORTED_VERSION, parseOcrVersion, ensureOcr } from "../scripts/ocr-setup.mjs";
+import {
+  OCR_NPM_PACKAGE,
+  OCR_PINNED_VERSION,
+  OCR_MINIMUM_VERSION,
+  parseOcrVersion,
+  compareOcrVersions,
+  probeDelegateCapability,
+  ensureOcr,
+} from "../scripts/ocr-setup.mjs";
 
 assert.equal(OCR_NPM_PACKAGE, "@alibaba-group/open-code-review");
-assert.equal(OCR_SUPPORTED_VERSION, "1.8.10");
+assert.equal(OCR_MINIMUM_VERSION, "1.8.10");
+assert.ok(compareOcrVersions(OCR_PINNED_VERSION, OCR_MINIMUM_VERSION) >= 0, "pin >= minimum");
 assert.equal(parseOcrVersion("open-code-review v1.8.10"), "1.8.10");
-assert.equal(parseOcrVersion("open-code-review v1.8.9"), "1.8.9");
+assert.equal(parseOcrVersion("open-code-review v1.9.2 (5b37b5f8e) windows/amd64"), "1.9.2");
 assert.equal(parseOcrVersion("ocr unknown"), null);
 
-{
-  const calls = [];
-  let installed = false;
-  const result = ensureOcr({
-    run: (command, args) => {
-      calls.push([command, args]);
-      if (command === "ocr") return installed
-        ? { ok: true, stdout: "open-code-review v1.8.10\n", stderr: "", status: 0 }
-        : { ok: false, stdout: "", stderr: "not found", status: 1 };
-      if (command === "npm") { installed = true; return { ok: true, stdout: "installed", stderr: "", status: 0 }; }
-      throw new Error(`unexpected command ${command}`);
-    },
-  });
-  assert.equal(result.installed, true);
-  assert.equal(result.version, "1.8.10");
-  assert.deepEqual(calls, [
-    ["ocr", ["version"]],
-    ["npm", ["install", "-g", "@alibaba-group/open-code-review@1.8.10", "--no-audit", "--no-fund"]],
-    ["ocr", ["version"]],
-  ]);
-}
+assert.equal(compareOcrVersions("1.8.10", "1.8.10"), 0);
+assert.equal(compareOcrVersions("1.8.9", "1.8.10"), -1);
+assert.equal(compareOcrVersions("1.9.2", "1.8.10"), 1);
+assert.equal(compareOcrVersions("2.0.0", "1.99.99"), 1);
 
+const capableRun = (versionLine) => (command, args) => {
+  if (command === "ocr" && args[0] === "version") {
+    return { ok: true, stdout: `${versionLine}\n`, stderr: "", status: 0 };
+  }
+  if (command === "ocr" && args[0] === "delegate") {
+    return { ok: true, stdout: "--repo <path> --from <ref> --to <ref>", stderr: "", status: 0 };
+  }
+  throw new Error(`unexpected command ${command} ${args.join(" ")}`);
+};
+
+// probeDelegateCapability requires --repo/--from in BOTH delegate help outputs.
+assert.deepEqual(probeDelegateCapability(capableRun("open-code-review v1.9.2")), { ok: true });
+assert.deepEqual(
+  probeDelegateCapability(() => ({ ok: true, stdout: "no flags here", stderr: "", status: 0 })),
+  { ok: false, command: "preview" },
+);
+
+// A capable install at the tested baseline is accepted as-is (no npm call).
 {
-  const result = ensureOcr({
-    run: () => ({ ok: true, stdout: "open-code-review v1.8.10\n", stderr: "", status: 0 }),
-  });
+  const result = ensureOcr({ run: capableRun("open-code-review v1.8.10") });
   assert.equal(result.installed, false);
   assert.equal(result.version, "1.8.10");
 }
 
+// A NEWER capable install is accepted as-is — never downgraded to the pin.
 {
   const calls = [];
-  let upgraded = false;
+  const inner = capableRun("open-code-review v1.9.2");
   const result = ensureOcr({
     run: (command, args) => {
       calls.push([command, args]);
-      if (command === "ocr") return upgraded
-        ? { ok: true, stdout: "open-code-review v1.8.10\n", stderr: "", status: 0 }
-        : { ok: true, stdout: "open-code-review v1.8.9\n", stderr: "", status: 0 };
-      upgraded = true;
-      return { ok: true, stdout: "installed", stderr: "", status: 0 };
+      return inner(command, args);
+    },
+  });
+  assert.equal(result.installed, false);
+  assert.equal(result.version, "1.9.2");
+  assert.ok(calls.every(([command]) => command !== "npm"), "no downgrade install");
+}
+
+// Missing OCR is repaired by installing the pinned version.
+{
+  const calls = [];
+  let installed = false;
+  const capable = capableRun(`open-code-review v${OCR_PINNED_VERSION}`);
+  const result = ensureOcr({
+    run: (command, args) => {
+      calls.push([command, args]);
+      if (command === "ocr" && !installed) {
+        return { ok: false, stdout: "", stderr: "not found", status: 1 };
+      }
+      if (command === "npm") {
+        installed = true;
+        return { ok: true, stdout: "installed", stderr: "", status: 0 };
+      }
+      return capable(command, args);
     },
   });
   assert.equal(result.installed, true);
-  assert.equal(result.version, "1.8.10");
-  assert.equal(calls[1][0], "npm");
+  assert.equal(result.version, OCR_PINNED_VERSION);
+  assert.deepEqual(calls[1], ["npm", ["install", "-g", `${OCR_NPM_PACKAGE}@${OCR_PINNED_VERSION}`, "--no-audit", "--no-fund"]]);
 }
 
+// A version below the verified minimum is upgraded to the pin.
+{
+  let upgraded = false;
+  const result = ensureOcr({
+    run: (command, args) => {
+      if (command === "npm") {
+        upgraded = true;
+        return { ok: true, stdout: "installed", stderr: "", status: 0 };
+      }
+      const version = upgraded ? OCR_PINNED_VERSION : "1.8.9";
+      return capableRun(`open-code-review v${version}`)(command, args);
+    },
+  });
+  assert.equal(result.installed, true);
+  assert.equal(result.version, OCR_PINNED_VERSION);
+}
+
+// A newer version that FAILS the capability probe is repaired with the pin —
+// downgrade for real incompatibility, never for a mere version difference.
+{
+  let repaired = false;
+  const result = ensureOcr({
+    run: (command, args) => {
+      if (command === "npm") {
+        repaired = true;
+        return { ok: true, stdout: "installed", stderr: "", status: 0 };
+      }
+      if (args[0] === "version") {
+        return { ok: true, stdout: repaired ? `open-code-review v${OCR_PINNED_VERSION}\n` : "open-code-review v9.9.9\n", stderr: "", status: 0 };
+      }
+      // delegate --help: broken before repair, capable after.
+      return repaired
+        ? { ok: true, stdout: "--repo <path> --from <ref>", stderr: "", status: 0 }
+        : { ok: true, stdout: "flags renamed", stderr: "", status: 0 };
+    },
+  });
+  assert.equal(result.installed, true);
+  assert.equal(result.version, OCR_PINNED_VERSION);
+}
+
+// npm failure is fatal and explicit.
 assert.throws(
   () => ensureOcr({
     run: (command) => command === "ocr"
@@ -62,6 +131,18 @@ assert.throws(
       : { ok: false, stdout: "", stderr: "npm failed", status: 1 },
   }),
   /OCR_INSTALL_FAILED/,
+);
+
+// A repair install that still lacks the delegate capability fails closed.
+assert.throws(
+  () => ensureOcr({
+    run: (command, args) => {
+      if (command === "npm") return { ok: true, stdout: "installed", stderr: "", status: 0 };
+      if (args[0] === "version") return { ok: true, stdout: `open-code-review v${OCR_PINNED_VERSION}\n`, stderr: "", status: 0 };
+      return { ok: true, stdout: "no delegate flags", stderr: "", status: 0 };
+    },
+  }),
+  /OCR_CAPABILITY_MISSING/,
 );
 
 console.log("ocr setup tests passed");

--- a/test/policy.test.mts
+++ b/test/policy.test.mts
@@ -760,6 +760,69 @@ assert.ok(
 );
 assert.ok(mcpBlockReason("lead", { tool: {} }) !== null);
 
+// Lead create_workspace argument gate (Layer 1 of reviewer worktree invariant).
+assert.match(
+	mcpBlockReason("lead", { tool: "create_workspace" }) ?? "",
+	/args object/,
+	"missing create_workspace args → block",
+);
+assert.match(
+	mcpBlockReason("lead", {
+		tool: "create_workspace",
+		args: { path: "/repo" },
+	}) ?? "",
+	/explicit isolation/,
+	"missing isolation → block (no daemon default)",
+);
+assert.match(
+	mcpBlockReason("lead", {
+		tool: "create_workspace",
+		args: { path: "/repo", isolation: "worktee" },
+	}) ?? "",
+	/explicit isolation/,
+	"misspelled isolation → block fail-closed",
+);
+assert.equal(
+	mcpBlockReason("lead", {
+		tool: "create_workspace",
+		args: { path: "/repo", isolation: "local", title: "scout scratch" },
+	}),
+	null,
+	"non-review local workspace passes",
+);
+assert.equal(
+	mcpBlockReason("lead", {
+		tool: "create_workspace",
+		args: { path: "/repo", isolation: "worktree", title: "review:T-042" },
+	}),
+	null,
+	"review-marked worktree workspace passes",
+);
+assert.match(
+	mcpBlockReason("lead", {
+		tool: "create_workspace",
+		args: { path: "/repo", isolation: "local", title: "review:T-042" },
+	}) ?? "",
+	/worktree/,
+	"review-titled workspace with local isolation → block",
+);
+assert.match(
+	mcpBlockReason("lead", {
+		tool: "create_workspace",
+		args: { path: "/repo", isolation: "local", worktreeSlug: "review-T-042" },
+	}) ?? "",
+	/worktree/,
+	"review-slugged workspace with local isolation → block",
+);
+assert.match(
+	mcpBlockReason("lead", {
+		tool: "paseo_create_workspace",
+		args: JSON.stringify({ path: "/repo", isolation: "local", title: "Review T-9" }),
+	}) ?? "",
+	/worktree/,
+	"prefixed target + string args are gated the same way",
+);
+
 // Peer is fully blocked (handled by caller always blocking mcp for peer).
 
 // --- mcpScriptBlockReason (lead heuristic backstop) ---------------------------

--- a/test/remote-paseo.test.mjs
+++ b/test/remote-paseo.test.mjs
@@ -1037,6 +1037,45 @@ assert.deepEqual(
 }
 
 {
+	const t =
+		"e2e: reviewer worktree creation failure → REVIEW_WORKTREE_UNAVAILABLE, not CLI_ERROR";
+	const r = runWrapper(
+		[
+			"workspace-create",
+			"--host-id",
+			"mac-review",
+			"--path",
+			"/Users/admin/repo",
+			"--disposition",
+			"independent-reviewer",
+		],
+		{ extraEnv: { FAKE_PASEO_WORKSPACE_CREATE_FAIL: "1" } },
+	);
+	assert.equal(r.code, 2, `${t} (got ${r.code}: ${r.stdout})`);
+	assert.equal(r.json.ok, false, t);
+	assert.equal(r.json.code, "REVIEW_WORKTREE_UNAVAILABLE", t);
+	assert.match(r.json.message, /REVIEW_WORKTREE_UNAVAILABLE/, t);
+	assert.match(r.json.message, /never fall back/i, t);
+}
+
+{
+	const t =
+		"e2e: non-reviewer workspace-create failure stays CLI_ERROR";
+	const r = runWrapper(
+		[
+			"workspace-create",
+			"--host-id",
+			"mac-review",
+			"--path",
+			"/Users/admin/repo",
+		],
+		{ extraEnv: { FAKE_PASEO_WORKSPACE_CREATE_FAIL: "1" } },
+	);
+	assert.equal(r.code, 2, `${t} (got ${r.code}: ${r.stdout})`);
+	assert.equal(r.json.code, "CLI_ERROR", t);
+}
+
+{
 	const t = "successful CLI output is redacted at the wrapper boundary";
 	const home = makeHome();
 	const previous = process.env.FAKE_PASEO_LEAK_ENDPOINT;

--- a/test/remote-paseo.test.mjs
+++ b/test/remote-paseo.test.mjs
@@ -481,6 +481,84 @@ const EP = "https://app.paseo.sh/#offer=tok";
 }
 
 {
+	const t = "buildArgv: workspace-create validates --isolation values";
+	expectRemoteError("USAGE", () =>
+		buildArgv(
+			"workspace-create",
+			{ path: "/Users/admin/repo", isolation: "worktee" },
+			EP,
+		),
+	);
+	assert.ok(
+		buildArgv(
+			"workspace-create",
+			{ path: "/Users/admin/repo", isolation: "worktree" },
+			EP,
+		).includes("worktree"),
+		t,
+	);
+}
+
+{
+	const t = "buildArgv: independent-reviewer disposition forces worktree isolation";
+	// Unspecified isolation defaults to worktree for a reviewer workspace.
+	const argv = buildArgv(
+		"workspace-create",
+		{
+			path: "/Users/admin/repo",
+			disposition: "independent-reviewer",
+			title: "review-workspace",
+		},
+		EP,
+	);
+	const isolationIndex = argv.indexOf("--isolation");
+	assert.ok(isolationIndex !== -1 && argv[isolationIndex + 1] === "worktree", t);
+	// Explicit worktree is accepted unchanged.
+	assert.ok(
+		buildArgv(
+			"workspace-create",
+			{
+				path: "/Users/admin/repo",
+				disposition: "independent-reviewer",
+				isolation: "worktree",
+			},
+			EP,
+		).includes("worktree"),
+		t,
+	);
+	// Local isolation for a reviewer is a hard error, never a silent fallback.
+	expectRemoteError("REVIEW_ISOLATION_INVALID", () =>
+		buildArgv(
+			"workspace-create",
+			{
+				path: "/Users/admin/repo",
+				disposition: "independent-reviewer",
+				isolation: "local",
+			},
+			EP,
+		),
+	);
+	// Non-reviewer dispositions do not force isolation.
+	assert.ok(
+		!buildArgv(
+			"workspace-create",
+			{ path: "/Users/admin/repo", disposition: "engineer" },
+			EP,
+		).includes("--isolation"),
+		t,
+	);
+	// A misspelled disposition fails closed instead of silently skipping the
+	// reviewer worktree enforcement.
+	expectRemoteError("USAGE", () =>
+		buildArgv(
+			"workspace-create",
+			{ path: "/Users/admin/repo", disposition: "independent-reviwer" },
+			EP,
+		),
+	);
+}
+
+{
 	const t = "buildArgv: agents";
 	assert.deepEqual(
 		buildArgv("agents", {}, EP),


### PR DESCRIPTION
## Summary

Fixes two confirmed review-pipeline bugs that broke determinism and isolation:

### 1. OCR version drift blocked reviews (hard pin on 1.8.10)

`ocr-setup.mjs` and `ocr-review.mjs` hard-pinned `open-code-review@1.8.10`. After upstream released **v1.9.2** (2026-08-12), any machine that upgraded was blocked: the wrapper threw `OCR_VERSION_UNSUPPORTED` **before the review ran**, and the installer force-downgraded a newer working CLI — even though 1.9.2's output is fully compatible with the existing parsers (verified against the real CLI).

**Fix — compatibility is capability/schema-based; version is provenance only:**
- `ocr-setup.mjs`: `OCR_PINNED_VERSION` (1.9.2, installed only on repair) + `OCR_MINIMUM_VERSION` (1.8.10 baseline) + `probeDelegateCapability()`. An installed OCR ≥ baseline that passes the probe is kept as-is and **never downgraded**.
- `ocr-review.mjs`: version-equality gate removed. The wrapper probes `ocr delegate preview|rule --help`, uses `--format json` on format-capable CLIs (1.9.x) and keeps Markdown parsing for 1.8.10; both normalize to one strict schema. Manifest records `harness.ocr_version` + `harness.ocr_output_format` as provenance. Blocks only on real incompatibility (`OCR_CAPABILITY_MISSING`, `OCR_OUTPUT_SCHEMA_UNSUPPORTED`).
- `preflight.mjs`: warns below-baseline instead of on non-equality.

### 2. Reviewer isolation was advisory, not enforced

The review gates only checked `HEAD == candidate` + clean `git status`, so a **standalone clone or fresh local workspace at the right SHA passed review**, and `remote-paseo.mjs` never required `--isolation worktree` for reviewers — the Lead could legally create a non-isolated reviewer workspace.

**Fix — the worktree is a mechanical invariant with no fallback:**
- `ocr-review.mjs`: new `assertLinkedWorktree` gate compares `git rev-parse --git-dir` vs `--git-common-dir` (realpath). A primary checkout or standalone clone fails with `REVIEW_WORKSPACE_NOT_WORKTREE` even when clean at the exact SHA. Applies to both review and `--verify` paths.
- `remote-paseo.mjs`: `workspace-create` validates `--isolation` (`local|worktree` only); `--disposition independent-reviewer` **forces** `--isolation worktree` and rejects `local` with `REVIEW_ISOLATION_INVALID`; dispositions are allowlisted so a typo cannot silently skip enforcement. Worktree creation failure ⇒ `BLOCKED: REVIEW_WORKTREE_UNAVAILABLE`, never a fallback workspace.
- Lead + reviewer skills, prompts docs, and examples updated to state the invariant.

## Verification

- **Real end-to-end on Windows with the actual `open-code-review v1.9.2`**: installer keeps 1.9.2 (no downgrade), preflight passes both capability probes, the wrapper emits a JSON-format manifest from a real linked worktree (`ocr: 1.9.2, fmt: json, selected: 24, groups: 3`), and rejects both the primary checkout and a clean exact-SHA clone with `REVIEW_WORKSPACE_NOT_WORKTREE`.
- All 11 test suites pass (`node test/*.test.mjs`). New/updated coverage: version drift no longer blocks, `--format json` is actually passed (fixture rejects otherwise), clean clone rejected, reviewer disposition forces worktree, misspelled disposition fails closed, installer never downgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OCR compatibility now supports capable versions 1.8.10 and newer, with JSON output preferred when available.
  - Existing compatible OCR installations are retained; incompatible or missing installations are repaired with version 1.9.2.
  - Reviewer workspaces now require fresh linked Git worktrees created from the exact candidate revision.
  - Workspace validation provides clearer errors when isolation or worktree requirements are not met.

- **Documentation**
  - Updated installation, OCR integration, and reviewer workflow guidance to reflect capability-based checks and worktree requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->