### PR TITLE
feat(browser): opt-in CDP attach mode with reachability preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,45 @@ normalized prefixes); Paseo MCP and other servers stay off-limits.
 `node scripts/preflight.mjs --json` covers the CLI, Chrome/runtime, skill and
 MCP entry checks.
 
+#### Launch mode vs. CDP attach mode
+
+By default the MCP entry is `args: ["mcp"]` — **launch mode**. agent-browser
+starts its own browser, which carries no cookies and no logged-in sessions.
+That emptiness is what makes a per-turn `BROWSER_MCP_AUTHORITY` grant a real
+bound: the worst a granted Peer can do is browse as a stranger.
+
+**Attach mode** points agent-browser at a browser that is already running,
+through the Chrome DevTools Protocol:
+
+```bash
+scripts/install.sh --attach-cdp-port 9222
+# or, directly:
+node scripts/browser-setup.mjs --install --attach-cdp-port 9222
+```
+
+That writes `args: ["--cdp", "9222", "mcp"]` (agent-browser takes `--cdp` as a
+global flag, before the subcommand). It is faster and reuses the profile's auth
+— which is exactly the cost: a Peer holding the grant inherits **every session
+open in that profile**, and agent-browser refuses `--allowed-domains` while CDP
+is in use, so per-domain restriction is off the table too. Point it at a
+dedicated automation profile, never your daily browser.
+
+The rules around it:
+
+- **Opt-in, explicit port, no env fallback.** A setting this consequential has
+  to be visible in the command that caused it.
+- **Existing MCP entries are still never rewritten.** If one already exists with
+  a different target, the installer *fails* rather than silently ignoring the
+  flag — re-running `--attach-cdp-port` on an already-installed host is an
+  error you can see, not a no-op you cannot.
+- **Preflight probes it.** `agent-browser-cdp` reports launch mode, or dials
+  `127.0.0.1:<port>/json/version` and fails when nothing answers, so a dead
+  attach target surfaces as host unreadiness instead of a browser call dying
+  mid-turn. `agent-browser-cdp-exposure` warns when the same port also answers
+  on a non-loopback address — a browser started with
+  `--remote-debugging-address=0.0.0.0` is unauthenticated remote control of
+  that profile for anyone on the network.
+
 ### Paseo inspect contract test
 
 Because `peer_ask_lead` and the watchdog depend on JSON fields Paseo exposes,

--- a/scripts/browser-setup.mjs
+++ b/scripts/browser-setup.mjs
@@ -50,10 +50,23 @@ export function assertCdpPort(value) {
 			: Number.NaN;
 	if (!Number.isInteger(port) || port < 1 || port > 65535) {
 		throw new Error(
-			`CDP port must be an integer 1-65535, got ${JSON.stringify(value) ?? String(value)}`,
+			`CDP port must be an integer 1-65535, got ${describeValue(value)}`,
 		);
 	}
 	return port;
+}
+
+/**
+ * Render a rejected value for an error message without ever throwing itself.
+ * JSON.stringify raises on BigInt and returns undefined for symbols, so a
+ * fail-closed check that formats its input naively dies with the wrong error.
+ */
+function describeValue(value) {
+	try {
+		return JSON.stringify(value) ?? String(value);
+	} catch {
+		return String(value);
+	}
 }
 
 /**
@@ -167,6 +180,16 @@ export function describeCdpTarget(target) {
 }
 
 /**
+ * CDP version-probe URL. An IPv6 literal must be bracketed in a URL authority,
+ * and the exposure probe dials IPv6 addresses, so this is not cosmetic.
+ */
+export function cdpEndpointUrl(host, port) {
+	const literal =
+		host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+	return `http://${literal}:${assertCdpPort(port)}/json/version`;
+}
+
+/**
  * Ask a CDP endpoint to identify itself. Used by preflight so an unreachable
  * attach target is a host-readiness failure instead of a browser call that
  * dies inside a Peer turn.
@@ -177,7 +200,7 @@ export async function probeCdpEndpoint({
 	timeoutMs = 2000,
 } = {}) {
 	try {
-		const response = await fetch(`http://${host}:${assertCdpPort(port)}/json/version`, {
+		const response = await fetch(cdpEndpointUrl(host, port), {
 			signal: AbortSignal.timeout(timeoutMs),
 		});
 		if (!response.ok) {
@@ -198,15 +221,26 @@ export async function probeCdpEndpoint({
 }
 
 /**
- * Non-loopback local addresses on which the same CDP port answers. Chrome
- * started with --remote-debugging-address=0.0.0.0 hands full, unauthenticated
- * browser control to anything on the network; a loopback-only probe cannot see
- * that, so dial the host's own external addresses too.
+ * Non-loopback local addresses on which the same CDP port answers. A browser
+ * started with --remote-debugging-address=0.0.0.0 (or [::]) hands full,
+ * unauthenticated control to anything on the network; a loopback-only probe
+ * cannot see that, so dial the host's own external addresses too.
+ *
+ * Link-local addresses are skipped: IPv6 link-local needs a scope id fetch()
+ * will not carry, and neither family is how a LAN peer would reach this host,
+ * so probing them only adds timeouts.
  */
 export async function probeCdpExposure({ port, timeoutMs = 1000 } = {}) {
 	const addresses = Object.values(networkInterfaces())
 		.flat()
-		.filter((entry) => entry && entry.family === "IPv4" && !entry.internal)
+		.filter(
+			(entry) =>
+				entry &&
+				(entry.family === "IPv4" || entry.family === "IPv6") &&
+				!entry.internal &&
+				!entry.address.startsWith("169.254.") &&
+				!/^fe80:/i.test(entry.address),
+		)
 		.map((entry) => entry.address);
 	const probes = await Promise.all(
 		[...new Set(addresses)].map(async (address) => {
@@ -215,6 +249,33 @@ export async function probeCdpExposure({ port, timeoutMs = 1000 } = {}) {
 		}),
 	);
 	return probes.filter((address) => address !== null);
+}
+
+/**
+ * What an install run should do about an agent-browser entry that already
+ * exists. Pure, so the conflict rule is testable without shelling out to
+ * npm/agent-browser.
+ *
+ *   { action: "keep",     target }            leave the user's entry alone
+ *   { action: "conflict", target, message }   the requested port cannot be honoured
+ *
+ * The merge never rewrites an entry the user owns. That is the right default,
+ * but it would turn --attach-cdp-port into a knob that silently does nothing on
+ * the second run — so a request the existing entry cannot satisfy is an error
+ * you can see, not a no-op you cannot.
+ */
+export function resolveExistingEntryDecision(existing, requestedCdpPort = null) {
+	const target = agentBrowserCdpTarget(existing.server);
+	if (requestedCdpPort !== null && target.port !== requestedCdpPort) {
+		return {
+			action: "conflict",
+			target,
+			message:
+				`--attach-cdp-port ${requestedCdpPort} conflicts with the existing ${AGENT_BROWSER_MCP_SERVER} entry in ${existing.path} (${describeCdpTarget(target)}). ` +
+				"Existing MCP entries are never rewritten: edit or remove that entry, then re-run.",
+		};
+	}
+	return { action: "keep", target };
 }
 
 /** Add agent-browser only when the user has not configured that server yet. */
@@ -507,18 +568,10 @@ export function installAgentBrowser({
 		})
 		.find((entry) => entry !== null);
 	if (existingConfig) {
-		const target = agentBrowserCdpTarget(existingConfig.server);
-		// The merge never rewrites an entry the user owns. That is the right
-		// default, but it would turn --attach-cdp-port into a knob that silently
-		// does nothing on the second run — so say so instead of pretending.
-		if (requestedCdpPort !== null && target.port !== requestedCdpPort) {
-			throw new Error(
-				`--attach-cdp-port ${requestedCdpPort} conflicts with the existing ${AGENT_BROWSER_MCP_SERVER} entry in ${existingConfig.path} (${describeCdpTarget(target)}). ` +
-					"Existing MCP entries are never rewritten: edit or remove that entry, then re-run.",
-			);
-		}
+		const decision = resolveExistingEntryDecision(existingConfig, requestedCdpPort);
+		if (decision.action === "conflict") throw new Error(decision.message);
 		actions.push(
-			`MCP server ${AGENT_BROWSER_MCP_SERVER} already configured (${describeCdpTarget(target)})`,
+			`MCP server ${AGENT_BROWSER_MCP_SERVER} already configured (${describeCdpTarget(decision.target)})`,
 		);
 	} else {
 		mkdirSync(dirname(resolvedConfig), { recursive: true });

--- a/scripts/browser-setup.mjs
+++ b/scripts/browser-setup.mjs
@@ -131,9 +131,11 @@ export function isValidAgentBrowserMcpServer(server) {
 	if (server.disabled !== undefined && typeof server.disabled !== "boolean") {
 		return false;
 	}
-	if (server.lifecycle !== undefined && typeof server.lifecycle !== "string") {
-		return false;
-	}
+	// Deliberately NOT validating `lifecycle` or any other extra field. What this
+	// predicate really decides is whether the installer OVERWRITES the entry, so
+	// every rejection is a clobber: rejecting a field the previous rule ignored
+	// would silently replace a config the user owns. Only the fields the
+	// installer itself relies on may gate validity.
 	return readAgentBrowserArgs(server.args) !== null;
 }
 

--- a/scripts/browser-setup.mjs
+++ b/scripts/browser-setup.mjs
@@ -5,6 +5,17 @@
 // Pi's MCP adapter reads the user-global config at ~/.pi/agent/mcp.json, so
 // this script adds only the missing server entry and never rewrites an
 // existing server definition.
+//
+// Usage:
+//   node scripts/browser-setup.mjs --install [--pi-home <dir>] [--config <path>]
+//                                  [--skill-dir <dir>] [--with-deps]
+//                                  [--attach-cdp-port <port>]
+//
+// Default is launch mode: agent-browser starts its own browser, which holds no
+// credentials. --attach-cdp-port switches to attaching to an already-running
+// Chrome over CDP — faster and reuses that profile's auth, at the cost of
+// handing a granted Peer every session in it. Opt-in, explicit port, no env
+// fallback: a knob this consequential must be visible in the install command.
 
 import { spawnSync } from "node:child_process";
 import {
@@ -17,7 +28,7 @@ import {
 	cpSync,
 	writeFileSync,
 } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, networkInterfaces } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
 export const AGENT_BROWSER_PACKAGE = "agent-browser";
@@ -26,30 +37,186 @@ const CONFIG_LOCK_RETRIES = 50;
 const CONFIG_LOCK_WAIT_MS = 100;
 const CONFIG_LOCK_STALE_MS = 5 * 60 * 1000;
 
-export function browserMcpConfig() {
+/**
+ * Validate a CDP port at the boundary. Everything downstream (mcp.json, the
+ * preflight probe) assumes a real TCP port, so a typo must die here rather
+ * than become a browser call that fails mid-turn.
+ */
+export function assertCdpPort(value) {
+	const raw = typeof value === "string" ? value.trim() : value;
+	const port =
+		typeof raw === "number" || (typeof raw === "string" && raw.length > 0)
+			? Number(raw)
+			: Number.NaN;
+	if (!Number.isInteger(port) || port < 1 || port > 65535) {
+		throw new Error(
+			`CDP port must be an integer 1-65535, got ${JSON.stringify(value) ?? String(value)}`,
+		);
+	}
+	return port;
+}
+
+/**
+ * MCP entry for the agent-browser stdio server.
+ *
+ * `cdpPort: null` (the default) is launch mode: agent-browser starts its own
+ * browser, which carries no ambient credentials — the isolation that makes a
+ * per-turn BROWSER_MCP_AUTHORITY grant a meaningful bound. Passing a port
+ * switches to attach mode, where a granted Peer inherits every logged-in
+ * session in the target profile, so it is opt-in only (`--attach-cdp-port`).
+ *
+ * agent-browser takes --cdp as a global flag, before the subcommand:
+ *   agent-browser --cdp 9222 mcp
+ */
+export function browserMcpConfig({ cdpPort = null } = {}) {
+	const args =
+		cdpPort === null || cdpPort === undefined
+			? ["mcp"]
+			: ["--cdp", String(assertCdpPort(cdpPort)), "mcp"];
 	return {
 		command: "agent-browser",
-		args: ["mcp"],
+		args,
 		lifecycle: "lazy",
 	};
 }
 
+/**
+ * Shared arg reader for the validator and the CDP-target parser.
+ * Returns null when the args are not a shape we can reason about.
+ */
+function readAgentBrowserArgs(args) {
+	if (!Array.isArray(args) || args.length === 0) return null;
+	if (!args.every((arg) => typeof arg === "string")) return null;
+	const ports = new Set();
+	let index = 0;
+	// Leading global flag: --cdp <port> mcp
+	if (args[0] === "--cdp") {
+		if (args.length < 3) return null;
+		let port;
+		try {
+			port = assertCdpPort(args[1]);
+		} catch {
+			return null;
+		}
+		ports.add(port);
+		index = 2;
+	}
+	if (args[index] !== "mcp") return null;
+	// A hand-written entry may also put the flag after the subcommand. Read it
+	// so preflight probes the port the user actually meant, but stay permissive:
+	// this function decides whether the installer OVERWRITES the entry, and an
+	// entry we merely find odd is still the user's.
+	const trailing = args.slice(index + 1);
+	for (let i = 0; i < trailing.length; i++) {
+		if (trailing[i] !== "--cdp") continue;
+		try {
+			ports.add(assertCdpPort(trailing[i + 1]));
+		} catch {
+			return { ports: new Set(), ambiguous: true };
+		}
+	}
+	return { ports, ambiguous: ports.size > 1 };
+}
+
 export function isValidAgentBrowserMcpServer(server) {
-	return Boolean(
-		server &&
-		typeof server === "object" &&
-		!Array.isArray(server) &&
-		typeof server.command === "string" &&
-		server.command.trim() === "agent-browser" &&
-		Array.isArray(server.args) &&
-		server.args[0] === "mcp" &&
-		server.args.every((arg) => typeof arg === "string") &&
-		(server.disabled === undefined || typeof server.disabled === "boolean"),
+	if (
+		!server ||
+		typeof server !== "object" ||
+		Array.isArray(server) ||
+		typeof server.command !== "string" ||
+		server.command.trim() !== "agent-browser"
+	) {
+		return false;
+	}
+	if (server.disabled !== undefined && typeof server.disabled !== "boolean") {
+		return false;
+	}
+	if (server.lifecycle !== undefined && typeof server.lifecycle !== "string") {
+		return false;
+	}
+	return readAgentBrowserArgs(server.args) !== null;
+}
+
+/**
+ * How an installed entry reaches a browser.
+ *   { mode: "launch",    port: null }   agent-browser starts an isolated browser
+ *   { mode: "attach",    port: <n> }    it dials CDP on 127.0.0.1:<n>
+ *   { mode: "ambiguous", port: null }   two different --cdp ports; we refuse to guess
+ */
+export function agentBrowserCdpTarget(server) {
+	if (!isValidAgentBrowserMcpServer(server)) {
+		throw new Error(
+			"agentBrowserCdpTarget expects a valid agent-browser MCP server entry",
+		);
+	}
+	const parsed = readAgentBrowserArgs(server.args);
+	if (parsed.ambiguous) return { mode: "ambiguous", port: null };
+	const [port] = parsed.ports;
+	return port === undefined
+		? { mode: "launch", port: null }
+		: { mode: "attach", port };
+}
+
+/** One-line description of a parsed CDP target, for installer/preflight output. */
+export function describeCdpTarget(target) {
+	if (target.mode === "attach") return `attach mode, CDP port ${target.port}`;
+	if (target.mode === "ambiguous") return "ambiguous --cdp flags";
+	return "launch mode, isolated browser";
+}
+
+/**
+ * Ask a CDP endpoint to identify itself. Used by preflight so an unreachable
+ * attach target is a host-readiness failure instead of a browser call that
+ * dies inside a Peer turn.
+ */
+export async function probeCdpEndpoint({
+	host = "127.0.0.1",
+	port,
+	timeoutMs = 2000,
+} = {}) {
+	try {
+		const response = await fetch(`http://${host}:${assertCdpPort(port)}/json/version`, {
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		if (!response.ok) {
+			return { ok: false, browser: "", error: `HTTP ${response.status}` };
+		}
+		const payload = await response.json();
+		const browser = typeof payload?.Browser === "string" ? payload.Browser : "";
+		return browser
+			? { ok: true, browser, error: "" }
+			: { ok: false, browser: "", error: "response is not a CDP /json/version payload" };
+	} catch (error) {
+		return {
+			ok: false,
+			browser: "",
+			error: String(error?.message ?? error) || "unreachable",
+		};
+	}
+}
+
+/**
+ * Non-loopback local addresses on which the same CDP port answers. Chrome
+ * started with --remote-debugging-address=0.0.0.0 hands full, unauthenticated
+ * browser control to anything on the network; a loopback-only probe cannot see
+ * that, so dial the host's own external addresses too.
+ */
+export async function probeCdpExposure({ port, timeoutMs = 1000 } = {}) {
+	const addresses = Object.values(networkInterfaces())
+		.flat()
+		.filter((entry) => entry && entry.family === "IPv4" && !entry.internal)
+		.map((entry) => entry.address);
+	const probes = await Promise.all(
+		[...new Set(addresses)].map(async (address) => {
+			const probe = await probeCdpEndpoint({ host: address, port, timeoutMs });
+			return probe.ok ? address : null;
+		}),
 	);
+	return probes.filter((address) => address !== null);
 }
 
 /** Add agent-browser only when the user has not configured that server yet. */
-export function mergeAgentBrowserMcpConfig(config) {
+export function mergeAgentBrowserMcpConfig(config, { cdpPort = null } = {}) {
 	const source =
 		config && typeof config === "object" && !Array.isArray(config)
 			? config
@@ -66,7 +233,7 @@ export function mergeAgentBrowserMcpConfig(config) {
 		...source,
 		mcpServers: {
 			...servers,
-			[AGENT_BROWSER_MCP_SERVER]: browserMcpConfig(),
+			[AGENT_BROWSER_MCP_SERVER]: browserMcpConfig({ cdpPort }),
 		},
 	};
 }
@@ -242,6 +409,10 @@ export function inspectAgentBrowser({ piHome, configPath, skillPath } = {}) {
 		browserRuntime: runtime.ok,
 		browserMcp: isValidAgentBrowserMcpServer(server),
 		browserMcpEnabled: isValidAgentBrowserMcpServer(server) && server.disabled !== true,
+		// Parsed once here so preflight never re-scans args on its own.
+		cdpTarget: isValidAgentBrowserMcpServer(server)
+			? agentBrowserCdpTarget(server)
+			: null,
 		skill: skillIsInstalled(join(resolvedSkill, "SKILL.md")),
 		skillPath: resolvedSkill,
 		configPath: configWithServer?.path ?? resolvedConfig,
@@ -254,7 +425,9 @@ export function installAgentBrowser({
 	configPath,
 	skillPath,
 	withDeps,
+	cdpPort = null,
 } = {}) {
+	const requestedCdpPort = cdpPort === null ? null : assertCdpPort(cdpPort);
 	const resolvedConfig = configPath ?? defaultMcpConfigPath(piHome);
 	const resolvedSkill = skillPath ?? defaultSkillPath(piHome);
 	const actions = [];
@@ -321,23 +494,42 @@ export function installAgentBrowser({
 		throw new Error(`Skill copy failed: ${targetSkillFile}`);
 	actions.push("installed agent-browser skill");
 
-	const existingConfig = mcpConfigCandidates(piHome).some((path) => {
-		try {
-			return isValidAgentBrowserMcpServer(readJson(path).mcpServers?.[AGENT_BROWSER_MCP_SERVER]);
-		} catch {
-			return false;
-		}
-	});
+	const existingConfig = mcpConfigCandidates(piHome)
+		.map((path) => {
+			try {
+				const server = readJson(path).mcpServers?.[AGENT_BROWSER_MCP_SERVER];
+				return isValidAgentBrowserMcpServer(server) ? { path, server } : null;
+			} catch {
+				return null;
+			}
+		})
+		.find((entry) => entry !== null);
 	if (existingConfig) {
-		actions.push(`MCP server ${AGENT_BROWSER_MCP_SERVER} already configured`);
+		const target = agentBrowserCdpTarget(existingConfig.server);
+		// The merge never rewrites an entry the user owns. That is the right
+		// default, but it would turn --attach-cdp-port into a knob that silently
+		// does nothing on the second run — so say so instead of pretending.
+		if (requestedCdpPort !== null && target.port !== requestedCdpPort) {
+			throw new Error(
+				`--attach-cdp-port ${requestedCdpPort} conflicts with the existing ${AGENT_BROWSER_MCP_SERVER} entry in ${existingConfig.path} (${describeCdpTarget(target)}). ` +
+					"Existing MCP entries are never rewritten: edit or remove that entry, then re-run.",
+			);
+		}
+		actions.push(
+			`MCP server ${AGENT_BROWSER_MCP_SERVER} already configured (${describeCdpTarget(target)})`,
+		);
 	} else {
 		mkdirSync(dirname(resolvedConfig), { recursive: true });
 		withConfigLock(resolvedConfig, () => {
 			const before = readJson(resolvedConfig);
-			const after = mergeAgentBrowserMcpConfig(before);
+			const after = mergeAgentBrowserMcpConfig(before, { cdpPort: requestedCdpPort });
 			if (after !== before) {
 				writeJsonAtomic(resolvedConfig, after);
-				actions.push(`added MCP server ${AGENT_BROWSER_MCP_SERVER}`);
+				actions.push(
+					`added MCP server ${AGENT_BROWSER_MCP_SERVER} (${describeCdpTarget(
+						agentBrowserCdpTarget(after.mcpServers[AGENT_BROWSER_MCP_SERVER]),
+					)})`,
+				);
 			}
 		});
 	}
@@ -358,13 +550,27 @@ if (process.argv.includes("--install")) {
 		return index >= 0 ? process.argv[index + 1] : undefined;
 	};
 	try {
+		// Attach mode is opt-in and takes an explicit port: no env fallback, no
+		// bare-flag default. A browser reached over CDP carries the profile's
+		// live sessions, so the choice must be visible in the install command.
+		const attachCdpPort = process.argv.includes("--attach-cdp-port")
+			? assertCdpPort(valueAfter("--attach-cdp-port"))
+			: null;
 		const result = installAgentBrowser({
 			piHome: valueAfter("--pi-home"),
 			configPath: valueAfter("--config"),
 			skillPath: valueAfter("--skill-dir"),
 			withDeps: process.argv.includes("--with-deps") ? true : undefined,
+			cdpPort: attachCdpPort,
 		});
 		console.log(`[paseo-team] ${result.actions.join("; ")}`);
+		if (attachCdpPort !== null) {
+			console.warn(
+				`[paseo-team] attach mode: agent-browser will drive the browser already running on CDP port ${attachCdpPort}. ` +
+					"A Peer holding BROWSER_MCP_AUTHORITY inherits every logged-in session in that profile, " +
+					"and agent-browser rejects --allowed-domains while CDP is in use. Point it at a dedicated profile, never your daily browser.",
+			);
+		}
 	} catch (error) {
 		console.error(
 			`[paseo-team] agent-browser setup failed: ${String(error?.message ?? error)}`,

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,7 +9,11 @@
 
 param(
   [string]$PiHome = "$env:USERPROFILE\.pi",
-  [string]$RolePackRoot = (Split-Path -Parent $PSScriptRoot)
+  [string]$RolePackRoot = (Split-Path -Parent $PSScriptRoot),
+  # Optional: attach agent-browser to an already-running browser over CDP
+  # instead of letting it launch an isolated one. Opt-in with an explicit port
+  # - see scripts/browser-setup.mjs for why this is not a default.
+  [string]$AttachCdpPort = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -60,6 +64,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 $browserSetupArgs = @("--install")
 if (-not $env:PI_CODING_AGENT_DIR) { $browserSetupArgs += @("--pi-home", $PiHome) }
+if ($AttachCdpPort) { $browserSetupArgs += @("--attach-cdp-port", $AttachCdpPort) }
 & node (Join-Path $RolePackRoot "scripts\browser-setup.mjs") @browserSetupArgs
 if ($LASTEXITCODE -ne 0) {
   throw "agent-browser setup failed with exit code $LASTEXITCODE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,6 +10,27 @@
 
 set -euo pipefail
 
+# Optional: attach agent-browser to an already-running browser over CDP instead
+# of letting it launch an isolated one. Opt-in with an explicit port — see
+# scripts/browser-setup.mjs for why this is not a default.
+ATTACH_CDP_PORT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --attach-cdp-port)
+      if [[ $# -lt 2 ]]; then
+        echo "[paseo-team] --attach-cdp-port requires a port" >&2
+        exit 1
+      fi
+      ATTACH_CDP_PORT="$2"
+      shift 2
+      ;;
+    *)
+      echo "[paseo-team] unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
 ROLE_PACK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PI_HOME="${PI_HOME:-$HOME/.pi}"
 AGENT_DIR="${PI_CODING_AGENT_DIR:-$PI_HOME/agent}"
@@ -60,6 +81,9 @@ fi
 BROWSER_SETUP_ARGS=(--install)
 if [[ -z "${PI_CODING_AGENT_DIR:-}" ]]; then
   BROWSER_SETUP_ARGS+=(--pi-home "$PI_HOME")
+fi
+if [[ -n "$ATTACH_CDP_PORT" ]]; then
+  BROWSER_SETUP_ARGS+=(--attach-cdp-port "$ATTACH_CDP_PORT")
 fi
 if ! node "$ROLE_PACK_ROOT/scripts/browser-setup.mjs" "${BROWSER_SETUP_ARGS[@]}"; then
   echo "[paseo-team] agent-browser setup failed" >&2

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -8,7 +8,8 @@
 // Checks (per host): node, git, paseo CLI + daemon, pi CLI, pi-mcp-adapter,
 // role-pack extension + prompts, Paseo role providers, model inventory,
 // routing-config validity, per-model thinking support, cluster routing
-// contract, endpoint env presence, repository state.
+// contract, endpoint env presence, agent-browser CDP mode + reachability,
+// repository state.
 //
 // Never prints secret values: only env-var NAMES are checked/reported.
 // Exit code 1 when any check fails. In --strict mode, warnings that affect
@@ -20,7 +21,12 @@ import { execFileSync, execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { inspectAgentBrowser } from "./browser-setup.mjs";
+import {
+	describeCdpTarget,
+	inspectAgentBrowser,
+	probeCdpEndpoint,
+	probeCdpExposure,
+} from "./browser-setup.mjs";
 import {
 	RoutingError,
 	buildProviderInventory,
@@ -278,6 +284,45 @@ let daemonUp = false;
 			"agent-browser-mcp",
 			`${browser.configPath} has no agent-browser server entry`,
 		);
+
+	// How the entry reaches a browser. A config only names a port; without the
+	// probe below, an unreachable CDP target first shows up as a failed browser
+	// call in the middle of a Peer turn instead of as host unreadiness.
+	if (browser.browserMcpEnabled && browser.cdpTarget) {
+		const target = browser.cdpTarget;
+		if (target.mode === "launch") {
+			pass("agent-browser-cdp", describeCdpTarget(target));
+		} else if (target.mode === "ambiguous") {
+			fail(
+				"agent-browser-cdp",
+				`the agent-browser entry in ${browser.configPath} has ambiguous --cdp flags (duplicated with different ports, or one is missing its port) — leave exactly one "--cdp <port>"`,
+			);
+		} else {
+			const probe = await probeCdpEndpoint({ port: target.port });
+			if (probe.ok) {
+				pass(
+					"agent-browser-cdp",
+					`attached to 127.0.0.1:${target.port} (${probe.browser}) — a Peer granted BROWSER_MCP_AUTHORITY inherits every session in that profile`,
+				);
+				// Loopback reachability says nothing about the bind address. A
+				// browser started with --remote-debugging-address=0.0.0.0 hands
+				// full, unauthenticated control to the whole network. Only
+				// meaningful once something is actually listening.
+				const exposed = await probeCdpExposure({ port: target.port });
+				if (exposed.length > 0)
+					warn(
+						"agent-browser-cdp-exposure",
+						`CDP port ${target.port} also answers on ${exposed.join(", ")} — unauthenticated browser control is reachable off-host; bind the browser to 127.0.0.1`,
+					);
+				else pass("agent-browser-cdp-exposure", "CDP port is loopback-only");
+			} else {
+				fail(
+					"agent-browser-cdp",
+					`nothing answers CDP on 127.0.0.1:${target.port} (${probe.error}) — start the browser with --remote-debugging-port=${target.port}, or reinstall without --attach-cdp-port to use launch mode`,
+				);
+			}
+		}
+	}
 }
 
 // --- role-pack installation ---------------------------------------------------

--- a/test/browser-setup.test.mjs
+++ b/test/browser-setup.test.mjs
@@ -149,10 +149,57 @@ assert.equal(
 	false,
 );
 assert.equal(isValidAgentBrowserMcpServer({ command: "agent-browser", args: [] }), false);
-assert.equal(
-	isValidAgentBrowserMcpServer({ command: "agent-browser", args: ["mcp"], lifecycle: 7 }),
-	false,
-);
+
+// Superset guard. Every rejection here makes the installer OVERWRITE that entry,
+// so the rule must never reject anything the pre-CDP rule accepted — including
+// fields it did not look at, such as `lifecycle`. This replays the old rule
+// verbatim over a corpus and fails on any entry that lost validity.
+{
+	const preCdpRule = (server) =>
+		Boolean(
+			server &&
+				typeof server === "object" &&
+				!Array.isArray(server) &&
+				typeof server.command === "string" &&
+				server.command.trim() === "agent-browser" &&
+				Array.isArray(server.args) &&
+				server.args[0] === "mcp" &&
+				server.args.every((arg) => typeof arg === "string") &&
+				(server.disabled === undefined || typeof server.disabled === "boolean"),
+		);
+	const argSets = [
+		["mcp"],
+		["mcp", "--tools", "core"],
+		["mcp", "--cdp"],
+		["mcp", "--cdp", "9222"],
+		["mcp", "--cdp", "0"],
+		["open"],
+		[],
+		["--cdp", "9222", "mcp"],
+	];
+	const extras = [
+		{},
+		{ disabled: true },
+		{ disabled: false },
+		{ lifecycle: "lazy" },
+		{ lifecycle: 7 },
+		{ lifecycle: null },
+		{ lifecycle: {} },
+		{ someFutureField: { nested: true } },
+	];
+	for (const args of argSets) {
+		for (const extra of extras) {
+			const server = { command: "agent-browser", args, ...extra };
+			if (preCdpRule(server)) {
+				assert.equal(
+					isValidAgentBrowserMcpServer(server),
+					true,
+					`the installer would clobber a previously valid entry: ${JSON.stringify(server)}`,
+				);
+			}
+		}
+	}
+}
 
 // Preflight needs the parsed target, not a second ad-hoc scan of args.
 assert.deepEqual(agentBrowserCdpTarget({ command: "agent-browser", args: ["mcp"] }), {

--- a/test/browser-setup.test.mjs
+++ b/test/browser-setup.test.mjs
@@ -8,10 +8,12 @@ import {
 	agentBrowserCdpTarget,
 	assertCdpPort,
 	browserMcpConfig,
+	cdpEndpointUrl,
 	isValidAgentBrowserMcpServer,
 	mergeAgentBrowserMcpConfig,
 	mcpConfigCandidates,
 	probeCdpEndpoint,
+	resolveExistingEntryDecision,
 	skillIsInstalled,
 } from "../scripts/browser-setup.mjs";
 
@@ -105,11 +107,30 @@ assert.deepEqual(browserMcpConfig({ cdpPort: "9222" }).args, [
 // Ports are validated at the boundary so a typo can never reach mcp.json.
 assert.equal(assertCdpPort(9222), 9222);
 assert.equal(assertCdpPort(" 9222 "), 9222);
-for (const bad of ["", " ", "abc", "0", "-1", "65536", "92.22", null, undefined, {}, 1.5, Number.NaN]) {
+// Every rejection must be THIS error, not an incidental one from formatting the
+// offending value — a fail-closed helper that dies the wrong way is a helper you
+// cannot diagnose.
+for (const bad of [
+	"",
+	" ",
+	"abc",
+	"0",
+	"-1",
+	"65536",
+	"92.22",
+	null,
+	undefined,
+	{},
+	1.5,
+	Number.NaN,
+	9222n,
+	Symbol("9222"),
+	[9222],
+]) {
 	assert.throws(
 		() => assertCdpPort(bad),
-		/CDP port/,
-		`assertCdpPort must reject ${JSON.stringify(bad) ?? String(bad)}`,
+		/CDP port must be an integer/,
+		`assertCdpPort must reject ${String(bad)} with its own error`,
 	);
 }
 assert.throws(() => browserMcpConfig({ cdpPort: "nope" }), /CDP port/);
@@ -243,6 +264,54 @@ assert.deepEqual(
 );
 assert.throws(() => agentBrowserCdpTarget({ command: "gh", args: ["mcp"] }), /agent-browser/);
 
+// An IPv6 target has to be bracketed or the URL is nonsense — and the exposure
+// probe now dials IPv6 addresses too, so this is on a live path.
+assert.equal(cdpEndpointUrl("127.0.0.1", 9222), "http://127.0.0.1:9222/json/version");
+assert.equal(cdpEndpointUrl("::1", 9222), "http://[::1]:9222/json/version");
+assert.equal(cdpEndpointUrl("fd00::1", 9222), "http://[fd00::1]:9222/json/version");
+// Already-bracketed input must not be double-wrapped.
+assert.equal(cdpEndpointUrl("[::1]", 9222), "http://[::1]:9222/json/version");
+assert.throws(() => cdpEndpointUrl("127.0.0.1", 0), /CDP port/);
+
+// The conflict rule is the safety behaviour of this whole change. It lives in a
+// pure function so it is testable without shelling out to npm/agent-browser.
+{
+	const launchEntry = {
+		path: "/home/u/.pi/agent/mcp.json",
+		server: { command: "agent-browser", args: ["mcp"] },
+	};
+	const attach9222 = {
+		path: "/home/u/.pi/agent/mcp.json",
+		server: { command: "agent-browser", args: ["--cdp", "9222", "mcp"] },
+	};
+
+	// No port requested: whatever the user has stays, in either mode.
+	assert.deepEqual(resolveExistingEntryDecision(launchEntry, null), {
+		action: "keep",
+		target: { mode: "launch", port: null },
+	});
+	assert.equal(resolveExistingEntryDecision(attach9222, null).action, "keep");
+
+	// Requested port already in place: idempotent, not a conflict.
+	assert.equal(resolveExistingEntryDecision(attach9222, 9222).action, "keep");
+
+	// Requested port the existing entry cannot satisfy: loud, never a silent
+	// no-op, and never an overwrite.
+	for (const [entry, requested] of [
+		[launchEntry, 9222],
+		[attach9222, 9333],
+	]) {
+		const decision = resolveExistingEntryDecision(entry, requested);
+		assert.equal(decision.action, "conflict");
+		assert.match(decision.message, /--attach-cdp-port/);
+		assert.match(decision.message, /never rewritten/);
+		assert.ok(
+			decision.message.includes(entry.path),
+			"the conflict must name the config file the user has to edit",
+		);
+	}
+}
+
 // A requested attach port must reach the merged config.
 {
 	const merged = mergeAgentBrowserMcpConfig({}, { cdpPort: 9222 });
@@ -300,6 +369,26 @@ for (const args of [["mcp", "--tools", "core"], ["--cdp", "9333", "mcp"]]) {
 	const { port } = server.address();
 	const probe = await probeCdpEndpoint({ port, timeoutMs: 2000 });
 	assert.equal(probe.ok, false);
+	await new Promise((resolve) => server.close(resolve));
+}
+// The probe must actually work over IPv6, not just format the URL correctly.
+{
+	const server = createServer((req, res) => {
+		if (req.url === "/json/version") {
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ Browser: "Chrome/141.0.0.0" }));
+			return;
+		}
+		res.writeHead(404).end("nope");
+	});
+	const listening = await new Promise((resolve) => {
+		server.once("error", () => resolve(false));
+		server.listen(0, "::1", () => resolve(true));
+	});
+	assert.ok(listening, "IPv6 loopback must be available to exercise the probe");
+	const { port } = server.address();
+	const probe = await probeCdpEndpoint({ host: "::1", port, timeoutMs: 2000 });
+	assert.equal(probe.ok, true, "probeCdpEndpoint must reach an IPv6 endpoint");
 	await new Promise((resolve) => server.close(resolve));
 }
 

--- a/test/browser-setup.test.mjs
+++ b/test/browser-setup.test.mjs
@@ -1,13 +1,17 @@
 import assert from "node:assert/strict";
+import { createServer } from "node:http";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	AGENT_BROWSER_MCP_SERVER,
+	agentBrowserCdpTarget,
+	assertCdpPort,
 	browserMcpConfig,
 	isValidAgentBrowserMcpServer,
 	mergeAgentBrowserMcpConfig,
 	mcpConfigCandidates,
+	probeCdpEndpoint,
 	skillIsInstalled,
 } from "../scripts/browser-setup.mjs";
 
@@ -73,5 +77,183 @@ assert.equal(
 );
 assert.equal(skillIsInstalled(join(skillRoot, "agent-browser")), false);
 rmSync(skillRoot, { recursive: true, force: true });
+
+// --- CDP attach mode ------------------------------------------------------------
+//
+// Launch mode is the default on purpose: agent-browser starts a browser with no
+// ambient credentials, which is the isolation BROWSER_MCP_AUTHORITY is sized
+// for. Attaching to a running Chrome hands a granted Peer every session in that
+// profile, so it must be an explicit opt-in — never a default, never implied.
+
+// Default stays launch mode: no --cdp is written into anyone's config.
+assert.deepEqual(browserMcpConfig().args, ["mcp"]);
+assert.equal(browserMcpConfig().args.includes("--cdp"), false);
+
+// agent-browser takes --cdp as a GLOBAL flag, before the subcommand:
+//   agent-browser --cdp 9222 mcp
+assert.deepEqual(browserMcpConfig({ cdpPort: 9222 }).args, [
+	"--cdp",
+	"9222",
+	"mcp",
+]);
+assert.deepEqual(browserMcpConfig({ cdpPort: "9222" }).args, [
+	"--cdp",
+	"9222",
+	"mcp",
+]);
+
+// Ports are validated at the boundary so a typo can never reach mcp.json.
+assert.equal(assertCdpPort(9222), 9222);
+assert.equal(assertCdpPort(" 9222 "), 9222);
+for (const bad of ["", " ", "abc", "0", "-1", "65536", "92.22", null, undefined, {}, 1.5, Number.NaN]) {
+	assert.throws(
+		() => assertCdpPort(bad),
+		/CDP port/,
+		`assertCdpPort must reject ${JSON.stringify(bad) ?? String(bad)}`,
+	);
+}
+assert.throws(() => browserMcpConfig({ cdpPort: "nope" }), /CDP port/);
+
+// The validator accepts both shapes. It must stay a superset of the old rule:
+// anything it rejects gets OVERWRITTEN by the installer, so tightening it here
+// would silently clobber a config the user edited by hand.
+assert.equal(isValidAgentBrowserMcpServer({ command: "agent-browser", args: ["mcp"] }), true);
+assert.equal(
+	isValidAgentBrowserMcpServer({ command: "agent-browser", args: ["mcp", "--tools", "core"] }),
+	true,
+);
+assert.equal(
+	isValidAgentBrowserMcpServer({ command: "agent-browser", args: ["--cdp", "9222", "mcp"] }),
+	true,
+);
+assert.equal(
+	isValidAgentBrowserMcpServer({ command: "agent-browser", args: ["mcp", "--cdp", "9222"] }),
+	true,
+);
+assert.equal(isValidAgentBrowserMcpServer(browserMcpConfig({ cdpPort: 9222 })), true);
+// --cdp without a usable port is not a config we can reason about.
+assert.equal(
+	isValidAgentBrowserMcpServer({ command: "agent-browser", args: ["--cdp", "9222"] }),
+	false,
+);
+assert.equal(
+	isValidAgentBrowserMcpServer({ command: "agent-browser", args: ["--cdp", "mcp"] }),
+	false,
+);
+assert.equal(
+	isValidAgentBrowserMcpServer({ command: "agent-browser", args: ["--cdp", "0", "mcp"] }),
+	false,
+);
+assert.equal(
+	isValidAgentBrowserMcpServer({ command: "agent-browser", args: ["--cdp", "70000", "mcp"] }),
+	false,
+);
+assert.equal(isValidAgentBrowserMcpServer({ command: "agent-browser", args: [] }), false);
+assert.equal(
+	isValidAgentBrowserMcpServer({ command: "agent-browser", args: ["mcp"], lifecycle: 7 }),
+	false,
+);
+
+// Preflight needs the parsed target, not a second ad-hoc scan of args.
+assert.deepEqual(agentBrowserCdpTarget({ command: "agent-browser", args: ["mcp"] }), {
+	mode: "launch",
+	port: null,
+});
+assert.deepEqual(
+	agentBrowserCdpTarget({ command: "agent-browser", args: ["--cdp", "9222", "mcp"] }),
+	{ mode: "attach", port: 9222 },
+);
+assert.deepEqual(
+	agentBrowserCdpTarget({ command: "agent-browser", args: ["mcp", "--cdp", "9333"] }),
+	{ mode: "attach", port: 9333 },
+);
+// Same port twice is redundant but unambiguous; two different ports is not, and
+// guessing which one agent-browser honours is not our call.
+assert.deepEqual(
+	agentBrowserCdpTarget({
+		command: "agent-browser",
+		args: ["--cdp", "9222", "mcp", "--cdp", "9222"],
+	}),
+	{ mode: "attach", port: 9222 },
+);
+assert.deepEqual(
+	agentBrowserCdpTarget({
+		command: "agent-browser",
+		args: ["--cdp", "9222", "mcp", "--cdp", "9333"],
+	}),
+	{ mode: "ambiguous", port: null },
+);
+// A trailing --cdp with no port stays VALID (the old rule accepted it, and
+// re-classifying it would clobber a user's entry) but is not a target we will
+// probe — preflight reports it instead of guessing.
+assert.equal(
+	isValidAgentBrowserMcpServer({ command: "agent-browser", args: ["mcp", "--cdp"] }),
+	true,
+);
+assert.deepEqual(
+	agentBrowserCdpTarget({ command: "agent-browser", args: ["mcp", "--cdp"] }),
+	{ mode: "ambiguous", port: null },
+);
+assert.throws(() => agentBrowserCdpTarget({ command: "gh", args: ["mcp"] }), /agent-browser/);
+
+// A requested attach port must reach the merged config.
+{
+	const merged = mergeAgentBrowserMcpConfig({}, { cdpPort: 9222 });
+	assert.deepEqual(merged.mcpServers[AGENT_BROWSER_MCP_SERVER].args, [
+		"--cdp",
+		"9222",
+		"mcp",
+	]);
+}
+// ...but an entry the user already owns still wins, in either shape.
+for (const args of [["mcp", "--tools", "core"], ["--cdp", "9333", "mcp"]]) {
+	const existing = {
+		mcpServers: { [AGENT_BROWSER_MCP_SERVER]: { command: "agent-browser", args } },
+	};
+	assert.deepEqual(
+		mergeAgentBrowserMcpConfig(existing, { cdpPort: 9222 }),
+		existing,
+		`existing ${args.join(" ")} entry survives a --attach-cdp-port install`,
+	);
+}
+
+// --- CDP reachability probe -----------------------------------------------------
+//
+// A config entry only says which port to dial. Without this probe an unreachable
+// CDP endpoint surfaces as a failed browser call in the middle of a Peer turn
+// instead of as a host-readiness failure.
+{
+	const server = createServer((req, res) => {
+		if (req.url === "/json/version") {
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ Browser: "Chrome/141.0.0.0", "Protocol-Version": "1.3" }));
+			return;
+		}
+		res.writeHead(404).end("nope");
+	});
+	await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const { port } = server.address();
+
+	const reachable = await probeCdpEndpoint({ port, timeoutMs: 2000 });
+	assert.equal(reachable.ok, true);
+	assert.match(reachable.browser, /Chrome\/141/);
+
+	await new Promise((resolve) => server.close(resolve));
+
+	const unreachable = await probeCdpEndpoint({ port, timeoutMs: 500 });
+	assert.equal(unreachable.ok, false);
+	assert.ok(unreachable.error.length > 0, "an unreachable probe explains itself");
+}
+// Garbage on the port is not a CDP endpoint.
+{
+	const server = createServer((_req, res) => {
+		res.writeHead(200, { "Content-Type": "text/html" }).end("<html>hi</html>");
+	});
+	await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const { port } = server.address();
+	const probe = await probeCdpEndpoint({ port, timeoutMs: 2000 });
+	assert.equal(probe.ok, false);
+	await new Promise((resolve) => server.close(resolve));
+}
 
 console.log("[paseo-team] browser setup tests passed");


### PR DESCRIPTION
## Why

`agent-browser` can either launch its own browser or attach to one that is already running over the Chrome DevTools Protocol. Launch mode starts a browser with no cookies and no logged-in sessions, and that emptiness is what makes a per-turn `BROWSER_MCP_AUTHORITY` grant a meaningful bound: the worst a granted Peer can do is browse as a stranger.

Attach mode is genuinely useful — it is faster and reuses the profile's auth — but it inverts that property. A Peer holding the grant inherits **every session open in the target profile**, and `agent-browser` refuses `--allowed-domains` while CDP is in use, so per-domain restriction is off the table too. It belongs in the role pack, as an explicit choice rather than a default.

## What changed

**Attach mode is opt-in, with an explicit port.**

```bash
scripts/install.sh --attach-cdp-port 9222
node scripts/browser-setup.mjs --install --attach-cdp-port 9222
```

The default MCP entry is unchanged (`args: ["mcp"]`). With a port it becomes `["--cdp","9222","mcp"]` — `--cdp` is a global flag on `agent-browser`, before the subcommand. No env fallback and no bare-flag default: a setting this consequential has to be visible in the command that caused it. The installer prints what the choice implies.

**The no-clobber invariant is preserved, and now enforced by a test.** `isValidAgentBrowserMcpServer` decides whether the installer *overwrites* an entry, so every rejection is a clobber. It accepts both arg shapes, and a superset guard replays the pre-change rule over an arg/extra-field corpus and fails on any entry that lost validity. That guard caught a real regression during review (a `lifecycle` type check that would have silently replaced hand-edited entries) and is mutation-verified: reintroducing the check fails the guard.

**A request that cannot be honoured fails loudly.** Existing entries are never rewritten, which would otherwise make `--attach-cdp-port` a knob that silently does nothing on the second run. Re-running with a port that conflicts with the installed entry now errors and names the config file to edit. The rule lives in a pure `resolveExistingEntryDecision()` so it is covered without shelling out to npm/agent-browser.

**Preflight probes the target.** A config entry only names a port; without a probe, a dead CDP endpoint first appears as a failed browser call in the middle of a Peer turn.

- `agent-browser-cdp` — reports launch mode, or dials `/json/version` and fails when nothing answers. Ambiguous `--cdp` flags fail rather than being guessed at.
- `agent-browser-cdp-exposure` — warns when the same port also answers on a non-loopback address (IPv4 or IPv6). A browser started with `--remote-debugging-address=0.0.0.0` or `[::]` is unauthenticated remote control of that profile for anyone on the network.

## Verification

`npm run check` green (13/13 test files + typecheck). Beyond unit tests, each path was exercised for real:

| Path | Observed |
|---|---|
| Default install | `args: ["mcp"]`, `launch mode, isolated browser` |
| `--attach-cdp-port 9333` | `args: ["--cdp","9333","mcp"]` + profile warning |
| `--attach-cdp-port 70000` | `CDP port must be an integer 1-65535` |
| Conflicting re-run | errors, names the config file, leaves it untouched |
| Preflight, endpoint up | `pass — attached to 127.0.0.1:9333 (Chrome/141.0.7390.54)` |
| Preflight, endpoint down | `fail — nothing answers CDP on 127.0.0.1:9333` |
| Listener on `0.0.0.0` | `warn — also answers on 100.97.6.20, 172.24.144.1, 192.168.1.17` |
| Listener on `::` | `warn — also answers on fd7a:115c:a1e0::7601:6ae, …` |
| Duplicate `--cdp` ports | `fail — ambiguous --cdp flags` |
| `install.sh --nope` | exit 1 before anything is copied |

Reviewed with the repo's own OCR delegation harness (`scripts/ocr-review.mjs`, OCR 1.9.5) in a linked worktree at the exact candidate SHA — 5/5 reviewable files, 100% coverage, clean entry/exit. Four findings were raised against the first commit and all four are fixed in the two follow-ups; the review is what produced the superset guard.

## Risk

`preflight.mjs` now uses top-level await, so module evaluation is async. Nothing depends on synchronous ordering and `process.exit` still runs last, but it changes the shape of a previously fully-synchronous file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
