### PR TITLE
feat(cli): paseo-team CLI + WebUI extension (CLI-as-truth, pteam alias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ paseo-pi-team/
 │   ├── architect-task.md           # solution-architect brief (read-only)
 │   ├── scout-task.md               # repository-scout brief (read-only)
 │   └── supervisor-observation.md   # observation template
+├── cli/
+│   ├── paseo-team.mjs              # the CLI: every config read/write and every daemon query
+│   └── lib/
+│       ├── config-walker.mjs       # path resolution + atomic write with backup
+│       ├── paseo-bridge.mjs        # the only place that spawns `paseo` (argv, timeouts, fan-out)
+│       ├── graph-cache.mjs         # spawn-tree cache; `paseo ls` has no parent link, `inspect` does
+│       └── graph.mjs               # agents + parents + permits -> nodes/edges/degraded
+├── webui/
+│   ├── server.mjs                  # transport only: route -> paseo-team argv, token, localhost
+│   └── public/                     # zero-dependency SPA (index.html / app.js / style.css)
 ├── scripts/
 │   ├── install.ps1 / install.sh    # installers
 │   ├── lib-common.mjs              # shared helpers: exec/shim resolution, entrypoint, versions
@@ -72,12 +82,17 @@ paseo-pi-team/
 │   ├── browser-setup.test.mjs      # MCP config merge + skill install
 │   ├── installer-contract.test.mjs # shipped files must exist and carry their dependencies
 │   ├── paseo-contract.test.mjs     # Paseo JSON field contract (needs a live daemon — see below)
+│   ├── paseo-bridge.test.mjs       # argv validation, error codes, bounded concurrency
+│   ├── graph.test.mjs              # role inference, PEER_MESSAGE_V1 parse, graph assembly, cache
+│   ├── cli-contract.test.mjs       # the CLI end to end against a fake paseo + throwaway HOME
+│   ├── webui-server.test.mjs       # route allowlist, token, host check, cache, CLI failures
 │   └── fixtures/                   # fake CLIs (paseo, ocr) + version-pinned OCR output
 └── docs/
     ├── demonthorn-agent-orchestration-deep-dive.md   # original design
     ├── model-routing.md            # the 4 model-routing layers, verified commands
     ├── multi-host.md               # N-host routing + cross-host test plan
-    └── ocr-integration.md          # OpenCodeReview Phase 1 single-machine setup
+    ├── ocr-integration.md          # OpenCodeReview Phase 1 single-machine setup
+    └── webui-architecture.md       # CLI <-> WebUI contract, graph schema, measured costs
 ```
 
 ## Roles
@@ -432,6 +447,71 @@ cluster contract), each route against the real inventory, provider status, empty
 model segments, pi's per-model `thinkingLevelMap` (a `null` level means the
 level gets clamped), endpoint env vars, and repository state (a writer host must
 be clean in strict mode). No secret is ever printed.
+
+## CLI and WebUI
+
+`pteam` (long alias: `paseo-team`) is the pack's CLI and the single writer for
+everything the pack configures. The WebUI is an extension of that CLI, not an application beside
+it: it maps an HTTP route onto a fixed `pteam` argv, spawns it, and renders
+the JSON. It never touches a file and never calls `paseo` itself, so anything
+you see in the browser can be reproduced in a terminal — the UI prints the exact
+command behind every panel.
+
+### Run it straight from GitHub (no clone)
+
+The package has zero runtime dependencies, so npm can fetch and run it directly
+from the repository:
+
+```bash
+# try it once, nothing installed
+npx --package github:Minnyat/paseo-pi-team pteam status
+
+# or install it globally — puts both `pteam` and `paseo-team` on your PATH
+npm install -g github:Minnyat/paseo-pi-team
+pteam web --open
+```
+
+Requires Node >= 22.18. The repository is private, so the machine needs GitHub
+git credentials for the fetch (an SSH key, or `gh auth login` if git uses the
+`gh` credential helper).
+
+### From a checkout
+
+```bash
+node cli/paseo-team.mjs --help          # or `npm link` once, then `pteam`
+pteam status                            # paths + presence, machine readable
+pteam graph                             # agents, spawn tree, pending permits
+pteam permits list
+pteam web --port 4321 --open            # prints http://127.0.0.1:PORT/#token=...
+```
+
+The web server binds `127.0.0.1`, requires a per-run bearer token (handed to the
+page through the URL fragment so it never reaches a server log), and checks
+`Origin`/`Host` against DNS rebinding. `--no-token` exists for a throwaway demo
+and says so loudly: this UI can approve permission requests.
+
+Two different things are called "permission", and the UI keeps them apart:
+
+- **Runtime permit** — one tool call is blocked right now and a human has to
+  answer: `paseo-team permits list|allow|deny`, delegating to `paseo permit`.
+  Every decision is appended to `~/.paseo-pi-team/permit-audit.jsonl` *before*
+  the daemon is asked, so a decision that was made stays visible even if the
+  delegate call then fails.
+- **Policy authority** — what a role may do at all: the allowlists in
+  `extensions/paseo-team-policy.ts`, `PASEO_TEAM_LEAD_WRITE`,
+  `PASEO_TEAM_EXTRA_TOOLS`, and the V3 brief authority fields. The UI shows this
+  read-only; there is no "grant everything" button.
+
+Cost note, because it shapes the whole design: every `paseo` invocation costs
+~3s of process startup on Windows regardless of the query. `paseo-team graph`
+therefore batches a whole snapshot per call, caches the spawn tree in
+`~/.paseo-pi-team/graph-cache.json` (`paseo ls` does not carry the parent link —
+only `inspect` does), and spends at most `--max-inspect` lookups per run. A cold
+cache fills over a few polls; a warm one answers in ~3.8s. Anything that could
+not be collected is reported in `degraded[]` rather than quietly missing.
+
+See `docs/webui-architecture.md` for the full contract, the graph schema, and
+what is still missing (agent-to-agent message edges, multi-host).
 
 ## Debug commands
 

--- a/TASK_STATE.md
+++ b/TASK_STATE.md
@@ -1,0 +1,44 @@
+# Task: Build paseo-pi-team thành CLI + WebUI extension (WebUI chỉ gọi qua CLI)
+
+## Original request (verbatim)
+> repo paseo-pi-team sẽ build thành dạng cli. và webui như phần mở rộng được cài thêm cho cli đó để thao tác qua web còn mọi thứ vẫn call qua cli
+
+(cảnh trước: thiết kế web-ui để cấu hình role prompts, mcp, skill. User chốt pattern CLI-as-truth + WebUI-extension only-talking-to-CLI.)
+
+## Success criteria (observable)
+- [x] Có `bin/` trong `package.json`, chạy được `paseo-team <subcommand> --json`.
+- [x] CLI là "nguồn sự thật": mọi đọc/ghi config (providers, routing, cluster, mcp, prompts, skills, env) đều qua CLI, trả JSON.
+- [x] CLI wrap được `scripts/preflight.mjs --json` (tái sử dụng, không copy logic).
+- [x] WebUI extension: local server + SPA; KHÔNG đụng file trực tiếp — mọi request proxy sang spawn `paseo-team ...` và render JSON.
+- [x] Smoke-test chạy được: `paseo-team --help`, `status`, `config read`, `prompts read` với HOME tạm.
+- [x] Các test có sẵn `npm test` vẫn xanh (không phá vỡ hiện trạng).
+- [x] Có `docs/webui-architecture.md` mô tả contract CLI ↔ WebUI.
+
+## Constraints & decisions
+- Zero external runtime deps cho cả CLI và webui server (chỉ `node:*`) để portability cao, repo vốn private + devDeps sẵn.
+- READ back từ file hiện có; config WRITE qua stdin full-JSON → CLI tự backup + ghi atomic (không regex-patch).
+- PHP/Node >= 22.18 theo `engines`.
+- CLI delegate các script có sẵn (`preflight.mjs`, `install`, `ocr-*`) thay vì viết lại.
+- Không đổi hành vi/API hiện có của `scripts/*` và các test. Chỉ thêm lớp CLI + webui.
+
+## Plan
+- [x] Step 1: anchor (TASK_STATE.md) + đọc phần còn lại (config-walker paths, mcp/prompts structure).
+- [x] Step 2: `cli/lib/config-walker.mjs` — resolve đường dẫn (~/.pi, ~/.paseo, ~/.paseo-pi-team) + backup + atomic write + JSON validate.
+- [x] Step 3: `cli/paseo-team.mjs` — router subcommand: help/status/preflight/config read|write/prompts read|write/skills list|read|write/env list|set/install. Mọi output `--json`.
+- [x] Step 4: `bin` trong `package.json` + `scripts.web`.
+- [x] Step 5: `webui/server.mjs` (zero-dep http) spawn CLI → REST proxy; `webui/public/` SPA (index.html/app.js/style.css).
+- [x] Step 6: `docs/webui-architecture.md` — contract CLI↔WebUI, diagram, JSON schemas.
+- [x] Step 7: smoke-test (--help, status, config read, prompts read, SPA tải) + `npm test` vẫn xanh + self-review.
+
+## Open questions / risks
+- Phạm vi "cấu hình skills" có cần copy ngược về repo (git diff) hay chỉ sửa local? → MVP: sửa local file ~/.pi; ghi ngược về repo là follow-up.
+- Việc helper mcp.json / models.json merge có nên trong CLI? → MVP: đọc/ghi qua `config`; merge phức tạp (browser-setup; --attach-cdp-port) giao script có sẵn, webui nuôi qua `install --attach-cdp-port`.
+
+## Log
+- (bắt đầu) anchor; đã khảo sát scripts/preflight, model-routing, browser-setup, ocr-review, remote-paseo + package.json (chưa có bin), prompts/*.md, skills/SKILL.md, config/*.example.json, installer destinations (~/.pi/agent/extensions, /prompts, /skills, /mcp.json).
+- (2026-08-21) Probe live Paseo CLI 0.3.0: xác nhận bề mặt `ls/inspect/permit/chat/logs/attach`; `inspect` có `ParentAgentId` + `PendingPermissions`. Tái hiện lỗi `paseo logs` timeout (`get_state`) với agent idle nguội -> timeline là dữ liệu có thể vắng, phải degrade chứ không crash.
+- (2026-08-21) Mở rộng scope theo yêu cầu mới: thêm mặt phẳng **permission** (runtime permit vs policy authority) và **team graph** (trực quan hoá agent liên lạc). Viết `docs/webui-architecture.md` (contract CLI↔WebUI + schema graph + lộ trình PR-1..PR-5). Bước 6 xong; còn Bước 5 (webui server+SPA) và Bước 7 (smoke-test).
+- (2026-08-21) MVP xong (PR-1 + PR-2 gộp). Thêm `cli/lib/paseo-bridge.mjs`, `cli/lib/graph-cache.mjs`, `cli/lib/graph.mjs`; CLI thêm `agents`/`agent inspect|send`/`permits`/`chat`/`graph`/`watchdog`/`web`; `webui/server.mjs` + SPA 6 tab (Dashboard, Team graph, Permissions, Roles, Config, Chat). 4 test file mới; `npm test` 17/17 xanh, typecheck sạch. Verify thật: daemon local 21 agent, 7 cạnh spawn, đã render trong Chrome.
+- (2026-08-21) Đo chi phí thật: mỗi lệnh `paseo` ~3.0-3.5s (chi phí khởi động tiến trình, không phải query); `graph` lạnh ~12s, ấm ~3.8s; `preflight` ~25-30s (phải cho timeout riêng 180s, đã tái hiện timeout ở trình duyệt khi dùng chung 60s). Vì `paseo ls` không trả parent, cây spawn phải cache (`~/.paseo-pi-team/graph-cache.json`, TTL 15', tối đa `--max-inspect` lần inspect mỗi lượt).
+- (2026-08-21) Còn lại: cạnh **message** giữa agent (`graph --with-logs`, parse `PEER_MESSAGE_V1` từ timeline Lead) và multi-host — xem PR-4/PR-5 trong docs/webui-architecture.md.
+- (2026-08-22) Đặt tên ngắn cho CLI: thêm bin `pteam` (giữ alias `paseo-team`, cả hai trỏ `cli/paseo-team.mjs`; webui vẫn spawn theo path nên không phụ thuộc tên). Help text chuyển sang tiền tố `pteam`. README thêm mục "Run it straight from GitHub (no clone)": `npx --package github:Minnyat/paseo-pi-team pteam ...` / `npm i -g github:Minnyat/paseo-pi-team`. Lưu ý: lệnh GitHub chỉ thấy thay đổi sau khi commit + push.

--- a/cli/lib/config-walker.mjs
+++ b/cli/lib/config-walker.mjs
@@ -1,0 +1,134 @@
+/**
+ * config-walker.mjs — "source of truth" for every path a role-pack config can
+ * touch. Shared by the CLI (`paseo-team`) and only invoked by scripts that own
+ * a real operation (read/write). The WebUI never imports this: it always goes
+ * through `paseo-team` subcommands, which reach file I/O here and nowhere else.
+ *
+ * Path resolution honors the same env overrides the installers use, so tests
+ * and the WebUI can point at a throwaway HOME:
+ *   PI_HOME               -> default ~/.pi
+ *   PI_CODING_AGENT_DIR   -> default $PI_HOME/agent
+ *   PST_TEAM_CONFIG_DIR   -> default ~/.paseo-pi-team
+ *   PASEO_CONFIG_JSON     -> default ~/.paseo/config.json
+ */
+
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+import {
+	mkdirSync,
+	writeFileSync,
+	renameSync,
+	copyFileSync,
+	existsSync,
+	readFileSync,
+} from "node:fs";
+
+export function piHome() {
+	return process.env.PI_HOME || join(homedir(), ".pi");
+}
+
+export function agentDir() {
+	return process.env.PI_CODING_AGENT_DIR || join(piHome(), "agent");
+}
+
+export function teamConfigDir() {
+	return process.env.PST_TEAM_CONFIG_DIR || join(homedir(), ".paseo-pi-team");
+}
+
+export function paseoConfigPath() {
+	return process.env.PASEO_CONFIG_JSON || join(homedir(), ".paseo", "config.json");
+}
+
+export function mcpConfigPath() {
+	return join(agentDir(), "mcp.json");
+}
+
+export function promptsDir() {
+	return join(agentDir(), "extensions", "prompts");
+}
+
+export function skillsDir() {
+	return join(agentDir(), "skills");
+}
+
+export function extensionsDir() {
+	return join(agentDir(), "extensions");
+}
+
+export function policyExtensionPath() {
+	return join(extensionsDir(), "paseo-team-policy.ts");
+}
+
+/**
+ * Well-known role prompts this pack ships/installs.
+ */
+export const ROLE_PROMPTS = ["supervisor", "lead", "peer"];
+
+export function rolePromptPath(role) {
+	if (!ROLE_PROMPTS.includes(role)) {
+		throw new Error(`unknown role prompt '${role}' (expected one of: ${ROLE_PROMPTS.join(", ")})`);
+	}
+	return join(promptsDir(), `${role}.md`);
+}
+
+/**
+ * Well-known skip/first-class skills installed by the pack. Anything else in
+ * skillsDir() is still listable by generic name.
+ */
+export const PACK_SKILLS = ["paseo-team-lead", "paseo-ocr-reviewer", "agent-browser"];
+
+export function skillDirPath(name) {
+	return join(skillsDir(), name);
+}
+
+export function skillPromptPath(name) {
+	return join(skillsDir(), name, "SKILL.md");
+}
+
+/**
+ * Escape any name so it cannot traverse into an arbitrary path.
+ */
+export function safeName(name) {
+	if (typeof name !== "string" || name.length === 0 || /[\\/]|\.\./.test(name)) {
+		throw new Error(`unsafe name: '${name}'`);
+	}
+	return name;
+}
+
+/**
+ * Atomic write with a timestamped backup. Never leaves a half-written file:
+ * write to a temp sibling then rename over the destination. If the destination
+ * already exists we first copy it to <name>.bak-<ts>.
+ */
+export function atomicWriteJson(absPath, data) {
+	const parsed = JSON.parse(data); // throws early on invalid JSON
+	atomicWrite(absPath, JSON.stringify(parsed, null, 2) + "\n");
+	return parsed;
+}
+
+export function atomicWrite(absPath, content) {
+	ensureDir(dirname(absPath));
+	if (existsSync(absPath)) {
+		copyFileSync(absPath, `${absPath}.bak-${Date.now()}`);
+	}
+	const tmp = `${absPath}.tmp-${process.pid}-${Date.now()}`;
+	writeFileSync(tmp, content, "utf8");
+	renameSync(tmp, absPath);
+}
+
+export function ensureDir(dir) {
+	mkdirSync(dir, { recursive: true });
+}
+
+export function readJsonOrNull(absPath) {
+	if (!existsSync(absPath)) return null;
+	try {
+		return JSON.parse(readText(absPath));
+	} catch {
+		return null;
+	}
+}
+
+export function readText(absPath) {
+	return readFileSync(absPath, "utf8");
+}

--- a/cli/lib/graph-cache.mjs
+++ b/cli/lib/graph-cache.mjs
@@ -1,0 +1,93 @@
+/**
+ * graph-cache.mjs — parent-link cache for the team graph.
+ *
+ * Why a cache exists at all: `paseo ls` does NOT carry the parent link, only
+ * `paseo inspect <id>` does, and every paseo invocation costs ~3s (see
+ * paseo-bridge.mjs). Rebuilding the supervisor -> lead -> peer tree from
+ * scratch would mean N x 3s per refresh — 21 live agents on the reference
+ * machine is over a minute of wall clock for a graph that barely changes.
+ *
+ * The parent link is *nearly* immutable: it is assigned at spawn time and only
+ * `paseo agent detach` can clear it. So entries are cached with a timestamp
+ * and a TTL rather than forever — a detached agent heals on its own within one
+ * TTL instead of showing a phantom edge until someone clears the cache by hand.
+ *
+ * Stored in the controller-local team config dir, never in the repo.
+ */
+
+import { join } from "node:path";
+import { existsSync, unlinkSync } from "node:fs";
+import * as cw from "./config-walker.mjs";
+
+export const CACHE_VERSION = 1;
+export const DEFAULT_PARENT_TTL_MS = 15 * 60_000;
+
+export function graphCachePath() {
+	return join(cw.teamConfigDir(), "graph-cache.json");
+}
+
+function emptyCache() {
+	return { version: CACHE_VERSION, parents: {} };
+}
+
+/**
+ * A corrupt or foreign-version cache is discarded, not repaired: it is
+ * derived data, and guessing at a half-written shape is how stale edges get
+ * drawn as facts.
+ */
+export function readParentCache(path = graphCachePath()) {
+	const raw = cw.readJsonOrNull(path);
+	if (!raw || raw.version !== CACHE_VERSION || typeof raw.parents !== "object" || raw.parents === null) {
+		return emptyCache();
+	}
+	const parents = {};
+	for (const [id, entry] of Object.entries(raw.parents)) {
+		if (!entry || typeof entry !== "object") continue;
+		const parentId = entry.parentId === null || typeof entry.parentId === "string" ? entry.parentId : undefined;
+		const checkedAt = typeof entry.checkedAt === "number" ? entry.checkedAt : undefined;
+		if (parentId === undefined || checkedAt === undefined) continue;
+		parents[id] = { parentId, checkedAt };
+	}
+	return { version: CACHE_VERSION, parents };
+}
+
+export function writeParentCache(cache, path = graphCachePath()) {
+	cw.atomicWrite(path, JSON.stringify({ version: CACHE_VERSION, parents: cache.parents ?? {} }, null, 2) + "\n");
+	return path;
+}
+
+export function clearParentCache(path = graphCachePath()) {
+	if (existsSync(path)) unlinkSync(path);
+	return path;
+}
+
+/** Entries older than the TTL are re-inspected; unknown ids always are. */
+export function isFresh(entry, { now = Date.now(), ttlMs = DEFAULT_PARENT_TTL_MS } = {}) {
+	if (!entry || typeof entry.checkedAt !== "number") return false;
+	return now - entry.checkedAt < Math.max(0, ttlMs);
+}
+
+/**
+ * Ids that still need a `paseo inspect`, oldest-first so a cold cache fills
+ * deterministically across successive polls instead of re-picking at random.
+ */
+export function staleIds(ids, cache, options = {}) {
+	return ids
+		.filter((id) => !isFresh(cache.parents?.[id], options))
+		.sort((a, b) => (cache.parents?.[a]?.checkedAt ?? 0) - (cache.parents?.[b]?.checkedAt ?? 0));
+}
+
+export function rememberParent(cache, id, parentId, now = Date.now()) {
+	cache.parents ??= {};
+	cache.parents[id] = { parentId: parentId ?? null, checkedAt: now };
+	return cache;
+}
+
+/** Drop ids the daemon no longer lists, so the file cannot grow forever. */
+export function pruneCache(cache, liveIds) {
+	const live = new Set(liveIds);
+	for (const id of Object.keys(cache.parents ?? {})) {
+		if (!live.has(id)) delete cache.parents[id];
+	}
+	return cache;
+}

--- a/cli/lib/graph.mjs
+++ b/cli/lib/graph.mjs
@@ -1,0 +1,322 @@
+/**
+ * graph.mjs — turns Paseo's flat agent list into the team graph the WebUI draws.
+ *
+ * Everything above `collectGraph` is pure and fixture-testable on purpose: the
+ * expensive, flaky part (spawning paseo) is one thin function, and the part
+ * that decides what an operator sees is not allowed to need a daemon to test.
+ *
+ * What Paseo gives us, and what it does not:
+ *   - nodes            <- `paseo ls -g --json`
+ *   - spawn edges      <- `paseo inspect <id>`.ParentAgentId  (one call each)
+ *   - pending permits  <- `paseo permit ls --json`            (one call total)
+ *   - message edges    <- NOT queryable. `send` is fire-and-forget.
+ *
+ * Message edges are therefore *reconstructed*, and every reconstruction path
+ * carries a confidence. The reliable one is Peer -> Lead: every such message
+ * already travels as a PEER_MESSAGE_V1 block built by
+ * scripts/team-communication.mjs, so its header parses back into a real edge.
+ * Lead -> Peer can only be inferred from tool-call logs and is marked
+ * "suspected"; a graph that draws a guess with the same weight as a fact is
+ * worse than a graph that admits it does not know.
+ */
+
+import { MESSAGE_KINDS } from "../../scripts/team-communication.mjs";
+import { runPaseoJson, mapWithConcurrency, PaseoError } from "./paseo-bridge.mjs";
+import * as cache from "./graph-cache.mjs";
+
+export const ROLES = Object.freeze(["supervisor", "lead", "peer"]);
+
+/** Default number of `paseo inspect` calls a single snapshot may spend. */
+export const DEFAULT_MAX_INSPECT = 6;
+
+/**
+ * "pi-supervisor/Minnyat/deepseek-v4-flash" (ls) and "pi-supervisor"
+ * (inspect) must map to the same role, so only the first path segment counts.
+ * Anything unrecognized returns null — an unknown provider is displayed as
+ * unknown, never bucketed into a role it might not have.
+ */
+export function inferRole(provider) {
+	if (typeof provider !== "string") return null;
+	const head = provider.split("/")[0].trim().toLowerCase();
+	const bare = head.startsWith("pi-") ? head.slice(3) : head;
+	return ROLES.includes(bare) ? bare : null;
+}
+
+const PEER_MESSAGE_HEADER = "PEER_MESSAGE_V1";
+const HEADER_LINE = /^([A-Z_]+):\s*(.+)$/;
+
+/**
+ * Parse a PEER_MESSAGE_V1 block out of arbitrary agent text.
+ *
+ * Fail-closed: a block missing any field, or carrying a kind outside
+ * MESSAGE_KINDS, yields null rather than a half-populated edge. The header is
+ * produced by our own sender, so a malformed one means either a version skew
+ * or text that merely quotes the marker — neither should become an edge.
+ */
+export function parsePeerMessage(text) {
+	if (typeof text !== "string") return null;
+	const start = text.indexOf(PEER_MESSAGE_HEADER);
+	if (start < 0) return null;
+	const lines = text.slice(start).split(/\r?\n/).slice(1);
+	const fields = {};
+	for (const line of lines) {
+		if (line.trim() === "") break;
+		const match = HEADER_LINE.exec(line.trim());
+		if (!match) break;
+		fields[match[1]] = match[2].trim();
+	}
+	const kind = fields.KIND;
+	const fromAgentId = fields.FROM_AGENT_ID;
+	if (!MESSAGE_KINDS.includes(kind)) return null;
+	if (!fromAgentId || !fields.CORRELATION_ID || !fields.TASK_ID) return null;
+	return {
+		kind,
+		fromAgentId,
+		correlationId: fields.CORRELATION_ID,
+		taskId: fields.TASK_ID,
+	};
+}
+
+const PERMIT_AGENT_KEYS = ["agentId", "AgentId", "agent_id", "agent", "AgentID"];
+const PERMIT_REQUEST_KEYS = ["requestId", "RequestId", "request_id", "reqId", "ReqId", "id", "Id"];
+const PERMIT_TOOL_KEYS = ["tool", "Tool", "toolName", "ToolName", "name", "Name"];
+
+function firstString(entry, keys) {
+	for (const key of keys) {
+		const value = entry?.[key];
+		if (typeof value === "string" && value.trim() !== "") return value.trim();
+	}
+	return null;
+}
+
+/**
+ * Normalize one `paseo permit ls` row.
+ *
+ * The pending list was empty on every machine available while this was
+ * written, so the field names are matched permissively across the casings
+ * Paseo uses elsewhere. A row we cannot pin to (agent, request) is NOT
+ * dropped: it is returned unclassified so the inbox can still show it —
+ * with allow/deny disabled, because approving a request you cannot name is
+ * exactly the mistake this UI must not enable.
+ */
+export function normalizePermit(entry) {
+	if (!entry || typeof entry !== "object") return { ok: false, raw: entry };
+	const agentId = firstString(entry, PERMIT_AGENT_KEYS);
+	const requestId = firstString(entry, PERMIT_REQUEST_KEYS);
+	if (!agentId || !requestId) return { ok: false, raw: entry };
+	return {
+		ok: true,
+		agentId,
+		requestId,
+		tool: firstString(entry, PERMIT_TOOL_KEYS),
+		raw: entry,
+	};
+}
+
+export function normalizePermits(list) {
+	const rows = Array.isArray(list) ? list : [];
+	const permits = [];
+	const unclassified = [];
+	for (const row of rows) {
+		const normalized = normalizePermit(row);
+		if (normalized.ok) permits.push(normalized);
+		else unclassified.push(normalized.raw);
+	}
+	return { permits, unclassified };
+}
+
+/**
+ * Assemble the snapshot. Pure: same inputs, same output, no clock of its own.
+ *
+ * @param {object} input
+ * @param {Array}  input.agents      rows from `paseo ls -g --json`
+ * @param {object} input.parents     { [agentId]: parentId|null } — the known subset
+ * @param {Array}  input.permits     rows from `paseo permit ls --json`
+ * @param {Array}  [input.messages]  reconstructed message edges
+ * @param {Array}  [input.degraded]  collection faults to surface verbatim
+ * @param {number} input.now
+ */
+export function buildGraph({ agents = [], parents = {}, permits = [], messages = [], degraded = [], now = 0 } = {}) {
+	const rows = Array.isArray(agents) ? agents.filter((a) => a && typeof a.id === "string") : [];
+	const known = new Set(rows.map((a) => a.id));
+	const { permits: normalizedPermits, unclassified } = normalizePermits(permits);
+
+	const permitCount = new Map();
+	for (const permit of normalizedPermits) {
+		permitCount.set(permit.agentId, (permitCount.get(permit.agentId) ?? 0) + 1);
+	}
+
+	const faults = [...degraded];
+	if (unclassified.length > 0) {
+		faults.push({
+			reason: "PERMIT_SHAPE_UNRECOGNIZED",
+			detail: `${unclassified.length} pending permit row(s) had no recognizable agent/request id`,
+		});
+	}
+
+	const nodes = rows.map((agent) => {
+		const hasParentInfo = Object.hasOwn(parents, agent.id);
+		const parentId = hasParentInfo ? parents[agent.id] : null;
+		// An agent whose parent exists but is not in the listing (archived, or
+		// living in a directory this listing did not cover) must not be drawn
+		// as a root: that would silently flatten the tree.
+		const orphan = Boolean(parentId) && !known.has(parentId);
+		if (orphan) {
+			faults.push({ agentId: agent.id, reason: "PARENT_NOT_LISTED", detail: parentId });
+		}
+		return {
+			id: agent.id,
+			shortId: typeof agent.shortId === "string" ? agent.shortId : agent.id.slice(0, 7),
+			name: typeof agent.name === "string" ? agent.name : "",
+			role: inferRole(agent.provider),
+			provider: typeof agent.provider === "string" ? agent.provider : null,
+			thinking: typeof agent.thinking === "string" ? agent.thinking : null,
+			status: typeof agent.status === "string" ? agent.status : "unknown",
+			cwd: typeof agent.cwd === "string" ? agent.cwd : null,
+			created: typeof agent.created === "string" ? agent.created : null,
+			parentId: hasParentInfo ? parentId : null,
+			parentKnown: hasParentInfo,
+			orphan,
+			pendingPermissions: permitCount.get(agent.id) ?? 0,
+		};
+	});
+
+	const edges = [];
+	for (const node of nodes) {
+		if (node.parentId && known.has(node.parentId)) {
+			edges.push({ type: "spawn", from: node.parentId, to: node.id, confidence: "confirmed" });
+		}
+	}
+	// Message edges are keyed by correlationId: the same PEER_MESSAGE_V1 block
+	// can be seen twice (sender log and recipient prompt) and must draw once.
+	const seen = new Set();
+	for (const message of messages) {
+		if (!message || typeof message.from !== "string" || typeof message.to !== "string") continue;
+		const key = message.correlationId ?? `${message.from}->${message.to}:${message.ts ?? ""}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		edges.push({
+			type: "message",
+			from: message.from,
+			to: message.to,
+			kind: message.kind ?? null,
+			taskId: message.taskId ?? null,
+			correlationId: message.correlationId ?? null,
+			ts: message.ts ?? null,
+			confidence: message.confidence ?? "suspected",
+		});
+	}
+
+	const byRole = {};
+	const byStatus = {};
+	for (const node of nodes) {
+		const role = node.role ?? "unknown";
+		byRole[role] = (byRole[role] ?? 0) + 1;
+		byStatus[node.status] = (byStatus[node.status] ?? 0) + 1;
+	}
+
+	return {
+		collectedAt: new Date(now).toISOString(),
+		counts: {
+			agents: nodes.length,
+			edges: edges.length,
+			pendingPermissions: normalizedPermits.length + unclassified.length,
+			byRole,
+			byStatus,
+		},
+		nodes,
+		edges,
+		permits: normalizedPermits.map(({ ok, raw, ...rest }) => ({ ...rest, raw })),
+		unclassifiedPermits: unclassified,
+		degraded: faults,
+	};
+}
+
+/**
+ * Collect one snapshot.
+ *
+ * Cost model (see paseo-bridge.mjs): `ls` and `permit ls` are issued
+ * concurrently — one ~3s round trip for both — and at most `maxInspect`
+ * parent lookups are spent per call, filling the cache across successive
+ * polls instead of blocking a minute on a cold start. `pendingParents` tells
+ * the UI the tree is still being drawn rather than letting it look complete.
+ */
+export async function collectGraph(options = {}) {
+	const now = options.now ?? Date.now();
+	const maxInspect = Math.max(0, Math.floor(options.maxInspect ?? DEFAULT_MAX_INSPECT));
+	const run = options.runPaseoJson ?? runPaseoJson;
+	const timeoutMs = options.timeoutMs;
+	const listArgs = options.all ? ["ls", "-g", "-a"] : ["ls", "-g"];
+	const degraded = [];
+
+	const [listed, permitted] = await Promise.all([
+		run(listArgs, { timeoutMs }).catch((error) => error),
+		run(["permit", "ls"], { timeoutMs }).catch((error) => error),
+	]);
+
+	if (listed instanceof Error) {
+		// No agent list means no graph at all. Report the fault as data instead
+		// of throwing: the WebUI must still render a page that explains itself.
+		return {
+			...buildGraph({ now }),
+			ok: false,
+			degraded: [{ reason: listed.code ?? "LIST_FAILED", detail: String(listed.message ?? listed) }],
+		};
+	}
+	const agents = Array.isArray(listed) ? listed : [];
+	let permits = [];
+	if (permitted instanceof Error) {
+		degraded.push({ reason: permitted.code ?? "PERMIT_LIST_FAILED", detail: String(permitted.message ?? permitted) });
+	} else if (Array.isArray(permitted)) {
+		permits = permitted;
+	} else {
+		degraded.push({ reason: "PERMIT_SHAPE_UNRECOGNIZED", detail: "permit ls did not return an array" });
+	}
+
+	const store = options.cache ?? cache.readParentCache();
+	const ids = agents.map((agent) => agent.id).filter((id) => typeof id === "string");
+	const stale = cache.staleIds(ids, store, { now, ttlMs: options.parentTtlMs });
+	const budget = stale.slice(0, maxInspect);
+
+	const inspected = await mapWithConcurrency(budget, options.concurrency ?? 4, (id) =>
+		run(["inspect", id], { timeoutMs }),
+	);
+	inspected.forEach((result, index) => {
+		const id = budget[index];
+		if (result.ok) {
+			const detail = result.value ?? {};
+			cache.rememberParent(store, id, detail.ParentAgentId ?? detail.parentAgentId ?? null, now);
+		} else {
+			degraded.push({
+				agentId: id,
+				reason: result.error?.code ?? "INSPECT_FAILED",
+				detail: String(result.error?.message ?? result.error),
+			});
+		}
+	});
+
+	cache.pruneCache(store, ids);
+	if (options.persistCache !== false) {
+		try {
+			cache.writeParentCache(store);
+		} catch (error) {
+			degraded.push({ reason: "CACHE_WRITE_FAILED", detail: String(error?.message ?? error) });
+		}
+	}
+
+	const parents = {};
+	for (const id of ids) {
+		const entry = store.parents?.[id];
+		if (entry) parents[id] = entry.parentId;
+	}
+
+	const graph = buildGraph({ agents, parents, permits, degraded, now });
+	return {
+		...graph,
+		ok: true,
+		pendingParents: Math.max(0, stale.length - budget.length),
+		inspectSpent: budget.length,
+	};
+}
+
+export { PaseoError };

--- a/cli/lib/paseo-bridge.mjs
+++ b/cli/lib/paseo-bridge.mjs
@@ -1,0 +1,138 @@
+/**
+ * paseo-bridge.mjs — the only place the `paseo-team` CLI talks to the Paseo CLI.
+ *
+ * Layering: WebUI -> paseo-team (this file) -> paseo. The WebUI never spawns
+ * `paseo` itself, so every daemon call is funnelled through one argv builder
+ * with one timeout policy and one error vocabulary.
+ *
+ * Measured on the reference machine (Windows, paseo 0.3.0): a *single* paseo
+ * invocation costs ~3.0-3.5s wall, and `paseo --version` alone costs ~2.7s.
+ * The cost is process/bundle startup, not the daemon query — spawning the
+ * dist entry directly instead of the .cmd shim does not help. Two consequences
+ * shape everything above this file:
+ *   1. Never issue one call per widget. Batch a whole snapshot per command.
+ *   2. Cache anything immutable (see graph-cache.mjs) instead of re-asking.
+ */
+
+import { execFile } from "node:child_process";
+import { resolvePaseoExec } from "../../scripts/lib-common.mjs";
+
+/** Generous because a cold paseo start alone eats ~3s of it. */
+export const DEFAULT_COMMAND_TIMEOUT_MS = 20_000;
+
+export class PaseoError extends Error {
+	constructor(code, message, details = undefined) {
+		super(message);
+		this.name = "PaseoError";
+		this.code = code;
+		if (details !== undefined) this.details = details;
+	}
+}
+
+/**
+ * Resolve `[bin, ...prefixArgs]`, mapping a malformed
+ * PASEO_TEAM_PASEO_EXEC onto PASEO_EXEC_INVALID rather than a generic spawn
+ * failure — a bad override is a configuration fault and must never be retried.
+ */
+export function paseoExec() {
+	return resolvePaseoExec((reason) => {
+		throw new PaseoError("PASEO_EXEC_INVALID", `PASEO_TEAM_PASEO_EXEC ${reason}`);
+	});
+}
+
+/**
+ * Every argv element must already be a string. Coercing would turn an
+ * undefined option into the literal argv element "undefined" and send a
+ * nonsense command to the daemon, which is exactly the class of bug a WebUI
+ * forwarding user input is most likely to introduce.
+ */
+export function assertArgv(args) {
+	if (!Array.isArray(args) || args.length === 0) {
+		throw new PaseoError("ARGV_INVALID", "paseo argv must be a non-empty array");
+	}
+	for (const [index, part] of args.entries()) {
+		if (typeof part !== "string" || part.length === 0) {
+			throw new PaseoError(
+				"ARGV_INVALID",
+				`paseo argv[${index}] must be a non-empty string (got ${typeof part})`,
+				{ index },
+			);
+		}
+	}
+	return args;
+}
+
+/**
+ * Run `paseo <args> --json` and parse stdout.
+ *
+ * `--json` is appended here, once, so no caller can forget it and get a table
+ * back. Errors carry a code so reliability.mjs#classifyRemoteFailure can tell
+ * a transport hiccup from a configuration fault.
+ */
+export function runPaseoJson(args, options = {}) {
+	// Validation and exec resolution happen inside the executor on purpose: a
+	// function that returns a promise must never *also* throw synchronously,
+	// or half the call sites need a try/catch the other half do not.
+	return new Promise((resolve, reject) => {
+		assertArgv(args);
+		const timeoutMs = Math.max(250, options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS);
+		const [bin, ...prefix] = paseoExec();
+		const argv = [...prefix, ...args, "--json"];
+		execFile(
+			bin,
+			argv,
+			{
+				encoding: "utf8",
+				timeout: timeoutMs,
+				signal: options.signal,
+				stdio: ["ignore", "pipe", "pipe"],
+				maxBuffer: 32 * 1024 * 1024,
+				env: process.env,
+				windowsHide: true,
+			},
+			(error, stdout, stderr) => {
+				if (error) {
+					const text = `${String(stderr ?? "").trim()} ${String(error.message ?? "")}`.trim();
+					const code = error.killed || error.signal ? "TIMEOUT" : (error.code ?? "CLI_ERROR");
+					reject(new PaseoError(typeof code === "number" ? "CLI_ERROR" : code, text || "paseo failed", { args }));
+					return;
+				}
+				try {
+					resolve(JSON.parse(stdout));
+				} catch (parseError) {
+					reject(
+						new PaseoError(
+							"INVALID_JSON",
+							`paseo returned invalid JSON for '${args.join(" ")}': ${String(parseError?.message ?? parseError)}`,
+							{ head: String(stdout).slice(0, 200) },
+						),
+					);
+				}
+			},
+		);
+	});
+}
+
+/**
+ * Bounded-concurrency map that never rejects: a failing item resolves to
+ * `{ ok: false, error }`. A snapshot must degrade per item, not collapse
+ * because one cold agent timed out.
+ */
+export async function mapWithConcurrency(items, limit, fn) {
+	const list = Array.from(items);
+	const width = Math.max(1, Math.min(16, Math.floor(limit) || 1));
+	const results = new Array(list.length);
+	let cursor = 0;
+	async function worker() {
+		while (cursor < list.length) {
+			const index = cursor++;
+			try {
+				results[index] = { ok: true, value: await fn(list[index], index) };
+			} catch (error) {
+				results[index] = { ok: false, error };
+			}
+		}
+	}
+	await Promise.all(Array.from({ length: Math.min(width, list.length) }, () => worker()));
+	return results;
+}

--- a/cli/paseo-team.mjs
+++ b/cli/paseo-team.mjs
@@ -1,0 +1,565 @@
+#!/usr/bin/env node
+/**
+ * paseo-team.mjs — the CLI that owns every paseo-pi-team config path.
+ *
+ * Everything paseo-pi-team configures is read/written here and only here; the
+ * WebUI extension is a *client* that spawns this binary with a subcommand and
+ * renders the JSON it returns. It never touches the filesystem itself.
+ *
+ * The preview CLI contract:
+ *
+ *   paseo-team status                  -> machine-readable snapshot of paths + presence
+ *   paseo-team preflight    [--strict|--json|--skip-models|--host-id <id>|--cluster <p>|--routes <p>]
+ *   paseo-team config read  <section>  -> full JSON of that section (stdout)
+ *   paseo-team config write <section>  -> full JSON of that section from stdin, atomic+backup
+ *   paseo-team prompts read <role>     -> markdown body (JSON-wrapped)
+ *   paseo-team prompts write <role>    -> markdown body from stdin, atomic+backup
+ *   paseo-team skills list             -> [{ name, path, pack }]
+ *   paseo-team skills read <name>      -> SKILL.md body (JSON-wrapped)
+ *   paseo-team skills write <name>     -> SKILL.md body from stdin
+ *   paseo-team env list                -> documented env knobs + process values + target file
+ *   paseo-team install [--attach-cdp-port <port>] -> delegate to the bundled installer
+ *
+ * Every command emits a single JSON object (or JSON for read bodies). Non-JSON
+ * errors go to stderr and the process exits non-zero.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, appendFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as cw from "./lib/config-walker.mjs";
+import { runPaseoJson, PaseoError } from "./lib/paseo-bridge.mjs";
+import * as graphCache from "./lib/graph-cache.mjs";
+import { collectGraph, inferRole, normalizePermits } from "./lib/graph.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function fail(msg, code = 1) {
+	process.stderr.write(`[paseo-team] ${msg}\n`);
+	process.exit(code);
+}
+
+function json(obj) {
+	process.stdout.write(JSON.stringify(obj, null, 2) + "\n");
+}
+
+function readStdin() {
+	try {
+		return readFileSync(0, "utf8");
+	} catch (e) {
+		fail(`failed to read stdin: ${e.message}`);
+	}
+	return "";
+}
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+function cmdStatus() {
+	const paseoCfg = cw.readJsonOrNull(cw.paseoConfigPath());
+	const providers = paseoCfg?.agents?.providers ?? {};
+	json({
+		repoRoot: ROOT,
+		version: "0.1.0",
+		pi: { home: cw.piHome(), agentDir: cw.agentDir() },
+		paths: {
+			paseoConfig: cw.paseoConfigPath(),
+			mcpConfig: cw.mcpConfigPath(),
+			promptsDir: cw.promptsDir(),
+			skillsDir: cw.skillsDir(),
+			policyExtension: cw.policyExtensionPath(),
+			routing: join(cw.teamConfigDir(), "model-routing.local.json"),
+			cluster: join(cw.teamConfigDir(), "cluster-routing.local.json"),
+		},
+		presence: {
+			paseoConfig: cw.readJsonOrNull(cw.paseoConfigPath()) !== null,
+			mcpConfig: cw.readJsonOrNull(cw.mcpConfigPath()) !== null,
+			policyExtension: existsSync(cw.policyExtensionPath()),
+			routing: existsSync(join(cw.teamConfigDir(), "model-routing.local.json")),
+			cluster: existsSync(join(cw.teamConfigDir(), "cluster-routing.local.json")),
+			prompts: Object.fromEntries(
+				cw.ROLE_PROMPTS.map((r) => [r, existsSync(cw.rolePromptPath(r))])
+			),
+		},
+		roleProfiles: Object.keys(providers).filter((k) => providers[k]?.extends === "pi"),
+		docs: "docs/webui-architecture.md",
+	});
+}
+
+// ---------------------------------------------------------------------------
+// preflight (delegate to the bundled script)
+// ---------------------------------------------------------------------------
+
+function cmdPreflight(argv) {
+	// Strip a no-op --json (script accepts it) and pass the rest through.
+	const res = spawnSync(process.execPath, [join(ROOT, "scripts", "preflight.mjs"), ...argv], {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	if (res.error) fail(`preflight failed to start: ${res.error.message}`);
+	if (res.stderr) process.stderr.write(res.stderr);
+	if (res.stdout) process.stdout.write(res.stdout);
+	process.exit(res.status ?? 1);
+}
+
+// ---------------------------------------------------------------------------
+// config read/write
+// ---------------------------------------------------------------------------
+
+const CONFIG_SECTIONS = {
+	providers: () => cw.paseoConfigPath(),
+	routing: () => join(cw.teamConfigDir(), "model-routing.local.json"),
+	cluster: () => join(cw.teamConfigDir(), "cluster-routing.local.json"),
+	mcp: () => cw.mcpConfigPath(),
+	paseo: () => cw.paseoConfigPath(),
+};
+
+function resolveSection(section) {
+	if (typeof section !== "string" || !(section in CONFIG_SECTIONS)) {
+		fail(`unknown config section '${section}' (expected: ${Object.keys(CONFIG_SECTIONS).join(", ")})`);
+	}
+	return CONFIG_SECTIONS[section]();
+}
+
+function cmdConfigRead(section) {
+	const path = resolveSection(section);
+	const data = cw.readJsonOrNull(path);
+	if (data === null) {
+		json({ exists: false, path, data: {} });
+		return;
+	}
+	json({ exists: true, path, data });
+}
+
+function cmdConfigWrite(section) {
+	const path = resolveSection(section);
+	const content = readStdin();
+	try {
+		cw.atomicWriteJson(path, content);
+	} catch (e) {
+		fail(`invalid JSON or write failed for ${path}: ${e.message}`);
+	}
+	json({ ok: true, wrote: true, path });
+}
+
+// ---------------------------------------------------------------------------
+// prompts read/write
+// ---------------------------------------------------------------------------
+
+function cmdPromptsRead(role) {
+	const path = cw.rolePromptPath(role);
+	if (!existsSync(path)) {
+		fail(`prompt not installed for role '${role}' at ${path} — run 'paseo-team install'`);
+	}
+	json({ role, path, content: cw.readText(path) });
+}
+
+function cmdPromptsWrite(role) {
+	const path = cw.rolePromptPath(role);
+	const content = readStdin();
+	cw.atomicWrite(path, content);
+	json({ ok: true, wrote: true, role, path });
+}
+
+// ---------------------------------------------------------------------------
+// skills list/read/write
+// ---------------------------------------------------------------------------
+
+function listSkills() {
+	if (!existsSync(cw.skillsDir())) return [];
+	return readdirSync(cw.skillsDir(), { withFileTypes: true })
+		.filter((d) => d.isDirectory())
+		.map((d) => d.name);
+}
+
+function cmdSkillsList() {
+	json({
+		skills: listSkills().map((name) => ({
+			name,
+			path: join(cw.skillsDir(), name),
+			pack: cw.PACK_SKILLS.includes(name),
+		})),
+	});
+}
+
+function cmdSkillsRead(name) {
+	const n = cw.safeName(name);
+	const p = cw.skillPromptPath(n);
+	if (!existsSync(p)) fail(`skill '${name}' has no SKILL.md at ${p}`);
+	json({ name, path: p, content: cw.readText(p) });
+}
+
+function cmdSkillsWrite(name) {
+	const n = cw.safeName(name);
+	const p = cw.skillPromptPath(n);
+	const content = readStdin();
+	cw.atomicWrite(p, content);
+	json({ ok: true, wrote: true, name, path: p });
+}
+
+// ---------------------------------------------------------------------------
+// env list (read-only view of documented knobs)
+// ---------------------------------------------------------------------------
+
+const DOC_ENV = [
+	{ key: "PASEO_PI_ROLE", scope: "per-provider", where: "Paseo config agents.providers.<name>.env", purpose: "role selection (supervisor|lead|peer)" },
+	{ key: "PASEO_TEAM_LEAD_WRITE", scope: "host", where: "machine env", purpose: "grant Lead write/edit tools ('1' to enable)" },
+	{ key: "PASEO_TEAM_EXTRA_TOOLS", scope: "host", where: "machine env", purpose: "comma-separated extra tools per profile" },
+	{ key: "PASEO_TEAM_PROMPTS_DIR", scope: "host", where: "machine env", purpose: "override prompts directory" },
+	{ key: "PASEO_TEAM_SCRIPTS_DIR", scope: "host", where: "machine env", purpose: "override support-scripts directory" },
+];
+
+function cmdEnvList() {
+	json({
+		env: DOC_ENV.map((e) => ({ ...e, current: process.env[e.key] ?? null })),
+	});
+}
+
+// ---------------------------------------------------------------------------
+// install (delegate)
+// ---------------------------------------------------------------------------
+
+function cmdInstall(argv) {
+	const isWin = process.platform === "win32";
+	if (isWin) {
+		const res = spawnSync("powershell", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", join(ROOT, "scripts", "install.ps1"), ...argv], { stdio: "inherit" });
+		process.exit(res.status ?? 0);
+	} else {
+		const res = spawnSync("bash", [join(ROOT, "scripts", "install.sh"), ...argv], { stdio: "inherit" });
+		process.exit(res.status ?? 0);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Live plane: agents, permits, chat, graph
+//
+// Everything below talks to the Paseo daemon through cli/lib/paseo-bridge.mjs
+// and nowhere else. Each paseo invocation costs ~3s of process startup, so
+// commands here are batch-shaped by design: one command, one snapshot.
+// ---------------------------------------------------------------------------
+
+/** Agent ids and short-id prefixes only — never a free-form string in argv. */
+const AGENT_REF = /^[0-9a-fA-F][0-9a-fA-F-]{5,63}$/;
+/** Chat rooms are addressed by name or id; keep it to a single safe token. */
+const ROOM_REF = /^[A-Za-z0-9._:-]{1,128}$/;
+
+function safeRef(ref, kind = "agent") {
+	if (typeof ref !== "string" || !AGENT_REF.test(ref)) {
+		fail(`invalid ${kind} reference '${ref}' (expected a Paseo id or short-id prefix)`);
+	}
+	return ref;
+}
+
+function safeRoom(room) {
+	if (typeof room !== "string" || !ROOM_REF.test(room)) {
+		fail(`invalid room '${room}' (expected [A-Za-z0-9._:-], max 128 chars)`);
+	}
+	return room;
+}
+
+function flag(argv, name) {
+	return argv.includes(name);
+}
+
+function flagValue(argv, name) {
+	const index = argv.indexOf(name);
+	if (index < 0) return undefined;
+	const value = argv[index + 1];
+	if (value === undefined || value.startsWith("--")) fail(`${name} requires a value`);
+	return value;
+}
+
+/** Fail closed on typos: an unknown flag must never be silently ignored. */
+function rejectUnknownFlags(argv, allowed) {
+	for (const part of argv) {
+		if (part.startsWith("--") && !allowed.includes(part)) {
+			fail(`unknown flag '${part}' (allowed: ${allowed.join(", ")})`);
+		}
+	}
+}
+
+async function live(args, label) {
+	try {
+		return await runPaseoJson(args);
+	} catch (error) {
+		const code = error instanceof PaseoError ? error.code : "PASEO_FAILED";
+		process.stdout.write(JSON.stringify({ ok: false, code, command: label, message: String(error?.message ?? error) }, null, 2) + "\n");
+		process.exit(3);
+	}
+}
+
+async function cmdAgents(argv) {
+	rejectUnknownFlags(argv, ["--all"]);
+	const listed = await live(flag(argv, "--all") ? ["ls", "-g", "-a"] : ["ls", "-g"], "agents");
+	const rows = Array.isArray(listed) ? listed : [];
+	json({
+		ok: true,
+		count: rows.length,
+		agents: rows.map((agent) => ({ ...agent, role: inferRole(agent?.provider) })),
+	});
+}
+
+async function cmdAgentInspect(ref) {
+	const detail = await live(["inspect", safeRef(ref)], "agent inspect");
+	json({ ok: true, role: inferRole(detail?.Provider ?? detail?.provider), agent: detail });
+}
+
+/**
+ * Send a prompt read from stdin. The body goes through a temp file rather than
+ * argv: on Windows the whole command line is one bounded string, and
+ * remote-paseo.mjs already learned that lesson the hard way (PROMPT_TOO_LONG).
+ */
+async function cmdAgentSend(ref) {
+	const agent = safeRef(ref);
+	const body = readStdin().trim();
+	if (!body) fail("agent send: empty prompt on stdin");
+	cw.ensureDir(cw.teamConfigDir());
+	const tmp = join(cw.teamConfigDir(), `send-${process.pid}-${Date.now()}.txt`);
+	writeFileSync(tmp, body, "utf8");
+	// Cleanup on 'exit' rather than in a finally: `live()` reports a failed
+	// delegate by calling process.exit, which skips finally blocks entirely and
+	// would leave a prompt file behind on every failure.
+	process.on("exit", () => {
+		try { unlinkSync(tmp); } catch { /* already gone, or the send still holds it — not worth failing over */ }
+	});
+	const sent = await live(["send", agent, "--prompt-file", tmp, "--no-wait"], "agent send");
+	json({ ok: true, agentId: agent, bytes: Buffer.byteLength(body, "utf8"), response: sent });
+}
+
+// --- permissions -----------------------------------------------------------
+
+export function permitAuditPath() {
+	return join(cw.teamConfigDir(), "permit-audit.jsonl");
+}
+
+/**
+ * Approving a tool call is an authority act, so it leaves a record before the
+ * daemon is asked — a decision that was made must be visible even if the
+ * delegate call then fails.
+ */
+function auditPermit(entry) {
+	cw.ensureDir(cw.teamConfigDir());
+	appendFileSync(permitAuditPath(), JSON.stringify(entry) + "\n", "utf8");
+}
+
+async function cmdPermitsList() {
+	const listed = await live(["permit", "ls"], "permits list");
+	const { permits, unclassified } = normalizePermits(listed);
+	json({
+		ok: true,
+		count: permits.length + unclassified.length,
+		permits: permits.map(({ ok, ...rest }) => rest),
+		// Surfaced, not swallowed: a row we cannot name is still a request
+		// somebody is blocked on, but it must not get a one-click approve.
+		unclassified,
+	});
+}
+
+async function cmdPermitDecision(action, argv) {
+	const [agentRef, requestId] = argv;
+	const agent = safeRef(agentRef);
+	if (typeof requestId !== "string" || !ROOM_REF.test(requestId)) {
+		fail(`permits ${action}: missing or invalid request id`);
+	}
+	const decidedAt = new Date().toISOString();
+	auditPermit({ decidedAt, action, agentId: agent, requestId, actor: process.env.USERNAME ?? process.env.USER ?? null });
+	const result = await live(["permit", action, agent, requestId], `permits ${action}`);
+	json({ ok: true, action, agentId: agent, requestId, decidedAt, response: result });
+}
+
+// --- chat ------------------------------------------------------------------
+
+async function cmdChatList() {
+	const rooms = await live(["chat", "ls"], "chat list");
+	json({ ok: true, rooms: Array.isArray(rooms) ? rooms : [] });
+}
+
+async function cmdChatRead(room, argv) {
+	rejectUnknownFlags(argv, ["--limit"]);
+	const limit = flagValue(argv, "--limit");
+	const args = ["chat", "read", safeRoom(room)];
+	if (limit !== undefined) {
+		if (!/^\d{1,4}$/.test(limit)) fail("--limit must be a number (max 4 digits)");
+		args.push("--limit", limit);
+	}
+	const messages = await live(args, "chat read");
+	json({ ok: true, room, messages });
+}
+
+async function cmdChatPost(room) {
+	const body = readStdin().trim();
+	if (!body) fail("chat post: empty message on stdin");
+	if (body.length > 8000) fail(`chat post: message is ${body.length} chars (max 8000)`);
+	const posted = await live(["chat", "post", safeRoom(room), body], "chat post");
+	json({ ok: true, room, response: posted });
+}
+
+// --- graph -----------------------------------------------------------------
+
+async function cmdGraph(argv) {
+	rejectUnknownFlags(argv, ["--all", "--max-inspect", "--refresh"]);
+	if (flag(argv, "--refresh")) graphCache.clearParentCache();
+	const maxInspect = flagValue(argv, "--max-inspect");
+	if (maxInspect !== undefined && !/^\d{1,3}$/.test(maxInspect)) {
+		fail("--max-inspect must be a number (max 3 digits)");
+	}
+	json(
+		await collectGraph({
+			all: flag(argv, "--all"),
+			maxInspect: maxInspect === undefined ? undefined : Number(maxInspect),
+		}),
+	);
+}
+
+async function cmdWatchdog(argv) {
+	rejectUnknownFlags(argv, ["--stale-after"]);
+	const staleAfter = flagValue(argv, "--stale-after");
+	if (staleAfter !== undefined && !/^\d{1,9}$/.test(staleAfter)) fail("--stale-after must be milliseconds");
+	const { collectWatchdogSnapshot } = await import("../scripts/watchdog.mjs");
+	json(await collectWatchdogSnapshot(staleAfter === undefined ? {} : { staleAfterMs: Number(staleAfter) }));
+}
+
+// --- web -------------------------------------------------------------------
+
+async function cmdWeb(argv) {
+	rejectUnknownFlags(argv, ["--port", "--open", "--no-token"]);
+	const port = flagValue(argv, "--port");
+	if (port !== undefined && !/^\d{1,5}$/.test(port)) fail("--port must be a number");
+	const { startServer } = await import("../webui/server.mjs");
+	await startServer({
+		port: port === undefined ? undefined : Number(port),
+		open: flag(argv, "--open"),
+		// --no-token is for a throwaway demo on a machine you already trust.
+		// It is opt-in and loud, because this UI approves permission requests.
+		requireToken: !flag(argv, "--no-token"),
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Help + dispatch
+// ---------------------------------------------------------------------------
+
+function help() {
+	process.stdout.write(`pteam — role pack CLI (Paseo + Pi)          (alias: paseo-team)
+
+usage:
+  pteam status
+  pteam preflight [--strict] [--json] [--skip-models] [--host-id <id>] [--cluster <path>] [--routes <path>]
+  pteam config read  <section>
+  pteam config write <section>             (JSON body on stdin)
+  pteam prompts read <role>                (supervisor|lead|peer)
+  pteam prompts write <role>               (markdown body on stdin)
+  pteam skills list
+  pteam skills read <name>
+  pteam skills write <name>                (markdown body on stdin)
+  pteam env list
+  pteam install [--attach-cdp-port <port>]
+
+live plane (talks to the Paseo daemon):
+  pteam agents [--all]
+  pteam agent inspect <ref>
+  pteam agent send <ref>                   (prompt on stdin)
+  pteam permits list
+  pteam permits allow <agent> <reqId>
+  pteam permits deny  <agent> <reqId>
+  pteam chat list
+  pteam chat read <room> [--limit <n>]
+  pteam chat post <room>                   (message on stdin)
+  pteam graph [--all] [--max-inspect <n>] [--refresh]
+  pteam watchdog [--stale-after <ms>]
+  pteam web [--port <n>] [--open] [--no-token]
+
+sections: ${Object.keys(CONFIG_SECTIONS).join(", ")}
+roles:    ${cw.ROLE_PROMPTS.join(", ")}
+documentation: docs/webui-architecture.md
+`);
+}
+
+async function main() {
+	const [cmd, ...argv] = process.argv.slice(2);
+	switch (cmd) {
+		case "status": return cmdStatus();
+		case "preflight": return cmdPreflight(argv);
+		case "config": return dispatchTwo("config", argv, { read: cmdConfigRead, write: cmdConfigWrite });
+		case "prompts": return dispatchTwo("prompts", argv, { read: cmdPromptsRead, write: cmdPromptsWrite });
+		case "skills": return dispatchSkills(argv);
+		case "env": return dispatchEnv(argv[0]);
+		case "install": return cmdInstall(argv);
+		case "agents": return cmdAgents(argv);
+		case "agent": return dispatchAgent(argv);
+		case "permits": return dispatchPermits(argv);
+		case "chat": return dispatchChat(argv);
+		case "graph": return cmdGraph(argv);
+		case "watchdog": return cmdWatchdog(argv);
+		case "web": return cmdWeb(argv);
+		case "--help":
+		case "-h":
+		case "help":
+		case undefined:
+			return help();
+		default:
+			fail(`unknown command '${cmd}'. Run 'pteam --help'.`, 2);
+	}
+}
+
+function dispatchAgent(argv) {
+	const [sub, ref] = argv;
+	switch (sub) {
+		case "inspect": if (!ref) fail("agent inspect: missing agent reference"); return cmdAgentInspect(ref);
+		case "send": if (!ref) fail("agent send: missing agent reference"); return cmdAgentSend(ref);
+		default: fail(`agent: unknown subcommand '${sub}' (expected inspect|send)`);
+	}
+}
+
+function dispatchPermits(argv) {
+	const [sub, ...rest] = argv;
+	switch (sub) {
+		case "list": return cmdPermitsList();
+		case "allow":
+		case "deny": return cmdPermitDecision(sub, rest);
+		default: fail(`permits: unknown subcommand '${sub}' (expected list|allow|deny)`);
+	}
+}
+
+function dispatchChat(argv) {
+	const [sub, room, ...rest] = argv;
+	switch (sub) {
+		case "list": return cmdChatList();
+		case "read": if (!room) fail("chat read: missing room"); return cmdChatRead(room, rest);
+		case "post": if (!room) fail("chat post: missing room"); return cmdChatPost(room);
+		default: fail(`chat: unknown subcommand '${sub}' (expected list|read|post)`);
+	}
+}
+
+function dispatchTwo(parent, argv, handlers) {
+	const [sub, arg] = argv;
+	if (!sub) fail(`${parent}: missing subcommand (read|write)`);
+	const fn = handlers[sub];
+	if (!fn) fail(`${parent}: unknown subcommand '${sub}' (expected ${Object.keys(handlers).join("|")})`);
+	if (!arg) fail(`${parent} ${sub}: missing argument`);
+	return fn(arg);
+}
+
+function dispatchSkills(argv) {
+	const [sub, name] = argv;
+	switch (sub) {
+		case "list": return cmdSkillsList();
+		case "read": if (!name) fail("skills read: missing skill name"); return cmdSkillsRead(name);
+		case "write": if (!name) fail("skills write: missing skill name"); return cmdSkillsWrite(name);
+		default: fail(`skills: unknown subcommand '${sub}' (expected list|read|write)`);
+	}
+}
+
+function dispatchEnv(sub) {
+	if (sub && sub !== "list") fail(`env: unknown subcommand '${sub}' (expected list)`);
+	return cmdEnvList();
+}
+
+// An unhandled rejection must not exit 0 with an empty stdout: the WebUI
+// treats a zero exit as "the CLI answered", and a silent success is the one
+// failure mode a JSON-over-argv contract cannot recover from.
+main().catch((error) => {
+	fail(String(error?.stack ?? error?.message ?? error), 1);
+});

--- a/docs/webui-architecture.md
+++ b/docs/webui-architecture.md
@@ -1,0 +1,272 @@
+# WebUI architecture — CLI là nguồn sự thật
+
+Thiết kế lớp WebUI của `paseo-pi-team`. WebUI **không phải** một ứng dụng độc
+lập: nó là phần mở rộng cài thêm cho CLI `paseo-team`, và mọi thao tác đọc/ghi
+đều đi qua CLI đó.
+
+```text
+Browser (SPA)  --HTTP/JSON-->  webui/server.mjs  --spawn argv-->  paseo-team <cmd> --json
+                                (transport only)                    |
+                                                                    +--> file I/O  (cli/lib/config-walker.mjs)
+                                                                    +--> paseo CLI (cli/lib/paseo-bridge.mjs)
+                                                                    +--> scripts/* (preflight, watchdog, remote-paseo)
+```
+
+Quy tắc cứng:
+
+- `webui/server.mjs` **không** import `config-walker.mjs`, không `readFile`,
+  không gọi `paseo` trực tiếp. Nó chỉ map `route -> argv template` rồi spawn.
+- Mọi tham số từ browser được validate theo allowlist **trước khi** trở thành
+  phần tử argv. Không bao giờ ghép chuỗi shell (`shell: false` tuyệt đối).
+- Mọi response của CLI là một JSON object duy nhất. Server trả nguyên văn
+  stdout kèm `{ exitCode, stderr }` khi lỗi — không diễn giải lại.
+- SPA hiển thị được **đúng câu lệnh CLI** vừa chạy cho mỗi hành động. Đây là
+  thứ làm cho "CLI-as-truth" kiểm chứng được, chứ không chỉ là khẩu hiệu.
+
+## 1. Ba mặt phẳng
+
+WebUI phục vụ ba loại dữ liệu có nhịp sống rất khác nhau; trộn chúng vào một
+màn hình là sai lầm thiết kế phổ biến nhất ở lớp này.
+
+| Mặt phẳng | Nguồn | Nhịp | Ghi |
+|---|---|---|---|
+| **Config** | file trong `~/.pi`, `~/.paseo`, `~/.paseo-pi-team` | thay đổi hiếm | full-JSON qua stdin, atomic + backup |
+| **Permission** | daemon Paseo (`paseo permit`) + policy tĩnh của role | giây, đang chặn agent | hành vi có thẩm quyền, cần audit |
+| **Observability** | daemon Paseo (`ls`/`inspect`/`logs`/`chat`) | 2-5s | chỉ đọc + gửi prompt |
+
+### "Cấp quyền" là hai thứ khác nhau
+
+Phải tách bạch trong UI, vì nhầm lẫn chúng là lỗi bảo mật:
+
+1. **Runtime permit** — agent đang bị chặn ở một tool call cụ thể, cần người
+   duyệt *ngay bây giờ*: `paseo permit ls|allow|deny`. Phạm vi: một request id.
+2. **Policy authority** — role đó *về nguyên tắc* được làm gì: bảng allowlist
+   trong `extensions/paseo-team-policy.ts`, biến môi trường
+   `PASEO_TEAM_LEAD_WRITE` / `PASEO_TEAM_EXTRA_TOOLS`, và các trường authority
+   của task brief V3 (`templates/TASK_BRIEF_V3.md`). Phạm vi: cả một lượt chạy.
+
+WebUI hiển thị (2) ở dạng chỉ-đọc-có-giải-thích (render từ chính bảng policy),
+và cho sửa qua env/prompt/brief. Không có nút "cấp full quyền".
+
+## 2. Bề mặt dữ liệu thật của Paseo (đã probe, CLI 0.3.0)
+
+Xác minh trực tiếp trên daemon local, không suy đoán từ tài liệu:
+
+```text
+paseo status --json      -> daemon, listen addr, provider đã cài + version
+paseo ls --json [-g][-a] -> [{ id, shortId, name, provider, thinking, status, cwd, created }]
+paseo inspect <id> --json-> { Id, Name, Provider, Model, Status, Mode, Cwd,
+                              CreatedAt, UpdatedAt, Capabilities, AvailableModes,
+                              PendingPermissions[], Worktree, ParentAgentId }
+paseo permit ls --json   -> [] (pending permission toàn cục)
+paseo permit allow|deny <agent> [req_id]
+paseo chat ls|create|inspect|post|read|wait   -> kênh phối hợp nhiều agent
+paseo logs <id> [--tail n] [--filter tools|text|errors|permissions] [-f]
+paseo attach <id>        -> stream output của agent đang chạy
+paseo send <id> --prompt ...
+```
+
+Hai trường quan trọng nhất cho đồ thị: `ParentAgentId` (cạnh spawn) và
+`PendingPermissions` (badge cảnh báo trên node).
+
+> **Ràng buộc đã xác nhận bằng thực nghiệm:** `paseo logs <id>` phải hỏi phiên
+> provider bên dưới; với agent `idle` lâu ngày nó trả
+> `Failed to get logs: Pi RPC request timed out for get_state`. Timeline
+> **không** phải dữ liệu luôn có. Bộ thu thập phải time-box từng agent, cô lập
+> lỗi, và đánh dấu `logsOk: false` thay vì làm hỏng cả đồ thị.
+
+## 3. Contract CLI cần bổ sung
+
+CLI hiện có: `status`, `preflight`, `config read|write`, `prompts read|write`,
+`skills list|read|write`, `env list`, `install`. Bổ sung (giữ nguyên phong cách
+một-JSON-object-mỗi-lệnh):
+
+```text
+paseo-team agents [--all]                      -> node list chuan hoa + role suy ra tu provider
+paseo-team agent inspect <ref>                 -> inspect + pending permit + parent
+paseo-team agent send <ref>                    -> prompt qua stdin -> file -> paseo send --prompt-file
+paseo-team permits list                        -> pending permit + hang khong phan loai duoc
+paseo-team permits allow|deny <agent> <reqId>  -> ghi audit roi delegate
+paseo-team chat list|read <room>|post <room>   -> delegate paseo chat
+paseo-team graph [--all] [--max-inspect <n>] [--refresh]  -> { nodes, edges, permits, degraded[] }
+paseo-team watchdog [--stale-after <ms>]       -> delegate scripts/watchdog.mjs
+paseo-team web [--port <n>] [--open] [--no-token]         -> khoi dong webui/server.mjs
+```
+
+Nguyên tắc tái sử dụng — repo đã có sẵn, **không viết lại**:
+
+- `scripts/preflight.mjs` — gate cấu hình.
+- `scripts/watchdog.mjs` — `classifyStaleAgents()`, fan-out `inspect` có giới
+  hạn đồng thời (`DEFAULT_INSPECT_CONCURRENCY = 6`) và deadline toàn cục. Đây
+  chính là bộ khung sẵn có cho `graph`.
+- `scripts/remote-paseo.mjs` — `buildArgv()` cho multi-host, đã có redaction
+  endpoint bí mật. Host selector của WebUI phải chảy qua đây.
+- `scripts/team-communication.mjs` — schema `PEER_MESSAGE_V1` (xem §5).
+
+## 4. Tiến trình và transport
+
+- `webui/server.mjs`: HTTP server zero-dep (`node:http`), bind **127.0.0.1**.
+- Một nhịp poll của SPA = **một** lần spawn `paseo-team graph`, không phải N
+  spawn cho N widget.
+- v1 dùng **polling + cache phía server**, không dùng stream. `logs -f` và
+  `attach` là tiến trình con sống dài; nuôi N tiến trình như vậy từ web server
+  nhân bội các chế độ lỗi (zombie process trên Windows, backpressure, đứt SSE).
+  `--follow` là follow-up sau khi v1 ổn, và chỉ cho *một* agent đang mở drawer.
+- Server được phép **cache nguyên văn** stdout của CLI vài giây và **gộp**
+  các request giống nhau đang bay (single-flight). Cả hai đều không bịa ra dữ
+  liệu, nên vẫn nằm trong "transport-only". Ba tab mở cùng lúc tốn đúng một
+  lần spawn.
+
+### Chi phí thật (đo trên máy tham chiếu, Windows, paseo 0.3.0)
+
+Con số này quyết định gần như mọi lựa chọn ở trên, nên nó được đo chứ không
+ước lượng:
+
+| Thao tác | Thời gian |
+|---|---|
+| `paseo --version` (chỉ khởi động tiến trình) | ~2.7s |
+| `paseo ls -g --json` / `permit ls` / `inspect` | ~3.0-3.5s mỗi lệnh |
+| `paseo-team graph` lần đầu (cache lạnh, 21 agent) | ~12s |
+| `paseo-team graph` khi cache đã ấm | ~3.8s |
+| `paseo-team preflight --json` | ~25-30s |
+
+Chi phí nằm ở **khởi động tiến trình**, không phải ở truy vấn daemon: chạy
+thẳng `node dist/index.js` thay vì shim `.cmd` không nhanh hơn. Hệ quả:
+
+1. Poll floor là **5s**, không phải 2s.
+2. `preflight` có timeout riêng (180s) và TTL cache dài (60s) — nếu dùng chung
+   timeout 60s với các lệnh khác thì nó timeout ngay khi có một nhịp poll
+   graph chạy song song (đã tái hiện trên trình duyệt).
+3. Cây spawn phải được **cache**, nếu không mỗi nhịp poll tốn N x 3s.
+
+### Cache cây spawn (`cli/lib/graph-cache.mjs`)
+
+`paseo ls` **không** trả parent; chỉ `paseo inspect <id>` có `ParentAgentId`.
+Dựng lại cây mỗi nhịp poll cho 21 agent là hơn một phút wall-clock cho một cấu
+trúc gần như không đổi. Nên:
+
+- parent được cache tại `~/.paseo-pi-team/graph-cache.json` kèm `checkedAt`;
+- TTL 15 phút chứ không phải vĩnh viễn, vì `paseo agent detach` có thể xoá
+  parent — một agent đã detach tự lành trong vòng một TTL thay vì hiện cạnh ma
+  cho tới khi ai đó xoá cache bằng tay;
+- mỗi lần chạy chỉ tiêu tối đa `--max-inspect` (mặc định 6) lần inspect, ưu
+  tiên id chưa từng thấy → cache lạnh tự đầy sau vài nhịp thay vì chặn 60s;
+- phần chưa kịp phân giải được báo ra ở `pendingParents`, UI hiển thị
+  "đang dựng cây: còn N" thay vì vẽ một cây trông đã xong.
+- Ghi config: browser gửi **full JSON** của section; CLI parse (fail sớm nếu
+  JSON hỏng), backup `<file>.bak-<ts>`, ghi tmp rồi `rename` — không
+  regex-patch, không merge từng field.
+
+### Bảo mật (bắt buộc, vì UI này duyệt quyền và ghi config)
+
+- Token per-run: `paseo-team web` sinh token ngẫu nhiên, in ra terminal, trao
+  cho SPA qua URL **fragment** (`#token=...` — fragment không đi lên server,
+  không vào access log). SPA lưu `sessionStorage`, gửi lại ở header
+  `Authorization: Bearer`.
+- Kiểm tra header `Origin`/`Host` để chặn DNS-rebinding. Không bật CORS.
+- Không route nào nhận đường dẫn tuỳ ý. Section/role/skill đi qua allowlist và
+  `safeName()` như CLI đang làm.
+- Endpoint bí mật của host từ xa **không bao giờ** rời server; SPA chỉ thấy
+  `hostId`.
+
+## 5. Bài toán khó: dựng lại đồ thị liên lạc agent ↔ agent
+
+Paseo cho sẵn **node** và **cạnh spawn**, nhưng *không* có API "liệt kê tin
+nhắn giữa các agent" — `send` là fire-and-forget. Ba nguồn để tái dựng cạnh tin
+nhắn, theo thứ tự độ tin cậy giảm dần:
+
+**(a) Chat room — tin cậy cao.** `paseo chat read <room> --json` là kênh
+broadcast có cấu trúc, truy vấn được đầy đủ. Nếu đội dùng chat room cho phối
+hợp, đây là nguồn tốt nhất, và nên được khuyến khích ngay trong prompt của Lead.
+
+**(b) Peer -> Lead — tin cậy cao nhờ wire format sẵn có.**
+`scripts/team-communication.mjs` đã đóng gói mọi tin nhắn Peer gửi lên Lead
+theo khối có header ổn định:
+
+```text
+PEER_MESSAGE_V1
+KIND: question|blocked|dependency|progress
+CORRELATION_ID: <token>
+TASK_ID: <token>
+FROM_AGENT_ID: <agent id>
+```
+
+Vì vậy chỉ cần parse timeline/prompt của **Lead** là dựng lại được cạnh
+`peer -> lead` kèm `kind`, `taskId`, `correlationId` — không cần Paseo hỗ trợ
+thêm gì. `kind` chính là màu của cạnh trong đồ thị (`blocked` = đỏ).
+
+**(c) Lead -> Peer — tin cậy trung bình.** Suy ra từ `paseo logs <id> --filter
+tools` của Lead: các lời gọi `send_agent_prompt` / `create_agent`. Phụ thuộc
+vào `logs` vốn có thể timeout (§2), nên cạnh loại này luôn kèm
+`confidence: "suspected"`, đúng idiom `confidence: "unknown"` mà
+`watchdog.mjs` đang dùng.
+
+Schema chuẩn hoá mà `paseo-team graph` trả về:
+
+```jsonc
+{
+  "collectedAt": "<iso>",
+  "nodes": [{ "id", "shortId", "name", "role", "provider", "model", "status",
+              "cwd", "worktree", "parentId", "pendingPermissions": 0,
+              "stale": false, "confidence": "suspected|unknown" }],
+  "edges": [{ "type": "spawn|message|chat", "from", "to", "kind", "taskId",
+              "correlationId", "ts", "confidence" }],
+  "events": [{ "ts", "agentId", "type", "summary" }],
+  "degraded": [{ "agentId", "reason": "LOGS_TIMEOUT" }]   // không im lặng nuốt lỗi
+}
+```
+
+`degraded[]` là bắt buộc: UI phải nói rõ "3 agent không lấy được timeline" thay
+vì vẽ một đồ thị trông đầy đủ nhưng thiếu cạnh.
+
+`role` suy ra từ tiền tố provider (`pi-supervisor/...` -> `supervisor`), đối
+chiếu với `roleProfiles` mà `paseo-team status` đã trả về.
+
+## 6. Màn hình
+
+1. **Dashboard** — `status` + `preflight --json`: daemon, provider, đường dẫn
+   nào có/thiếu, nút chạy lại `preflight --strict`.
+2. **Config** — editor JSON theo section (`providers`, `routing`, `cluster`,
+   `mcp`), kèm danh sách backup đã tạo.
+3. **Roles & authority** — sửa `prompts/{supervisor,lead,peer}.md`, xem bảng
+   tool allowlist render từ policy, chỉnh env knob, dựng task brief V3.
+4. **Permissions inbox** — permit đang chờ, allow/deny một chạm, kèm ngữ cảnh
+   (agent nào, tool gì, tham số gì) và nhật ký quyết định.
+5. **Team graph** — đồ thị agent: node tô màu theo role, viền theo status, badge
+   số permit đang chờ; cạnh spawn nét liền, cạnh message nét đứt có hướng và
+   nhấp nháy khi có tin mới. Click node -> drawer timeline + ô gửi prompt. Đây
+   là màn hình lý do tồn tại của WebUI.
+6. **Chat rooms** — đọc/gửi trong room.
+
+## 7. Rủi ro
+
+| Rủi ro | Xử lý |
+|---|---|
+| `paseo logs` timeout với agent nguội (**đã tái hiện**) | time-box từng agent, báo `degraded[]`, đồ thị vẫn dựng từ `ls`+`inspect` |
+| N spawn mỗi nhịp poll làm chậm trên Windows | gom vào một lệnh `graph` |
+| Cạnh Lead->Peer là suy đoán | gắn `confidence`, không vẽ như sự thật |
+| WebUI mở một cổng duyệt quyền | 127.0.0.1 + token + kiểm tra Origin |
+| Hai tab cùng sửa một config | backup theo timestamp + so `mtime` trước khi ghi (`--if-unchanged`) |
+| Schema Paseo đổi giữa các version | chỉ đọc field đã probe; thiếu field -> `null` + báo degraded, không crash |
+
+## 8. Lộ trình
+
+- **PR-1 — CLI observability** — *xong*: `agents`, `agent inspect|send`,
+  `permits list|allow|deny`, `chat`, `graph`, `watchdog`.
+  Test: `test/paseo-bridge.test.mjs`, `test/graph.test.mjs`,
+  `test/cli-contract.test.mjs`.
+- **PR-2 — WebUI transport** — *xong*: `webui/server.mjs` (token, bảng
+  route→argv, cache + single-flight) + SPA `webui/public/`.
+  Test: `test/webui-server.test.mjs`.
+- **PR-3 — Permissions inbox** — *xong*: màn hình duyệt quyền, hàng không phân
+  loại được thì hiện nhưng không cho một-chạm, audit tại
+  `~/.paseo-pi-team/permit-audit.jsonl`.
+- **PR-4 — Cạnh message** — *chưa*: `graph --with-logs` parse `PEER_MESSAGE_V1`
+  từ timeline của Lead; drawer timeline per-agent. Đây là phần phụ thuộc
+  `paseo logs`, tức là phần dễ degrade nhất (§2).
+- **PR-5 — Multi-host** — *chưa*: host selector qua `remote-paseo.mjs`, endpoint
+  bí mật không rời server.
+
+Trạng thái hiện tại của đồ thị: node + cạnh **spawn** + badge permit là dữ liệu
+thật; cạnh **message** chưa có (legend vẫn ghi rõ "suy đoán" để không ai đọc
+nhầm một đồ thị thiếu cạnh thành một đội không nói chuyện với nhau).

--- a/package.json
+++ b/package.json
@@ -5,13 +5,20 @@
   "description": "Paseo/pi multi-agent role pack — policy extension, role prompts, support scripts.",
   "type": "module",
   "license": "MIT",
+  "bin": {
+    "pteam": "cli/paseo-team.mjs",
+    "paseo-team": "cli/paseo-team.mjs"
+  },
   "engines": {
     "node": ">=22.18"
   },
   "scripts": {
     "test": "node --test \"test/*.test.mjs\" \"test/*.test.mts\"",
     "typecheck": "tsc --noEmit -p tsconfig.ci.json",
-    "check": "npm run test && npm run typecheck"
+    "check": "npm run test && npm run typecheck",
+    "web": "node cli/paseo-team.mjs web",
+    "paseo-team": "node cli/paseo-team.mjs",
+    "pteam": "node cli/paseo-team.mjs"
   },
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "0.83.0",

--- a/test/cli-contract.test.mjs
+++ b/test/cli-contract.test.mjs
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CLI = join(HERE, "..", "cli", "paseo-team.mjs");
+const FAKE = join(HERE, "fixtures", "fake-paseo-live.mjs");
+
+const sandbox = mkdtempSync(join(tmpdir(), "pst-cli-"));
+
+/** Every run is pointed at a throwaway HOME so no test can touch a real config. */
+function run(args, extraEnv = {}) {
+	const result = spawnSync(process.execPath, [CLI, ...args], {
+		encoding: "utf8",
+		input: extraEnv.__stdin ?? "",
+		env: {
+			...process.env,
+			PASEO_TEAM_PASEO_EXEC: `node "${FAKE}"`,
+			PI_HOME: join(sandbox, "pi"),
+			PST_TEAM_CONFIG_DIR: join(sandbox, "team"),
+			PASEO_CONFIG_JSON: join(sandbox, "paseo-config.json"),
+			...extraEnv,
+		},
+	});
+	let json = null;
+	try {
+		json = JSON.parse(result.stdout);
+	} catch {
+		/* not every command answers with JSON (help does not) */
+	}
+	return { ...result, json };
+}
+
+try {
+	// --- help + fail-closed dispatch ---------------------------------------
+	{
+		const help = run(["--help"]);
+		assert.equal(help.status, 0);
+		for (const command of ["agents", "permits list", "graph", "web", "chat read"]) {
+			assert.ok(help.stdout.includes(command), `help documents '${command}'`);
+		}
+
+		const unknown = run(["teleport"]);
+		assert.equal(unknown.status, 2, "an unknown command exits 2, it does not fall through to help");
+
+		// Typos must never be silently ignored — that is how a --strict-shaped
+		// flag ends up doing nothing while looking like it worked.
+		const badFlag = run(["graph", "--with-logs"]);
+		assert.notEqual(badFlag.status, 0);
+		assert.match(badFlag.stderr, /unknown flag/);
+
+		const badSub = run(["permits", "approve"]);
+		assert.notEqual(badSub.status, 0);
+		assert.match(badSub.stderr, /unknown subcommand/);
+	}
+
+	// --- agents: role inference travels with the row -----------------------
+	{
+		const agents = run(["agents"]);
+		assert.equal(agents.status, 0);
+		assert.equal(agents.json.ok, true);
+		assert.equal(agents.json.count, 3);
+		assert.deepEqual(agents.json.agents.map((agent) => agent.role), ["supervisor", "lead", "peer"]);
+	}
+
+	// --- agent refs are validated before they reach argv --------------------
+	{
+		const bad = run(["agent", "inspect", "$(rm -rf /)"]);
+		assert.notEqual(bad.status, 0);
+		assert.match(bad.stderr, /invalid agent reference/);
+
+		const good = run(["agent", "inspect", "22222222-2222-2222-2222-222222222222"]);
+		assert.equal(good.status, 0);
+		assert.equal(good.json.agent.ParentAgentId, "11111111-1111-1111-1111-111111111111");
+	}
+
+	// --- send: the prompt travels as a file, not as a command line ----------
+	{
+		const body = "x".repeat(20_000);
+		const sent = run(["agent", "send", "33333333-3333-3333-3333-333333333333"], { __stdin: body });
+		assert.equal(sent.status, 0, sent.stderr);
+		assert.equal(sent.json.ok, true);
+		assert.equal(sent.json.response.body, body, "a 20k prompt survives intact");
+		assert.equal(sent.json.bytes, 20_000);
+	}
+
+	// --- permits -------------------------------------------------------------
+	{
+		const empty = run(["permits", "list"]);
+		assert.equal(empty.json.count, 0);
+
+		const listed = run(["permits", "list"], { FAKE_PERMITS: "1" });
+		assert.equal(listed.json.permits.length, 1);
+		assert.equal(listed.json.permits[0].tool, "write");
+		// The row nothing could name is still shown — someone is blocked on it —
+		// but it arrives in `unclassified`, where the UI cannot one-click it.
+		assert.equal(listed.json.unclassified.length, 1);
+		assert.equal(listed.json.count, 2);
+
+		const decided = run(["permits", "allow", "33333333-3333-3333-3333-333333333333", "req-1"]);
+		assert.equal(decided.status, 0, decided.stderr);
+		assert.equal(decided.json.response.decided, "allow");
+
+		// Approving a tool call is an authority act and leaves a record.
+		const audit = join(sandbox, "team", "permit-audit.jsonl");
+		assert.ok(existsSync(audit), "a permit decision is audited");
+		const entry = JSON.parse(readFileSync(audit, "utf8").trim().split("\n").at(-1));
+		assert.equal(entry.action, "allow");
+		assert.equal(entry.requestId, "req-1");
+		assert.equal(entry.agentId, "33333333-3333-3333-3333-333333333333");
+
+		const malformed = run(["permits", "deny", "33333333-3333-3333-3333-333333333333", "req 1"]);
+		assert.notEqual(malformed.status, 0);
+	}
+
+	// --- graph over a fake daemon -------------------------------------------
+	{
+		const graph = run(["graph"]);
+		assert.equal(graph.status, 0, graph.stderr);
+		assert.equal(graph.json.ok, true);
+		assert.equal(graph.json.counts.agents, 3);
+		assert.deepEqual(
+			graph.json.edges.filter((edge) => edge.type === "spawn").map((edge) => `${edge.from.slice(0, 4)}->${edge.to.slice(0, 4)}`),
+			["1111->2222", "2222->3333"],
+		);
+		assert.deepEqual(graph.json.degraded, []);
+
+		// The cache lives in the throwaway team dir, not in the repo.
+		assert.ok(existsSync(join(sandbox, "team", "graph-cache.json")));
+
+		// Second run: the tree is already known, so no inspect is spent. This is
+		// what makes polling affordable at ~3s per paseo call.
+		const warm = run(["graph"]);
+		assert.equal(warm.json.inspectSpent, 0);
+		assert.equal(warm.json.pendingParents, 0);
+		assert.equal(warm.json.counts.edges, 2);
+	}
+
+	// --- chat ----------------------------------------------------------------
+	{
+		const rooms = run(["chat", "list"]);
+		assert.equal(rooms.json.rooms[0].name, "team");
+
+		const read = run(["chat", "read", "team", "--limit", "10"]);
+		assert.equal(read.json.messages[0].body, "hello");
+
+		const badRoom = run(["chat", "read", "../etc"]);
+		assert.notEqual(badRoom.status, 0);
+		assert.match(badRoom.stderr, /invalid room/);
+	}
+
+	// --- config still round-trips through the sandbox ------------------------
+	{
+		const written = run(["config", "write", "routing"], { __stdin: '{"hostId":"box-1"}' });
+		assert.equal(written.status, 0, written.stderr);
+		const read = run(["config", "read", "routing"]);
+		assert.equal(read.json.exists, true);
+		assert.deepEqual(read.json.data, { hostId: "box-1" });
+		assert.match(read.json.path, /model-routing\.local\.json$/);
+
+		const invalid = run(["config", "write", "routing"], { __stdin: "{not json" });
+		assert.notEqual(invalid.status, 0);
+	}
+} finally {
+	rmSync(sandbox, { recursive: true, force: true });
+}
+
+console.log("cli-contract tests passed");

--- a/test/fixtures/fake-paseo-live.mjs
+++ b/test/fixtures/fake-paseo-live.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// fake-paseo-live.mjs — a paseo stand-in for the live-plane CLI tests
+// (agents / permits / chat / graph).
+//
+// Separate from fake-paseo.mjs on purpose: that one echoes argv back for the
+// remote-paseo wrapper tests, while these tests need CLI-shaped *results*.
+// Returning real shapes here would have broken the echo assertions there.
+
+const argv = process.argv.slice(2).filter((part) => part !== "--json");
+const say = (value) => {
+	console.log(JSON.stringify(value));
+	process.exit(0);
+};
+
+const AGENTS = [
+	{ id: "11111111-1111-1111-1111-111111111111", shortId: "1111111", name: "supervisor", provider: "pi-supervisor/o/m", thinking: "medium", status: "idle", cwd: "/w", created: "1 day ago" },
+	{ id: "22222222-2222-2222-2222-222222222222", shortId: "2222222", name: "lead", provider: "pi-lead/o/m", thinking: "high", status: "running", cwd: "/w", created: "1 hour ago" },
+	{ id: "33333333-3333-3333-3333-333333333333", shortId: "3333333", name: "peer", provider: "pi-peer/o/m", thinking: "high", status: "running", cwd: "/w", created: "5 min ago" },
+];
+
+const PARENTS = {
+	"11111111-1111-1111-1111-111111111111": null,
+	"22222222-2222-2222-2222-222222222222": "11111111-1111-1111-1111-111111111111",
+	"33333333-3333-3333-3333-333333333333": "22222222-2222-2222-2222-222222222222",
+};
+
+if (argv[0] === "ls") say(AGENTS);
+
+if (argv[0] === "inspect") {
+	const id = argv[1];
+	say({
+		Id: id,
+		Name: AGENTS.find((agent) => agent.id === id)?.name ?? "unknown",
+		Provider: "pi-peer",
+		Status: "running",
+		PendingPermissions: [],
+		ParentAgentId: PARENTS[id] ?? null,
+	});
+}
+
+if (argv[0] === "permit" && argv[1] === "ls") {
+	say(
+		process.env.FAKE_PERMITS === "1"
+			? [{ agentId: "33333333-3333-3333-3333-333333333333", requestId: "req-1", tool: "write" }, { mystery: true }]
+			: [],
+	);
+}
+
+if (argv[0] === "permit" && (argv[1] === "allow" || argv[1] === "deny")) {
+	say({ decided: argv[1], agent: argv[2], request: argv[3] });
+}
+
+if (argv[0] === "chat" && argv[1] === "ls") say([{ id: "room_1", name: "team" }]);
+if (argv[0] === "chat" && argv[1] === "read") say([{ agentId: "peer", body: "hello", createdAt: "2026-08-21T00:00:00.000Z" }]);
+if (argv[0] === "chat" && argv[1] === "post") say({ posted: true, room: argv[2], body: argv[3] });
+
+if (argv[0] === "send") {
+	// The prompt must arrive through a file, never as one giant argv element.
+	const fileIndex = argv.indexOf("--prompt-file");
+	if (fileIndex < 0) {
+		console.error("fake-paseo-live: send without --prompt-file");
+		process.exit(1);
+	}
+	const { readFileSync } = await import("node:fs");
+	say({ sent: true, agent: argv[1], body: readFileSync(argv[fileIndex + 1], "utf8") });
+}
+
+console.error(`fake-paseo-live: unhandled argv ${argv.join(" ")}`);
+process.exit(1);

--- a/test/graph.test.mjs
+++ b/test/graph.test.mjs
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildGraph, collectGraph, inferRole, normalizePermits, parsePeerMessage } from "../cli/lib/graph.mjs";
+import * as cache from "../cli/lib/graph-cache.mjs";
+
+// --- role inference --------------------------------------------------------
+// `ls` reports "pi-lead/Owner/model" and `inspect` reports "pi-lead"; both
+// must land on the same role or the graph would colour the same agent twice.
+assert.equal(inferRole("pi-supervisor/Minnyat/deepseek-v4-flash"), "supervisor");
+assert.equal(inferRole("pi-lead"), "lead");
+assert.equal(inferRole("PI-PEER/x"), "peer");
+assert.equal(inferRole("claude"), null, "an unknown provider is unknown, not bucketed into a role");
+assert.equal(inferRole(undefined), null);
+
+// --- PEER_MESSAGE_V1 parsing ----------------------------------------------
+{
+	const body = [
+		"Some preamble the Lead also received.",
+		"PEER_MESSAGE_V1",
+		"KIND: blocked",
+		"CORRELATION_ID: peer-123-abc",
+		"TASK_ID: T-42",
+		"FROM_AGENT_ID: 11111111-2222-3333-4444-555555555555",
+		"",
+		"the actual question",
+	].join("\n");
+	const parsed = parsePeerMessage(body);
+	assert.equal(parsed.kind, "blocked");
+	assert.equal(parsed.taskId, "T-42");
+	assert.equal(parsed.correlationId, "peer-123-abc");
+	assert.equal(parsed.fromAgentId, "11111111-2222-3333-4444-555555555555");
+}
+// Fail closed: a kind outside MESSAGE_KINDS, or a missing field, must not
+// become a half-populated edge on the graph.
+assert.equal(parsePeerMessage("PEER_MESSAGE_V1\nKIND: gossip\nCORRELATION_ID: c\nTASK_ID: t\nFROM_AGENT_ID: a"), null);
+assert.equal(parsePeerMessage("PEER_MESSAGE_V1\nKIND: progress\nTASK_ID: t\nFROM_AGENT_ID: a"), null);
+assert.equal(parsePeerMessage("no marker here"), null);
+assert.equal(parsePeerMessage(null), null);
+
+// --- permit normalization --------------------------------------------------
+{
+	const { permits, unclassified } = normalizePermits([
+		{ agentId: "aaaa1111-0000-0000-0000-000000000000", requestId: "req-1", tool: "bash" },
+		{ AgentId: "bbbb2222-0000-0000-0000-000000000000", RequestId: "req-2" },
+		{ somethingElse: true },
+		"not-an-object",
+	]);
+	assert.equal(permits.length, 2, "both casings are recognized");
+	assert.equal(permits[0].tool, "bash");
+	assert.equal(permits[1].tool, null);
+	// A row we cannot name is kept, not dropped: someone is blocked on it.
+	assert.equal(unclassified.length, 2);
+}
+
+// --- buildGraph ------------------------------------------------------------
+const AGENTS = [
+	{ id: "sup", shortId: "sup", name: "supervisor", provider: "pi-supervisor/o/m", status: "idle", cwd: "/w" },
+	{ id: "lead", shortId: "lead", name: "lead", provider: "pi-lead/o/m", status: "running", cwd: "/w" },
+	{ id: "peer", shortId: "peer", name: "peer", provider: "pi-peer/o/m", status: "running", cwd: "/w" },
+	{ id: "lost", shortId: "lost", name: "orphan", provider: "pi-peer/o/m", status: "idle", cwd: "/w" },
+];
+
+{
+	const graph = buildGraph({
+		agents: AGENTS,
+		parents: { sup: null, lead: "sup", peer: "lead", lost: "archived-parent" },
+		permits: [{ agentId: "peer", requestId: "r1", tool: "write" }],
+		messages: [
+			{ from: "peer", to: "lead", kind: "blocked", correlationId: "c1", confidence: "confirmed" },
+			{ from: "peer", to: "lead", kind: "blocked", correlationId: "c1", confidence: "confirmed" },
+			{ from: "lead", to: "peer", kind: null, correlationId: "c2" },
+		],
+		now: Date.parse("2026-08-21T00:00:00.000Z"),
+	});
+
+	assert.equal(graph.counts.agents, 4);
+	assert.deepEqual(graph.counts.byRole, { supervisor: 1, lead: 1, peer: 2 });
+
+	const spawn = graph.edges.filter((edge) => edge.type === "spawn");
+	assert.deepEqual(
+		spawn.map((edge) => `${edge.from}->${edge.to}`),
+		["sup->lead", "lead->peer"],
+		"a parent that is not in the listing produces no edge",
+	);
+	assert.ok(spawn.every((edge) => edge.confidence === "confirmed"));
+
+	const messages = graph.edges.filter((edge) => edge.type === "message");
+	assert.equal(messages.length, 2, "a repeated correlationId draws once");
+	assert.equal(messages[1].confidence, "suspected", "an unlabelled message edge is a guess by default");
+
+	// The orphan must be flagged, not silently promoted to a root: flattening
+	// the tree would misrepresent who is answering to whom.
+	const lost = graph.nodes.find((node) => node.id === "lost");
+	assert.equal(lost.orphan, true);
+	assert.ok(graph.degraded.some((fault) => fault.reason === "PARENT_NOT_LISTED" && fault.agentId === "lost"));
+
+	assert.equal(graph.nodes.find((node) => node.id === "peer").pendingPermissions, 1);
+	assert.equal(graph.nodes.find((node) => node.id === "lead").pendingPermissions, 0);
+	assert.equal(graph.counts.pendingPermissions, 1);
+	assert.equal(graph.collectedAt, "2026-08-21T00:00:00.000Z");
+}
+
+{
+	// An agent nobody has inspected yet is "parent unknown", which is not the
+	// same claim as "has no parent".
+	const graph = buildGraph({ agents: AGENTS, parents: {}, now: 0 });
+	assert.equal(graph.edges.length, 0);
+	assert.ok(graph.nodes.every((node) => node.parentKnown === false));
+}
+
+{
+	const graph = buildGraph({ agents: AGENTS, parents: {}, permits: [{ nothing: true }], now: 0 });
+	assert.ok(graph.degraded.some((fault) => fault.reason === "PERMIT_SHAPE_UNRECOGNIZED"));
+	assert.equal(graph.counts.pendingPermissions, 1, "an unclassified permit still counts as pending");
+}
+
+// --- parent cache ----------------------------------------------------------
+{
+	const dir = mkdtempSync(join(tmpdir(), "pst-graph-"));
+	const path = join(dir, "graph-cache.json");
+	try {
+		assert.deepEqual(cache.readParentCache(path).parents, {}, "a missing cache reads as empty");
+
+		const store = { version: cache.CACHE_VERSION, parents: {} };
+		cache.rememberParent(store, "a", "root", 1000);
+		cache.rememberParent(store, "b", null, 500);
+		cache.writeParentCache(store, path);
+		assert.deepEqual(cache.readParentCache(path).parents, {
+			a: { parentId: "root", checkedAt: 1000 },
+			b: { parentId: null, checkedAt: 500 },
+		});
+
+		assert.equal(cache.isFresh(store.parents.a, { now: 1000 + 60_000, ttlMs: 15 * 60_000 }), true);
+		assert.equal(cache.isFresh(store.parents.a, { now: 1000 + 16 * 60_000, ttlMs: 15 * 60_000 }), false);
+		// Oldest first, so a cold cache fills deterministically over polls, and
+		// a never-seen id ("c") outranks any entry that was checked once.
+		assert.deepEqual(cache.staleIds(["a", "b", "c"], store, { now: 10 ** 9, ttlMs: 1 }), ["c", "b", "a"]);
+
+		cache.pruneCache(store, ["a"]);
+		assert.deepEqual(Object.keys(store.parents), ["a"], "ids the daemon stopped listing are dropped");
+
+		// Derived data: a corrupt cache is discarded rather than half-read.
+		cache.writeParentCache({ parents: { x: { parentId: 5, checkedAt: "soon" } } }, path);
+		assert.deepEqual(cache.readParentCache(path).parents, {});
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+// --- collectGraph ----------------------------------------------------------
+function fakeRunner(overrides = {}) {
+	const calls = [];
+	return {
+		calls,
+		run: async (args) => {
+			calls.push(args.join(" "));
+			if (args[0] === "ls") return overrides.ls ?? AGENTS;
+			if (args[0] === "permit") return overrides.permits ?? [];
+			if (args[0] === "inspect") {
+				if (overrides.inspectFails) throw Object.assign(new Error("cold agent"), { code: "TIMEOUT" });
+				return { Id: args[1], ParentAgentId: args[1] === "lead" ? "sup" : args[1] === "peer" ? "lead" : null };
+			}
+			throw new Error(`unexpected argv: ${args.join(" ")}`);
+		},
+	};
+}
+
+{
+	const fake = fakeRunner();
+	const store = { version: cache.CACHE_VERSION, parents: {} };
+	const result = await collectGraph({
+		runPaseoJson: fake.run,
+		cache: store,
+		persistCache: false,
+		maxInspect: 2,
+		now: 1000,
+	});
+	assert.equal(result.ok, true);
+	assert.equal(result.inspectSpent, 2, "the inspect budget is respected");
+	assert.equal(result.pendingParents, 2, "what the budget could not cover is reported, not hidden");
+	assert.equal(fake.calls.filter((call) => call.startsWith("inspect")).length, 2);
+	assert.ok(fake.calls.includes("ls -g"));
+	assert.ok(fake.calls.includes("permit ls"));
+}
+
+{
+	// Second pass with a warm cache: no inspect is spent, and the tree is
+	// complete. This is the property that makes a 5s poll affordable.
+	const fake = fakeRunner();
+	const store = { version: cache.CACHE_VERSION, parents: {} };
+	await collectGraph({ runPaseoJson: fake.run, cache: store, persistCache: false, maxInspect: 10, now: 1000 });
+	const warm = await collectGraph({ runPaseoJson: fake.run, cache: store, persistCache: false, maxInspect: 10, now: 2000 });
+	assert.equal(warm.inspectSpent, 0);
+	assert.equal(warm.pendingParents, 0);
+	assert.equal(warm.edges.filter((edge) => edge.type === "spawn").length, 2);
+}
+
+{
+	// One cold agent must degrade its own entry, not the whole snapshot.
+	const fake = fakeRunner({ inspectFails: true });
+	const result = await collectGraph({
+		runPaseoJson: fake.run,
+		cache: { version: cache.CACHE_VERSION, parents: {} },
+		persistCache: false,
+		maxInspect: 1,
+		now: 1000,
+	});
+	assert.equal(result.ok, true);
+	assert.equal(result.counts.agents, 4, "the graph still renders");
+	assert.ok(result.degraded.some((fault) => fault.reason === "TIMEOUT"));
+}
+
+{
+	// No agent list means no graph — but the answer is still a document that
+	// explains itself, because the WebUI has to render something.
+	const result = await collectGraph({
+		runPaseoJson: async (args) => {
+			if (args[0] === "ls") throw Object.assign(new Error("daemon down"), { code: "DAEMON_NOT_RUNNING" });
+			return [];
+		},
+		cache: { version: cache.CACHE_VERSION, parents: {} },
+		persistCache: false,
+		now: 0,
+	});
+	assert.equal(result.ok, false);
+	assert.equal(result.nodes.length, 0);
+	assert.equal(result.degraded[0].reason, "DAEMON_NOT_RUNNING");
+}
+
+{
+	// A failing permit list must not take the agent list down with it.
+	const result = await collectGraph({
+		runPaseoJson: async (args) => {
+			if (args[0] === "permit") throw Object.assign(new Error("nope"), { code: "CLI_ERROR" });
+			if (args[0] === "ls") return AGENTS;
+			return { Id: args[1], ParentAgentId: null };
+		},
+		cache: { version: cache.CACHE_VERSION, parents: {} },
+		persistCache: false,
+		maxInspect: 0,
+		now: 0,
+	});
+	assert.equal(result.ok, true);
+	assert.equal(result.counts.agents, 4);
+	assert.ok(result.degraded.some((fault) => fault.reason === "CLI_ERROR"));
+}
+
+console.log("graph tests passed");

--- a/test/humanize.test.mjs
+++ b/test/humanize.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import {
+	degradedSentence,
+	humanizeError,
+	missingSetup,
+	overallHealth,
+	permitSentence,
+	relativeTime,
+	roleLabel,
+	statusLabel,
+	toolMeaning,
+} from "../webui/public/humanize.js";
+
+// This module is the entire non-technical vocabulary of the WebUI, so it is
+// kept DOM-free and tested here rather than eyeballed in a browser.
+
+// --- labels ---------------------------------------------------------------
+assert.equal(roleLabel("lead"), "Trưởng nhóm");
+assert.equal(roleLabel("peer"), "Thành viên");
+assert.equal(roleLabel(undefined), "Chưa rõ vai trò", "an unknown role is never silently blank");
+assert.equal(statusLabel("running"), "Đang làm việc");
+assert.equal(statusLabel("ERROR"), "Gặp lỗi", "status casing from the daemon does not matter");
+assert.equal(statusLabel("something-new"), "something-new", "an unmapped status is shown as-is, not swallowed");
+
+// --- tool risk ------------------------------------------------------------
+assert.equal(toolMeaning("write").risk, "high");
+assert.equal(toolMeaning("bash").risk, "high");
+assert.equal(toolMeaning("archive_agent").risk, "high");
+assert.equal(toolMeaning("read").risk, "low");
+assert.equal(toolMeaning("list_agents").risk, "low");
+// The important one: anything unclassified must NOT be presented as safe.
+assert.equal(toolMeaning("frobnicate_9000").risk, "unknown");
+assert.equal(toolMeaning("").risk, "unknown");
+assert.equal(toolMeaning(undefined).risk, "unknown");
+assert.match(toolMeaning("bash").what, /chạy lệnh/);
+
+assert.match(permitSentence({ tool: "write" }, "Fix login bug"), /Fix login bug.*sửa hoặc tạo file/s);
+assert.match(permitSentence({ tool: "write" }, ""), /^Một agent/);
+
+// --- errors carry an action, never just a code ---------------------------
+{
+	const daemon = humanizeError({ code: "CLI_FAILED", stderr: "paseo daemon unreachable" });
+	assert.match(daemon.title, /Chưa kết nối/);
+	assert.match(daemon.advice, /paseo start/);
+
+	const timeout = humanizeError({ stderr: "paseo-team timed out" });
+	assert.match(timeout.advice, /paseo restart/);
+
+	const auth = humanizeError({ code: "UNAUTHORIZED", message: "missing or invalid bearer token" });
+	assert.match(auth.title, /hết hạn/);
+
+	const install = humanizeError({ stderr: "prompt not installed for role 'lead'" });
+	assert.match(install.advice, /install/);
+
+	// Unknown failures still get a next step instead of a dead end.
+	const unknown = humanizeError({ code: "WAT", message: "something odd" });
+	assert.equal(unknown.title, "Có lỗi xảy ra");
+	assert.match(unknown.advice, /Chi tiết kỹ thuật/);
+	assert.match(unknown.technical, /something odd/);
+
+	// The raw text is preserved for whoever does read codes.
+	assert.match(humanizeError({ command: "paseo-team graph", stderr: "boom" }).technical, /paseo-team graph.*boom/);
+}
+
+// --- relative time --------------------------------------------------------
+const now = Date.parse("2026-08-21T12:00:00.000Z");
+assert.equal(relativeTime("2026-08-21T11:59:58.000Z", now), "vừa xong");
+assert.equal(relativeTime("2026-08-21T11:59:30.000Z", now), "30 giây trước");
+assert.equal(relativeTime("2026-08-21T11:45:00.000Z", now), "15 phút trước");
+assert.equal(relativeTime("2026-08-21T09:00:00.000Z", now), "3 giờ trước");
+assert.equal(relativeTime("2026-08-19T12:00:00.000Z", now), "2 ngày trước");
+assert.equal(relativeTime("not a date", now), "không rõ");
+assert.equal(relativeTime(undefined, now), "không rõ");
+
+// --- setup gaps -----------------------------------------------------------
+{
+	const complete = { presence: { policyExtension: true, paseoConfig: true, prompts: { supervisor: true, lead: true, peer: true } } };
+	assert.deepEqual(missingSetup(complete), []);
+
+	const partial = { presence: { policyExtension: false, paseoConfig: true, prompts: { supervisor: true, lead: false, peer: false } } };
+	const missing = missingSetup(partial);
+	assert.equal(missing.length, 2);
+	assert.match(missing[1], /Trưởng nhóm.*Thành viên/, "missing prompts are named by role, not by filename");
+}
+
+// --- the home headline ranks by urgency -----------------------------------
+{
+	const status = { presence: { policyExtension: true, paseoConfig: true, prompts: { supervisor: true, lead: true, peer: true } } };
+	const graph = { ok: true, nodes: [{ status: "running" }, { status: "idle" }] };
+
+	assert.equal(overallHealth({}).level, "bad", "no status at all is a problem, not a green light");
+
+	// A blocked agent outranks everything else — it is the only thing that
+	// stops work until a human answers.
+	const waiting = overallHealth({ status, graph, permits: { count: 2 } });
+	assert.equal(waiting.level, "attention");
+	assert.match(waiting.headline, /2 việc đang chờ bạn duyệt/);
+
+	const one = overallHealth({ status, graph, permits: { count: 1 } });
+	assert.match(one.headline, /1 việc/, "singular is not '1 việc(s)'");
+
+	const brokenList = overallHealth({ status, graph: { ok: false }, permits: { count: 0 } });
+	assert.equal(brokenList.level, "bad");
+
+	const notInstalled = overallHealth({
+		status: { presence: { policyExtension: false, paseoConfig: true, prompts: {} } },
+		graph,
+		permits: { count: 0 },
+	});
+	assert.equal(notInstalled.level, "attention");
+	assert.match(notInstalled.detail, /install/);
+
+	const errored = overallHealth({ status, graph: { ok: true, nodes: [{ status: "error" }] }, permits: { count: 0 } });
+	assert.match(errored.headline, /1 agent đang gặp lỗi/);
+
+	const fine = overallHealth({ status, graph, permits: { count: 0 } });
+	assert.equal(fine.level, "good");
+	assert.match(fine.headline, /1 agent đang làm việc/);
+}
+
+// --- degraded data is stated, never hidden --------------------------------
+assert.equal(degradedSentence([], 0), "", "a clean snapshot says nothing");
+assert.match(degradedSentence([{ reason: "PARENT_NOT_LISTED" }], 0), /ngoài danh sách/);
+assert.match(degradedSentence([{ reason: "TIMEOUT" }, { reason: "INSPECT_FAILED" }], 0), /2 mục không lấy được/);
+assert.match(degradedSentence([{ reason: "PERMIT_SHAPE_UNRECOGNIZED" }], 0), /không đọc được nội dung/);
+assert.match(degradedSentence([], 5), /còn 5 agent chưa xếp xong/);
+
+console.log("humanize tests passed");

--- a/test/paseo-bridge.test.mjs
+++ b/test/paseo-bridge.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	assertArgv,
+	mapWithConcurrency,
+	PaseoError,
+	runPaseoJson,
+	DEFAULT_COMMAND_TIMEOUT_MS,
+} from "../cli/lib/paseo-bridge.mjs";
+
+const FAKE = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "fake-paseo.mjs");
+const previousExec = process.env.PASEO_TEAM_PASEO_EXEC;
+
+// --- argv validation is fail-closed ---------------------------------------
+assert.throws(() => assertArgv([]), (error) => error.code === "ARGV_INVALID");
+assert.throws(() => assertArgv("ls"), (error) => error.code === "ARGV_INVALID");
+// The bug this guards: an undefined option becoming the argv element
+// "undefined" and being sent to the daemon as if it were a real value.
+assert.throws(() => assertArgv(["inspect", undefined]), (error) => error.code === "ARGV_INVALID");
+assert.throws(() => assertArgv(["inspect", ""]), (error) => error.code === "ARGV_INVALID");
+assert.deepEqual(assertArgv(["ls", "-g"]), ["ls", "-g"]);
+
+// --- --json is appended exactly once, argv travels verbatim ----------------
+process.env.PASEO_TEAM_PASEO_EXEC = `node "${FAKE}"`;
+{
+	const echoed = await runPaseoJson(["ls", "-g"]);
+	assert.deepEqual(echoed.argv, ["ls", "-g", "--json"], "bridge appends --json and preserves argv order");
+}
+
+// --- a failing paseo becomes a coded error, never a silent empty result ----
+await assert.rejects(
+	runPaseoJson(["ls", "--fail"]),
+	(error) => error instanceof PaseoError && error.code === "CLI_ERROR",
+);
+
+// --- non-JSON stdout is its own code so the caller can tell it apart -------
+process.env.PASEO_TEAM_PASEO_EXEC = `node -e "process.stdout.write('not json')"`;
+await assert.rejects(
+	runPaseoJson(["ls"]),
+	(error) => error instanceof PaseoError && error.code === "INVALID_JSON",
+);
+
+// --- a malformed override is a config fault, not a transport fault ---------
+process.env.PASEO_TEAM_PASEO_EXEC = '"unclosed';
+await assert.rejects(
+	runPaseoJson(["ls"]),
+	(error) => error instanceof PaseoError && error.code === "PASEO_EXEC_INVALID",
+);
+
+if (previousExec === undefined) delete process.env.PASEO_TEAM_PASEO_EXEC;
+else process.env.PASEO_TEAM_PASEO_EXEC = previousExec;
+
+// --- bounded concurrency, and one failure does not sink the batch ----------
+{
+	let active = 0;
+	let peak = 0;
+	const results = await mapWithConcurrency([1, 2, 3, 4, 5, 6], 2, async (item) => {
+		active += 1;
+		peak = Math.max(peak, active);
+		await new Promise((resolve) => setTimeout(resolve, 15));
+		active -= 1;
+		if (item === 3) throw new PaseoError("TIMEOUT", "boom");
+		return item * 2;
+	});
+	assert.equal(peak, 2, "concurrency stays within the limit");
+	assert.equal(results.length, 6);
+	assert.deepEqual(results[0], { ok: true, value: 2 });
+	assert.equal(results[2].ok, false, "a failed item is reported, not thrown");
+	assert.equal(results[2].error.code, "TIMEOUT");
+	assert.deepEqual(results[5], { ok: true, value: 12 });
+}
+
+// A cold paseo start alone costs ~3s on the reference machine; a timeout
+// tighter than that would turn every snapshot into a false failure.
+assert.ok(DEFAULT_COMMAND_TIMEOUT_MS >= 10_000, "command timeout leaves room for paseo cold start");
+
+console.log("paseo-bridge tests passed");

--- a/test/webui-server.test.mjs
+++ b/test/webui-server.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import {
+	ROUTES,
+	bearerToken,
+	createCache,
+	handleApi,
+	isAllowedHost,
+	startServer,
+} from "../webui/server.mjs";
+
+// --- the route table is the whole attack surface ---------------------------
+// There is no dynamic argv assembly: a path that is not a key here cannot
+// reach the CLI at all.
+{
+	const echo = (args, stdin) => Promise.resolve({ exitCode: 0, stdout: "{}", stderr: "", args, stdin });
+
+	await assert.rejects(
+		handleApi({ method: "GET", pathname: "/api/nope", query: {}, exec: echo }),
+		(error) => error.status === 404 && error.code === "NO_ROUTE",
+	);
+	// Same path, wrong verb: a GET-only route must not be reachable by POST.
+	await assert.rejects(
+		handleApi({ method: "POST", pathname: "/api/status", query: {}, exec: echo }),
+		(error) => error.status === 404,
+	);
+
+	const status = await handleApi({ method: "GET", pathname: "/api/status", query: {}, exec: echo });
+	assert.deepEqual(status.args, ["status"]);
+
+	const graph = await handleApi({ method: "GET", pathname: "/api/graph", query: { all: "1", maxInspect: "8" }, exec: echo });
+	assert.deepEqual(graph.args, ["graph", "--all", "--max-inspect", "8"]);
+
+	const agents = await handleApi({ method: "GET", pathname: "/api/agents", query: {}, exec: echo });
+	assert.deepEqual(agents.args, ["agents"], "a missing flag is absent, never the string 'undefined'");
+}
+
+// --- parameters are checked before they become argv ------------------------
+{
+	const echo = () => Promise.resolve({ exitCode: 0, stdout: "{}", stderr: "" });
+	const rejects = (pathname, query, method = "GET", rawBody = "") =>
+		assert.rejects(
+			handleApi({ method, pathname, query, rawBody, exec: echo }),
+			(error) => error.status === 400 && error.code === "PARAM_INVALID",
+		);
+
+	await rejects("/api/config", { section: "../../etc/passwd" });
+	await rejects("/api/config", { section: "unknown" });
+	await rejects("/api/prompts", { role: "root" });
+	await rejects("/api/agent", { id: "not an id" });
+	await rejects("/api/skill", { name: "../secret" });
+	await rejects("/api/chat/read", { room: "a room with spaces" });
+	await rejects("/api/graph", { maxInspect: "99999" });
+	await rejects("/api/permits/decide", {}, "POST", JSON.stringify({ action: "approve-all", agentId: "aaaaaaaa", requestId: "r" }));
+	await rejects("/api/permits/decide", {}, "POST", JSON.stringify({ action: "allow", agentId: "; rm -rf /", requestId: "r" }));
+
+	// The happy path still builds the exact delegate command.
+	const decided = await handleApi({
+		method: "POST",
+		pathname: "/api/permits/decide",
+		query: {},
+		rawBody: JSON.stringify({ action: "deny", agentId: "aaaa1111-2222-3333-4444-555555555555", requestId: "req-9" }),
+		exec: echo,
+	});
+	assert.deepEqual(decided.args, ["permits", "deny", "aaaa1111-2222-3333-4444-555555555555", "req-9"]);
+}
+
+// --- config write forwards the raw document, not a re-serialized copy ------
+{
+	const raw = '{\n  "agents": { "providers": {} }\n}';
+	const seen = await handleApi({
+		method: "POST",
+		pathname: "/api/config",
+		query: { section: "providers" },
+		rawBody: raw,
+		exec: (args, stdin) => Promise.resolve({ exitCode: 0, stdout: "{}", stderr: "", stdin }),
+	});
+	assert.deepEqual(seen.args, ["config", "write", "providers"]);
+	assert.equal(seen.stdin, raw, "the CLI receives the document byte-for-byte");
+}
+
+// --- host / origin checks --------------------------------------------------
+assert.equal(isAllowedHost({ headers: { host: "127.0.0.1:4321" } }, 4321), true);
+assert.equal(isAllowedHost({ headers: { host: "localhost:4321" } }, 4321), true);
+// DNS rebinding: the name resolves to 127.0.0.1 but the Host header does not.
+assert.equal(isAllowedHost({ headers: { host: "evil.example.com:4321" } }, 4321), false);
+assert.equal(isAllowedHost({ headers: { host: "127.0.0.1:9999" } }, 4321), false);
+assert.equal(isAllowedHost({ headers: { host: "127.0.0.1:4321", origin: "http://evil.example.com" } }, 4321), false);
+assert.equal(isAllowedHost({ headers: {} }, 4321), false);
+
+assert.equal(bearerToken({ headers: { authorization: "Bearer abc.def" } }), "abc.def");
+assert.equal(bearerToken({ headers: { authorization: "Basic abc" } }), null);
+assert.equal(bearerToken({ headers: {} }), null);
+
+// --- cache: coalesce, expire, never memoize a failure ----------------------
+{
+	const cache = createCache();
+	let calls = 0;
+	const slow = () => new Promise((resolve) => setTimeout(() => { calls += 1; resolve({ exitCode: 0, stdout: "{}" }); }, 20));
+
+	// Three tabs polling the same thing must cost one spawn, not three.
+	const [a, b, c] = await Promise.all([
+		cache.run("graph", 1000, slow),
+		cache.run("graph", 1000, slow),
+		cache.run("graph", 1000, slow),
+	]);
+	assert.equal(calls, 1, "concurrent identical requests are single-flighted");
+	assert.ok(b.coalesced || c.coalesced);
+	assert.equal(a.exitCode, 0);
+
+	const hit = await cache.run("graph", 1000, slow);
+	assert.equal(calls, 1);
+	assert.equal(hit.cached, true);
+
+	const expired = await cache.run("graph", 0, slow);
+	assert.equal(calls, 2, "ttl 0 always re-runs");
+	assert.ok(!expired.cached);
+
+	// A failure must not stick: the daemon coming back has to be visible on
+	// the very next poll.
+	let failures = 0;
+	const failing = () => { failures += 1; return Promise.resolve({ exitCode: 2, stdout: "", stderr: "boom" }); };
+	await cache.run("bad", 10_000, failing);
+	await cache.run("bad", 10_000, failing);
+	assert.equal(failures, 2, "failed answers are never cached");
+}
+
+// --- end to end over a real socket ----------------------------------------
+{
+	const calls = [];
+	const handle = await startServer({
+		port: 0,
+		quiet: true,
+		token: "test-token",
+		runCli: (args) => {
+			calls.push(args.join(" "));
+			return Promise.resolve({ exitCode: 0, stdout: JSON.stringify({ ok: true, args }), stderr: "" });
+		},
+	});
+	const base = `http://127.0.0.1:${handle.port}`;
+	try {
+		const anonymous = await fetch(`${base}/api/status`);
+		assert.equal(anonymous.status, 401, "no token, no API");
+		assert.equal(calls.length, 0, "an unauthorized request never reaches the CLI");
+
+		const wrong = await fetch(`${base}/api/status`, { headers: { authorization: "Bearer nope" } });
+		assert.equal(wrong.status, 401);
+
+		const ok = await fetch(`${base}/api/status`, { headers: { authorization: "Bearer test-token" } });
+		assert.equal(ok.status, 200);
+		const payload = await ok.json();
+		assert.equal(payload.ok, true);
+		// Every answer names the command that produced it — that is what makes
+		// "the CLI is the source of truth" checkable rather than aspirational.
+		assert.equal(payload.command, "paseo-team status");
+		assert.deepEqual(payload.data.args, ["status"]);
+
+		const unknown = await fetch(`${base}/api/does-not-exist`, { headers: { authorization: "Bearer test-token" } });
+		assert.equal(unknown.status, 404);
+
+		// Static assets are public (they carry no data), but must not escape
+		// the public directory.
+		const page = await fetch(`${base}/`);
+		assert.equal(page.status, 200);
+		assert.match(await page.text(), /paseo-team/);
+		const escape = await fetch(`${base}/..%2Fserver.mjs`);
+		assert.ok(escape.status === 403 || escape.status === 404, `traversal blocked (got ${escape.status})`);
+	} finally {
+		await handle.close();
+	}
+}
+
+// --- a failing CLI is surfaced, not swallowed ------------------------------
+{
+	const handle = await startServer({
+		port: 0,
+		quiet: true,
+		token: "t",
+		runCli: () => Promise.resolve({ exitCode: 3, stdout: "", stderr: "paseo daemon unreachable" }),
+	});
+	try {
+		const response = await fetch(`http://127.0.0.1:${handle.port}/api/status`, { headers: { authorization: "Bearer t" } });
+		assert.equal(response.status, 502);
+		const payload = await response.json();
+		assert.equal(payload.ok, false);
+		assert.equal(payload.code, "CLI_FAILED");
+		assert.match(payload.stderr, /daemon unreachable/);
+	} finally {
+		await handle.close();
+	}
+}
+
+// --- every route is a real CLI subcommand ---------------------------------
+{
+	const known = new Set(["status", "preflight", "config", "prompts", "skills", "env", "install", "agents", "agent", "permits", "chat", "graph", "watchdog", "web"]);
+	for (const [key, route] of Object.entries(ROUTES)) {
+		const { args } = route.build(
+			{ section: "providers", role: "lead", id: "aaaa1111-2222-3333-4444-555555555555", name: "paseo-team-lead", room: "team" },
+			{ agentId: "aaaa1111-2222-3333-4444-555555555555", action: "allow", requestId: "r", name: "paseo-team-lead", room: "team" },
+			"{}",
+		);
+		assert.ok(known.has(args[0]), `${key} maps to a real subcommand (got '${args[0]}')`);
+	}
+}
+
+console.log("webui-server tests passed");

--- a/webui/public/app.js
+++ b/webui/public/app.js
@@ -1,0 +1,848 @@
+/**
+ * app.js — the WebUI client.
+ *
+ * It renders whatever `paseo-team` returned and nothing else: no field is
+ * computed here that the CLI did not send, so what you see on screen can
+ * always be reproduced by running the same command in a terminal.
+ *
+ * Two audiences share this page. The default ("Chế độ đơn giản") is written for
+ * someone who will never open a terminal: their job is to watch the team and
+ * answer permission requests, so every code, id and file path is either
+ * translated or hidden behind a disclosure. Advanced mode adds the editors that
+ * only make sense if you know what a JSON config is.
+ *
+ * Everything is inserted with textContent, never innerHTML: agent names and
+ * chat bodies are model-authored text, and this page holds a token that can
+ * approve permission requests.
+ */
+
+import {
+	ROLE_HINT,
+	degradedSentence,
+	humanizeError,
+	missingSetup,
+	overallHealth,
+	permitSentence,
+	relativeTime,
+	RISK_LABEL,
+	roleLabel,
+	statusLabel,
+	toolMeaning,
+} from "./humanize.js";
+
+// --- token -----------------------------------------------------------------
+
+const TOKEN_KEY = "paseo-team-token";
+
+function bootToken() {
+	const fromHash = /(?:^|[#&])token=([^&]+)/.exec(location.hash || "");
+	if (fromHash) {
+		sessionStorage.setItem(TOKEN_KEY, decodeURIComponent(fromHash[1]));
+		// Drop it from the address bar so a screenshot or a shared URL does not
+		// hand over the ability to approve tool calls.
+		history.replaceState(null, "", location.pathname + location.search);
+	}
+	return sessionStorage.getItem(TOKEN_KEY) ?? "";
+}
+
+let token = bootToken();
+
+// --- tiny DOM helpers ------------------------------------------------------
+
+const $ = (id) => document.getElementById(id);
+
+function el(tag, props = {}, children = []) {
+	const node = document.createElement(tag);
+	for (const [key, value] of Object.entries(props)) {
+		if (key === "class") node.className = value;
+		else if (key === "text") node.textContent = value;
+		else if (key.startsWith("on")) node.addEventListener(key.slice(2), value);
+		else if (value !== null && value !== undefined) node.setAttribute(key, value);
+	}
+	for (const child of [].concat(children)) {
+		if (child) node.appendChild(typeof child === "string" ? document.createTextNode(child) : child);
+	}
+	return node;
+}
+
+function svgEl(tag, props = {}, children = []) {
+	const node = document.createElementNS("http://www.w3.org/2000/svg", tag);
+	for (const [key, value] of Object.entries(props)) {
+		if (key === "text") node.textContent = value;
+		else if (key.startsWith("on")) node.addEventListener(key.slice(2), value);
+		else if (value !== null && value !== undefined) node.setAttribute(key, value);
+	}
+	for (const child of [].concat(children)) node.appendChild(child);
+	return node;
+}
+
+function clear(node) {
+	while (node.firstChild) node.removeChild(node.firstChild);
+	return node;
+}
+
+/** An error the reader can act on, with the raw text one click away. */
+function errorBlock(error) {
+	const info = error?.human ?? humanizeError({ message: error?.message });
+	return el("div", { class: "error-block" }, [
+		el("strong", { text: info.title }),
+		el("p", { text: info.advice }),
+		el("details", {}, [el("summary", { text: "Chi tiết kỹ thuật" }), el("pre", { text: info.technical })]),
+	]);
+}
+
+let toastTimer = null;
+function toast(message, isError = false) {
+	const node = $("toast");
+	node.textContent = message;
+	node.classList.toggle("err", isError);
+	node.classList.remove("hidden");
+	clearTimeout(toastTimer);
+	toastTimer = setTimeout(() => node.classList.add("hidden"), isError ? 10_000 : 3500);
+}
+
+function toastError(error) {
+	const info = error?.human ?? humanizeError({ message: error?.message });
+	toast(`${info.title}. ${info.advice}`, true);
+}
+
+// --- API -------------------------------------------------------------------
+
+let inFlight = 0;
+/** The CLI command behind the last answer — shown only in advanced mode. */
+let lastCommand = "";
+
+function paintConnection(state, extra = "") {
+	const node = $("conn");
+	node.className = `conn ${state}`;
+	node.textContent =
+		state === "busy" ? "đang cập nhật…" : state === "err" ? "mất kết nối" : `đã cập nhật ${extra}`.trim();
+}
+
+async function api(path, { method = "GET", body = null, raw = null } = {}) {
+	inFlight += 1;
+	paintConnection("busy");
+	const headers = { authorization: `Bearer ${token}` };
+	if (body !== null || raw !== null) headers["content-type"] = "application/json";
+	let response;
+	try {
+		response = await fetch(path, {
+			method,
+			headers,
+			body: raw !== null ? raw : body !== null ? JSON.stringify(body) : undefined,
+		});
+	} catch (cause) {
+		inFlight -= 1;
+		paintConnection("err");
+		const error = new Error(cause.message);
+		error.human = {
+			title: "Không liên lạc được với máy chủ trên máy bạn",
+			advice: "Cửa sổ dòng lệnh chạy 'paseo-team web' có thể đã bị đóng. Mở lại rồi tải lại trang.",
+			technical: String(cause.message),
+		};
+		throw error;
+	}
+	inFlight -= 1;
+	const payload = await response
+		.json()
+		.catch(() => ({ ok: false, code: "BAD_RESPONSE", message: "máy chủ trả về nội dung không đọc được" }));
+	if (payload.command) lastCommand = payload.command;
+	if (!response.ok || payload.ok === false) {
+		paintConnection("err");
+		if (response.status === 401) {
+			// The stored token outlived the server that issued it. Drop it, or
+			// every later action fails with the same opaque 401.
+			sessionStorage.removeItem(TOKEN_KEY);
+			token = "";
+		}
+		const error = new Error(payload.message ?? payload.code ?? `HTTP ${response.status}`);
+		error.human = humanizeError(payload);
+		error.payload = payload;
+		throw error;
+	}
+	if (inFlight === 0) paintConnection("ok", "vừa xong");
+	return payload;
+}
+
+// --- simple / advanced mode ------------------------------------------------
+
+const ADVANCED_KEY = "paseo-team-advanced";
+let advanced = localStorage.getItem(ADVANCED_KEY) === "1";
+
+function applyMode() {
+	document.body.classList.toggle("advanced", advanced);
+	$("advanced-toggle").checked = advanced;
+	// Leaving a hidden tab selected would show an empty page.
+	if (!advanced && (activeTab === "config" || activeTab === "roles")) selectTab("home");
+}
+
+$("advanced-toggle").addEventListener("change", (event) => {
+	advanced = event.target.checked;
+	localStorage.setItem(ADVANCED_KEY, advanced ? "1" : "0");
+	applyMode();
+});
+
+// --- tabs ------------------------------------------------------------------
+
+const loaders = {};
+let activeTab = "home";
+
+function selectTab(name) {
+	activeTab = name;
+	for (const button of document.querySelectorAll("#tabs button")) {
+		button.classList.toggle("active", button.dataset.tab === name);
+	}
+	for (const section of document.querySelectorAll(".tab")) {
+		section.classList.toggle("active", section.id === `tab-${name}`);
+	}
+	loaders[name]?.();
+}
+
+$("tabs").addEventListener("click", (event) => {
+	const tab = event.target?.closest?.("button")?.dataset?.tab;
+	if (tab) selectTab(tab);
+});
+
+// --- shared state ----------------------------------------------------------
+
+let lastGraph = null;
+let lastStatus = null;
+let lastPermits = null;
+
+function setBadge(count) {
+	const badge = $("permit-badge");
+	badge.textContent = String(count);
+	badge.classList.toggle("hidden", !count);
+}
+
+function kvTable(pairs) {
+	const table = el("table");
+	for (const [key, value] of pairs) {
+		table.appendChild(
+			el("tr", {}, [
+				el("th", { text: key }),
+				el("td", { class: "v", text: value === true ? "có" : value === false ? "không" : String(value ?? "—") }),
+			]),
+		);
+	}
+	return table;
+}
+
+// --- home ------------------------------------------------------------------
+
+const HEALTH_ICON = { good: "✓", attention: "!", bad: "×" };
+
+function paintHealth() {
+	const health = overallHealth({ status: lastStatus, graph: lastGraph, permits: lastPermits });
+	$("health").className = `health ${health.level}`;
+	$("health-icon").textContent = HEALTH_ICON[health.level] ?? "…";
+	$("health-headline").textContent = health.headline;
+	$("health-detail").textContent = health.detail;
+
+	const actions = clear($("health-actions"));
+	if ((lastPermits?.count ?? 0) > 0) {
+		actions.appendChild(
+			el("button", { class: "primary big", text: "Xem việc chờ duyệt", onclick: () => selectTab("permissions") }),
+		);
+	} else if (lastGraph?.nodes?.some((node) => node.status === "error")) {
+		actions.appendChild(el("button", { class: "big", text: "Xem agent gặp lỗi", onclick: () => selectTab("graph") }));
+	}
+
+	const nodes = lastGraph?.nodes ?? [];
+	$("stat-running").textContent = nodes.filter((node) => node.status === "running").length;
+	$("stat-permits").textContent = lastPermits?.count ?? 0;
+	$("stat-errors").textContent = nodes.filter((node) => node.status === "error").length;
+	$("stat-total").textContent = nodes.length;
+}
+
+function paintSetup() {
+	const body = clear($("setup-body"));
+	if (!lastStatus) {
+		body.appendChild(el("p", { class: "hint", text: "Chưa đọc được." }));
+		return;
+	}
+	const missing = missingSetup(lastStatus);
+	if (missing.length === 0) {
+		body.appendChild(el("p", { class: "ok", text: "✓ Đã cài đủ: bộ quy tắc phân quyền, mô tả vai trò và cấu hình Paseo." }));
+	} else {
+		body.appendChild(el("p", { class: "no", text: `Còn thiếu: ${missing.join(", ")}.` }));
+		body.appendChild(
+			el("p", { class: "hint", text: "Mở cửa sổ dòng lệnh trong thư mục dự án và chạy: npm run paseo-team -- install" }),
+		);
+	}
+	if (advanced) {
+		body.appendChild(
+			el("details", {}, [el("summary", { text: "Đường dẫn file" }), kvTable(Object.entries(lastStatus.paths ?? {}))]),
+		);
+	}
+}
+
+loaders.home = async () => {
+	paintHealth();
+	paintSetup();
+	await Promise.allSettled([refreshStatus(), refreshGraph({ silent: true }), refreshPermits({ silent: true })]);
+	paintHealth();
+	paintSetup();
+};
+
+async function refreshStatus() {
+	try {
+		lastStatus = (await api("/api/status")).data;
+	} catch (error) {
+		lastStatus = null;
+		if (activeTab === "home") toastError(error);
+	}
+}
+
+$("preflight-run").addEventListener("click", async () => {
+	const body = clear($("preflight-body"));
+	body.appendChild(el("p", { class: "hint", text: "Đang kiểm tra… việc này mất khoảng 30 giây." }));
+	try {
+		const { data } = await api("/api/preflight");
+		const checks = Array.isArray(data?.checks) ? data.checks : [];
+		clear(body);
+		if (checks.length === 0) {
+			body.appendChild(el("pre", { text: JSON.stringify(data, null, 2).slice(0, 4000) }));
+			return;
+		}
+		const failed = checks.filter((check) => check.status !== "pass");
+		body.appendChild(
+			el("p", {
+				class: failed.length === 0 ? "ok" : "no",
+				text:
+					failed.length === 0
+						? `✓ ${checks.length} mục đều đạt.`
+						: `${failed.length}/${checks.length} mục chưa đạt.`,
+			}),
+		);
+		const table = el("table");
+		for (const check of failed.length > 0 ? failed : checks) {
+			table.appendChild(
+				el("tr", {}, [
+					el("th", { text: check.id ?? "mục" }),
+					el("td", { class: check.status === "pass" ? "ok" : "no", text: check.status ?? "?" }),
+					el("td", { text: check.detail ?? "" }),
+				]),
+			);
+		}
+		body.appendChild(table);
+	} catch (error) {
+		clear(body).appendChild(errorBlock(error));
+	}
+});
+
+// --- permissions -----------------------------------------------------------
+
+function nodeFor(agentId) {
+	return lastGraph?.nodes?.find((node) => node.id === agentId) ?? null;
+}
+
+function agentNameFor(agentId) {
+	return nodeFor(agentId)?.name ?? "";
+}
+
+async function decide(action, permit, card) {
+	const meaning = toolMeaning(permit.tool);
+	if (action === "allow" && meaning.risk !== "low") {
+		// A high-impact approval gets one deliberate extra step. A non-technical
+		// reader cannot judge a tool name, so the confirm restates the effect.
+		if (!confirm(`Cho phép agent ${meaning.what}?\n\nHành động này thực hiện ngay trên máy của bạn.`)) return;
+	}
+	for (const button of card.querySelectorAll("button")) button.disabled = true;
+	try {
+		await api("/api/permits/decide", {
+			method: "POST",
+			body: { action, agentId: permit.agentId, requestId: permit.requestId },
+		});
+		toast(action === "allow" ? "Đã cho phép. Agent sẽ chạy tiếp." : "Đã từ chối.");
+		await refreshPermits();
+		renderPermits();
+	} catch (error) {
+		toastError(error);
+		for (const button of card.querySelectorAll("button")) button.disabled = false;
+	}
+}
+
+function permitCard(permit) {
+	const meaning = toolMeaning(permit.tool);
+	const node = nodeFor(permit.agentId);
+	const card = el("div", { class: `permit risk-${meaning.risk}` });
+	card.appendChild(el("div", { class: "risk-tag", text: RISK_LABEL[meaning.risk] }));
+	card.appendChild(el("p", { class: "permit-headline", text: permitSentence(permit, agentNameFor(permit.agentId)) }));
+
+	const facts = el("dl", { class: "facts" });
+	const addFact = (term, value) => {
+		if (!value) return;
+		facts.appendChild(el("dt", { text: term }));
+		facts.appendChild(el("dd", { text: String(value) }));
+	};
+	addFact("Agent", agentNameFor(permit.agentId) || "không rõ tên");
+	if (node) addFact("Vai trò", roleLabel(node.role));
+	if (node) addFact("Thư mục", node.cwd);
+	if (advanced) {
+		addFact("Công cụ", permit.tool ?? "không rõ");
+		addFact("Mã yêu cầu", permit.requestId);
+	}
+	card.appendChild(facts);
+
+	const allow = el("button", { class: "primary big", text: "Cho phép" });
+	const deny = el("button", { class: "danger big", text: "Từ chối" });
+	allow.addEventListener("click", () => decide("allow", permit, card));
+	deny.addEventListener("click", () => decide("deny", permit, card));
+	card.appendChild(el("div", { class: "permit-actions" }, [allow, deny]));
+
+	if (advanced) {
+		card.appendChild(
+			el("details", {}, [el("summary", { text: "Dữ liệu gốc" }), el("pre", { text: JSON.stringify(permit.raw, null, 2) })]),
+		);
+	}
+	return card;
+}
+
+function renderPermits() {
+	const body = clear($("permits-body"));
+	if (!lastPermits) {
+		body.appendChild(el("p", { class: "hint", text: "Đang tải…" }));
+		return;
+	}
+	const permits = lastPermits.permits ?? [];
+	const unclassified = lastPermits.unclassified ?? [];
+	if (permits.length === 0 && unclassified.length === 0) {
+		body.appendChild(
+			el("div", { class: "empty" }, [
+				el("div", { class: "empty-icon", text: "✓" }),
+				el("p", { text: "Không có việc nào chờ bạn duyệt." }),
+				el("p", {
+					class: "hint",
+					text: "Khi một agent cần bạn đồng ý, nó sẽ hiện ở đây và con số trên tab sẽ nhảy lên.",
+				}),
+			]),
+		);
+		return;
+	}
+	for (const permit of permits) body.appendChild(permitCard(permit));
+	for (const raw of unclassified) {
+		body.appendChild(
+			el("div", { class: "permit unclassified" }, [
+				el("strong", { text: "Có yêu cầu xin phép nhưng không đọc được nội dung" }),
+				el("p", {
+					text: "Không xác định được agent nào và xin phép điều gì, nên không cho duyệt từ đây — để tránh đồng ý nhầm.",
+				}),
+				el("p", { class: "hint", text: "Nhờ người phụ trách xử lý bằng lệnh: paseo permit ls" }),
+				el("details", {}, [el("summary", { text: "Dữ liệu gốc" }), el("pre", { text: JSON.stringify(raw, null, 2) })]),
+			]),
+		);
+	}
+}
+
+async function refreshPermits({ silent = false } = {}) {
+	try {
+		lastPermits = (await api("/api/permits")).data;
+		setBadge(lastPermits.count ?? 0);
+	} catch (error) {
+		if (!silent) toastError(error);
+	}
+}
+
+loaders.permissions = async () => {
+	renderPermits();
+	await refreshPermits();
+	renderPermits();
+};
+
+$("permits-refresh").addEventListener("click", () => loaders.permissions());
+
+// --- team view: diagram + list --------------------------------------------
+
+const NODE_W = 210;
+const NODE_H = 56;
+const COL_GAP = 90;
+const ROW_GAP = 14;
+
+let viewMode = "diagram";
+
+function setView(mode) {
+	viewMode = mode;
+	$("view-diagram").classList.toggle("active", mode === "diagram");
+	$("view-list").classList.toggle("active", mode === "list");
+	$("diagram-wrap").classList.toggle("hidden", mode !== "diagram");
+	$("list-wrap").classList.toggle("hidden", mode === "diagram");
+	if (lastGraph) renderTeam(lastGraph);
+}
+
+$("view-diagram").addEventListener("click", () => setView("diagram"));
+$("view-list").addEventListener("click", () => setView("list"));
+
+/** Depth = distance to a root through parentId, cycle-guarded. */
+function depthOf(node, byId, seen = new Set()) {
+	let depth = 0;
+	let current = node;
+	while (current?.parentId && byId.has(current.parentId) && !seen.has(current.id)) {
+		seen.add(current.id);
+		current = byId.get(current.parentId);
+		depth += 1;
+		if (depth > 32) break;
+	}
+	return depth;
+}
+
+function roleClass(role) {
+	return ["supervisor", "lead", "peer"].includes(role) ? role : "unknown";
+}
+
+function renderDiagram(graph) {
+	const svg = clear($("graph"));
+	const nodes = graph.nodes ?? [];
+	const byId = new Map(nodes.map((node) => [node.id, node]));
+	const columns = new Map();
+	const placed = new Map();
+
+	for (const node of nodes) {
+		const depth = depthOf(node, byId);
+		const column = columns.get(depth) ?? [];
+		column.push(node);
+		columns.set(depth, column);
+	}
+
+	let maxRows = 0;
+	for (const [depth, column] of [...columns.entries()].sort((a, b) => a[0] - b[0])) {
+		maxRows = Math.max(maxRows, column.length);
+		column.forEach((node, row) => {
+			placed.set(node.id, { x: 24 + depth * (NODE_W + COL_GAP), y: 24 + row * (NODE_H + ROW_GAP), node });
+		});
+	}
+
+	const width = 48 + (columns.size || 1) * (NODE_W + COL_GAP);
+	const height = Math.max(240, 48 + maxRows * (NODE_H + ROW_GAP));
+	svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+	svg.setAttribute("height", `${Math.min(height, 2400)}`);
+	// Left-align instead of the default centring: a two-column tree in a wide
+	// viewport would otherwise float in the middle with the roots off-centre.
+	svg.setAttribute("preserveAspectRatio", "xMinYMin meet");
+
+	for (const edge of graph.edges ?? []) {
+		const from = placed.get(edge.from);
+		const to = placed.get(edge.to);
+		if (!from || !to) continue;
+		const x1 = from.x + NODE_W;
+		const y1 = from.y + NODE_H / 2;
+		const x2 = to.x;
+		const y2 = to.y + NODE_H / 2;
+		const mid = (x1 + x2) / 2;
+		svg.appendChild(
+			svgEl("path", { class: `edge ${edge.type}`, d: `M ${x1} ${y1} C ${mid} ${y1}, ${mid} ${y2}, ${x2} ${y2}` }),
+		);
+	}
+
+	for (const { x, y, node } of placed.values()) {
+		const group = svgEl("g", { class: "node-box", transform: `translate(${x} ${y})`, onclick: () => openDrawer(node) });
+		group.appendChild(
+			svgEl("rect", {
+				class: "node-rect",
+				width: NODE_W,
+				height: NODE_H,
+				rx: 10,
+				fill: "#1b2120",
+				stroke: `var(--${roleClass(node.role)})`,
+				"stroke-width": node.status === "running" ? 2.5 : 1.2,
+				"stroke-dasharray": node.status === "error" ? "4 3" : null,
+			}),
+		);
+		// A hover tooltip carries the untruncated name; the box shows a slice.
+		group.appendChild(
+			svgEl("title", { text: `${node.name || "(không tên)"} — ${roleLabel(node.role)}, ${statusLabel(node.status)}` }),
+		);
+		group.appendChild(svgEl("text", { class: "node-label", x: 12, y: 23, text: (node.name || "(không tên)").slice(0, 24) }));
+		group.appendChild(
+			svgEl("text", { class: "node-sub", x: 12, y: 41, text: `${roleLabel(node.role)} · ${statusLabel(node.status)}` }),
+		);
+		if (node.pendingPermissions > 0) {
+			group.appendChild(svgEl("circle", { class: "badge-permit", cx: NODE_W - 16, cy: 16, r: 10 }));
+			group.appendChild(
+				svgEl("text", { class: "badge-text", x: NODE_W - 19.5, y: 20, text: String(node.pendingPermissions) }),
+			);
+		}
+		svg.appendChild(group);
+	}
+}
+
+function renderList(graph) {
+	const wrap = clear($("agent-list"));
+	// What needs a human first goes first: waiting on approval, then broken,
+	// then working, then idle.
+	const rank = (node) =>
+		node.pendingPermissions > 0 ? 0 : node.status === "error" ? 1 : node.status === "running" ? 2 : 3;
+	const nodes = [...(graph.nodes ?? [])].sort((a, b) => rank(a) - rank(b));
+	if (nodes.length === 0) {
+		wrap.appendChild(el("div", { class: "empty" }, [el("p", { text: "Chưa có agent nào." })]));
+		return;
+	}
+	const byId = new Map(nodes.map((node) => [node.id, node]));
+	const table = el("table", { class: "list" }, [
+		el("tr", {}, [
+			el("th", { text: "Tên việc" }),
+			el("th", { text: "Vai trò" }),
+			el("th", { text: "Trạng thái" }),
+			el("th", { text: "Người giao việc" }),
+			el("th", { text: "" }),
+		]),
+	]);
+	for (const node of nodes) {
+		const parent = node.parentId ? byId.get(node.parentId) : null;
+		table.appendChild(
+			el("tr", { class: node.status === "error" ? "row-error" : "" }, [
+				el("td", {}, [
+					el("span", { class: `dot-role ${roleClass(node.role)}` }),
+					el("span", { text: node.name || "(không tên)" }),
+					node.pendingPermissions > 0 ? el("span", { class: "pill", text: `${node.pendingPermissions} chờ duyệt` }) : null,
+				]),
+				el("td", { text: roleLabel(node.role) }),
+				el("td", { class: node.status === "error" ? "no" : "", text: statusLabel(node.status) }),
+				el("td", { text: parent ? parent.name || "(không tên)" : node.orphan ? "ngoài danh sách này" : "—" }),
+				el("td", {}, [el("button", { text: "Chi tiết", onclick: () => openDrawer(node) })]),
+			]),
+		);
+	}
+	wrap.appendChild(table);
+}
+
+function renderTeam(graph) {
+	if (viewMode === "diagram") renderDiagram(graph);
+	else renderList(graph);
+
+	const counts = graph.counts ?? {};
+	$("graph-meta").textContent = `${counts.agents ?? 0} agent · cập nhật ${relativeTime(graph.collectedAt)}`;
+
+	const notice = $("graph-degraded");
+	const sentence = degradedSentence(graph.degraded ?? [], graph.pendingParents ?? 0);
+	notice.textContent = sentence;
+	notice.classList.toggle("hidden", sentence === "");
+}
+
+function openDrawer(node) {
+	const drawer = $("node-drawer");
+	const body = clear($("drawer-body"));
+	drawer.classList.remove("hidden");
+	body.appendChild(el("h3", { text: node.name || "(không tên)" }));
+	body.appendChild(el("p", { class: "drawer-sub", text: `${roleLabel(node.role)} · ${statusLabel(node.status)}` }));
+	if (ROLE_HINT[node.role]) body.appendChild(el("p", { class: "hint", text: ROLE_HINT[node.role] }));
+
+	const facts = [
+		["Thư mục làm việc", node.cwd],
+		["Chờ bạn duyệt", node.pendingPermissions || "không có"],
+	];
+	if (node.orphan) facts.push(["Người giao việc", "không có trong danh sách này (có thể đã lưu trữ)"]);
+	if (advanced) facts.push(["Mã agent", node.id], ["Nhà cung cấp", node.provider], ["Mức suy nghĩ", node.thinking]);
+	body.appendChild(kvTable(facts));
+
+	body.appendChild(el("h4", { text: "Nhắn cho agent này" }));
+	const input = el("textarea", { class: "drawer-input", placeholder: "Ví dụ: dừng lại và báo cáo tiến độ hiện tại" });
+	const send = el("button", {
+		class: "primary big",
+		text: "Gửi",
+		onclick: async () => {
+			if (!input.value.trim()) {
+				toast("Chưa nhập nội dung.", true);
+				return;
+			}
+			send.disabled = true;
+			try {
+				await api("/api/agent/send", { method: "POST", body: { agentId: node.id, prompt: input.value } });
+				toast("Đã gửi. Agent sẽ đọc khi rảnh.");
+				input.value = "";
+			} catch (error) {
+				toastError(error);
+			} finally {
+				send.disabled = false;
+			}
+		},
+	});
+	body.appendChild(input);
+	body.appendChild(send);
+	if (advanced && lastCommand) body.appendChild(el("p", { class: "cmd", text: lastCommand }));
+}
+
+$("drawer-close").addEventListener("click", () => $("node-drawer").classList.add("hidden"));
+
+async function refreshGraph({ silent = false } = {}) {
+	try {
+		lastGraph = (await api(`/api/graph${$("graph-all").checked ? "?all=1" : ""}`)).data;
+		if (activeTab === "graph") renderTeam(lastGraph);
+	} catch (error) {
+		if (!silent) toastError(error);
+	}
+}
+
+loaders.graph = async () => {
+	if (lastGraph) renderTeam(lastGraph);
+	await refreshGraph();
+};
+
+$("graph-refresh").addEventListener("click", () => refreshGraph());
+$("graph-all").addEventListener("change", () => refreshGraph());
+
+// A paseo round trip costs ~3s, so 5s is the floor that still leaves the daemon
+// idle between polls. The server caches, so extra tabs cost nothing.
+setInterval(() => {
+	if (activeTab === "graph" && !document.hidden) refreshGraph({ silent: true });
+}, 5000);
+
+// The pending-approval count is the one thing worth knowing from any tab: an
+// agent sitting on a permission request is stopped until somebody answers.
+setInterval(async () => {
+	if (document.hidden) return;
+	await refreshPermits({ silent: true });
+	if (activeTab === "permissions") renderPermits();
+	if (activeTab === "home") paintHealth();
+}, 20_000);
+
+// --- roles -----------------------------------------------------------------
+
+async function loadPrompt() {
+	const role = $("role-select").value;
+	$("role-hint").textContent = ROLE_HINT[role] ?? "";
+	try {
+		const { data } = await api(`/api/prompts?role=${encodeURIComponent(role)}`);
+		$("prompt-editor").value = data.content ?? "";
+		$("prompt-meta").textContent = data.path ?? "";
+	} catch (error) {
+		$("prompt-meta").textContent = "";
+		toastError(error);
+	}
+}
+
+$("prompt-load").addEventListener("click", loadPrompt);
+$("role-select").addEventListener("change", loadPrompt);
+$("prompt-save").addEventListener("click", async () => {
+	const role = $("role-select").value;
+	try {
+		await api(`/api/prompts?role=${encodeURIComponent(role)}`, { method: "POST", body: { content: $("prompt-editor").value } });
+		toast("Đã lưu. Bản cũ được sao lưu tự động.");
+	} catch (error) {
+		toastError(error);
+	}
+});
+
+loaders.roles = async () => {
+	if (!$("prompt-editor").value) await loadPrompt();
+	if (!$("env-table").hasChildNodes()) await loadEnvTable();
+};
+
+async function loadEnvTable() {
+	try {
+		const { data } = await api("/api/env");
+		const table = el("table", {}, [
+			el("tr", {}, [el("th", { text: "Thiết lập" }), el("th", { text: "Hiện tại" }), el("th", { text: "Tác dụng" })]),
+		]);
+		for (const entry of data.env ?? []) {
+			table.appendChild(
+				el("tr", {}, [
+					el("td", { class: "v", text: entry.key }),
+					el("td", { class: entry.current ? "ok" : "k", text: entry.current ?? "chưa đặt" }),
+					el("td", { text: entry.purpose }),
+				]),
+			);
+		}
+		clear($("env-table")).appendChild(table);
+	} catch (error) {
+		clear($("env-table")).appendChild(errorBlock(error));
+	}
+}
+
+// --- config ----------------------------------------------------------------
+
+async function loadConfig() {
+	const section = $("config-section").value;
+	try {
+		const { data } = await api(`/api/config?section=${encodeURIComponent(section)}`);
+		$("config-editor").value = JSON.stringify(data.data ?? {}, null, 2);
+		$("config-meta").textContent = `${data.path}${data.exists ? "" : " (chưa tồn tại)"}`;
+	} catch (error) {
+		toastError(error);
+	}
+}
+
+$("config-load").addEventListener("click", loadConfig);
+$("config-section").addEventListener("change", loadConfig);
+$("config-save").addEventListener("click", async () => {
+	const section = $("config-section").value;
+	const text = $("config-editor").value;
+	try {
+		JSON.parse(text); // fail here, before anything touches the file
+	} catch (cause) {
+		toast(`Nội dung chưa đúng định dạng JSON: ${cause.message}`, true);
+		return;
+	}
+	try {
+		await api(`/api/config?section=${encodeURIComponent(section)}`, { method: "POST", raw: text });
+		toast("Đã lưu. Bản cũ được sao lưu kèm thời gian.");
+	} catch (error) {
+		toastError(error);
+	}
+});
+
+loaders.config = async () => {
+	if (!$("config-editor").value) await loadConfig();
+};
+
+// --- chat ------------------------------------------------------------------
+
+loaders.chat = async () => {
+	try {
+		const { data } = await api("/api/chat");
+		const select = clear($("chat-room"));
+		const rooms = data.rooms ?? [];
+		if (rooms.length === 0) {
+			clear($("chat-body")).appendChild(
+				el("div", { class: "empty" }, [
+					el("div", { class: "empty-icon", text: "…" }),
+					el("p", { text: "Chưa có phòng trao đổi nào." }),
+					el("p", { class: "hint", text: "Phòng do người phụ trách tạo bằng lệnh: paseo chat create <tên>" }),
+				]),
+			);
+			return;
+		}
+		for (const room of rooms) {
+			const name = room?.name ?? room?.id ?? String(room);
+			select.appendChild(el("option", { value: name, text: name }));
+		}
+	} catch (error) {
+		clear($("chat-body")).appendChild(errorBlock(error));
+	}
+};
+
+$("chat-load").addEventListener("click", async () => {
+	const room = $("chat-room").value;
+	if (!room) return;
+	try {
+		const { data } = await api(`/api/chat/read?room=${encodeURIComponent(room)}&limit=100`);
+		const body = clear($("chat-body"));
+		const messages = Array.isArray(data.messages) ? data.messages : [];
+		if (messages.length === 0) {
+			body.appendChild(el("p", { class: "hint", text: "Phòng này chưa có tin nhắn nào." }));
+			return;
+		}
+		for (const message of messages) {
+			const author = message.agentId ?? message.author ?? "";
+			body.appendChild(
+				el("div", { class: "message" }, [
+					el("div", {
+						class: "meta",
+						text: `${agentNameFor(author) || author || "không rõ"} · ${relativeTime(message.createdAt ?? message.ts)}`,
+					}),
+					el("div", { text: String(message.body ?? message.message ?? JSON.stringify(message)) }),
+				]),
+			);
+		}
+	} catch (error) {
+		toastError(error);
+	}
+});
+
+// --- boot ------------------------------------------------------------------
+
+applyMode();
+if (!token) {
+	toast("Thiếu mã truy cập. Mở đúng đường dẫn có #token=… mà cửa sổ dòng lệnh vừa in ra.", true);
+}
+selectTab("home");

--- a/webui/public/humanize.js
+++ b/webui/public/humanize.js
@@ -1,0 +1,227 @@
+/**
+ * humanize.js — turns the CLI's machine vocabulary into sentences a person who
+ * has never opened a terminal can act on.
+ *
+ * Kept free of DOM access on purpose: this is the layer that decides what a
+ * non-technical operator is told, so it must be testable without a browser
+ * (see test/humanize.test.mjs). app.js imports it; nothing here imports app.js.
+ *
+ * The rule this file follows everywhere: never show a code without also saying
+ * what to do about it. "DAEMON_NOT_RUNNING" tells the reader nothing; "Paseo
+ * chưa chạy — mở terminal và gõ `paseo start`" tells them everything.
+ */
+
+export const ROLE_LABEL = Object.freeze({
+	supervisor: "Giám sát",
+	lead: "Trưởng nhóm",
+	peer: "Thành viên",
+});
+
+export const ROLE_HINT = Object.freeze({
+	supervisor: "Theo dõi chất lượng công việc, không tự viết code.",
+	lead: "Nhận việc, chia việc và giao cho thành viên.",
+	peer: "Người trực tiếp làm một việc cụ thể.",
+});
+
+export function roleLabel(role) {
+	return ROLE_LABEL[role] ?? "Chưa rõ vai trò";
+}
+
+const STATUS_LABEL = Object.freeze({
+	running: "Đang làm việc",
+	idle: "Đang rảnh",
+	error: "Gặp lỗi",
+	closed: "Đã đóng",
+	archived: "Đã lưu trữ",
+	stopped: "Đã dừng",
+});
+
+export function statusLabel(status) {
+	return STATUS_LABEL[String(status ?? "").toLowerCase()] ?? String(status ?? "không rõ");
+}
+
+/**
+ * Tools are grouped by what they can do to the machine, not by their name.
+ * "bash" means nothing to a non-technical reader; "chạy lệnh trên máy" does.
+ */
+const TOOL_MEANING = [
+	{ match: /^(write|edit|create|apply_patch|multi_edit)/i, risk: "high", what: "sửa hoặc tạo file trong dự án" },
+	{ match: /^(bash|shell|exec|run|terminal|process)/i, risk: "high", what: "chạy lệnh trên máy này" },
+	{ match: /(delete|remove|rm|archive|cancel|stop)/i, risk: "high", what: "xoá hoặc dừng thứ gì đó" },
+	{ match: /(push|commit|merge|git)/i, risk: "high", what: "thay đổi lịch sử mã nguồn (git)" },
+	{ match: /^(fetch|web|http|curl|browser|navigate)/i, risk: "medium", what: "truy cập mạng ra ngoài" },
+	{ match: /^(mcp|send|create_agent|update_agent)/i, risk: "medium", what: "điều khiển agent khác" },
+	{ match: /^(read|cat|list|ls|glob|grep|search|inspect|get)/i, risk: "low", what: "đọc thông tin, không sửa gì" },
+];
+
+export const RISK_LABEL = Object.freeze({
+	high: "Ảnh hưởng lớn",
+	medium: "Cần cân nhắc",
+	low: "Ít rủi ro",
+	unknown: "Chưa rõ mức ảnh hưởng",
+});
+
+/**
+ * An unrecognized tool is "unknown", never "low": guessing low on something we
+ * cannot classify is exactly how a dangerous approval slips through.
+ */
+export function toolMeaning(tool) {
+	const name = typeof tool === "string" ? tool.trim() : "";
+	if (!name) return { risk: "unknown", what: "một hành động chưa xác định được", tool: null };
+	const hit = TOOL_MEANING.find((entry) => entry.match.test(name));
+	return hit ? { risk: hit.risk, what: hit.what, tool: name } : { risk: "unknown", what: `dùng công cụ “${name}”`, tool: name };
+}
+
+/**
+ * One sentence describing what is being asked, addressed to the person who has
+ * to answer it.
+ */
+export function permitSentence(permit, agentName) {
+	const who = agentName?.trim() ? `“${agentName.trim()}”` : "Một agent";
+	const { what } = toolMeaning(permit?.tool);
+	return `${who} đang xin phép để ${what}.`;
+}
+
+const ERROR_ADVICE = [
+	{
+		match: /daemon|econnrefused|not running|unreachable|connect/i,
+		title: "Chưa kết nối được với Paseo",
+		advice: "Paseo có thể chưa chạy. Mở cửa sổ dòng lệnh và gõ: paseo start",
+	},
+	{
+		match: /timed out|timeout|etimedout/i,
+		title: "Máy phản hồi quá chậm",
+		advice: "Thử lại sau vài giây. Nếu lặp lại, khởi động lại Paseo: paseo restart",
+	},
+	{
+		match: /unauthorized|token/i,
+		title: "Phiên làm việc đã hết hạn",
+		advice: "Mở lại đường dẫn có #token=… mà lệnh 'paseo-team web' vừa in ra trong cửa sổ dòng lệnh.",
+	},
+	{
+		match: /prompt not installed|run 'paseo-team install'|no SKILL\.md/i,
+		title: "Bộ vai trò chưa được cài",
+		advice: "Chạy lệnh cài đặt một lần: npm run paseo-team -- install",
+	},
+	{
+		match: /invalid JSON|not json/i,
+		title: "Nội dung nhập vào chưa đúng định dạng",
+		advice: "Kiểm tra lại phần vừa sửa — thiếu dấu phẩy hoặc dấu ngoặc là lỗi hay gặp nhất.",
+	},
+	{
+		match: /is missing or malformed|must be one of/i,
+		title: "Thông tin gửi lên chưa hợp lệ",
+		advice: "Tải lại trang rồi thử lại. Nếu vẫn vậy, đây là lỗi của ứng dụng chứ không phải của bạn.",
+	},
+];
+
+/**
+ * @param {object} payload the server's error envelope
+ * @returns {{title: string, advice: string, technical: string}}
+ */
+export function humanizeError(payload) {
+	const technical = [payload?.command, payload?.stderr, payload?.message, payload?.code]
+		.filter((part) => typeof part === "string" && part.trim() !== "")
+		.join(" · ")
+		.slice(0, 600);
+	const hit = ERROR_ADVICE.find((entry) => entry.match.test(technical));
+	if (hit) return { title: hit.title, advice: hit.advice, technical };
+	return {
+		title: "Có lỗi xảy ra",
+		advice: "Bấm “Chi tiết kỹ thuật” để xem nguyên văn, hoặc gửi phần đó cho người phụ trách.",
+		technical: technical || "không có thông tin chi tiết",
+	};
+}
+
+/** "12 giây trước", "3 phút trước" — a wall-clock time nobody has to subtract. */
+export function relativeTime(iso, now = Date.now()) {
+	const then = typeof iso === "number" ? iso : Date.parse(iso ?? "");
+	if (!Number.isFinite(then)) return "không rõ";
+	const seconds = Math.max(0, Math.round((now - then) / 1000));
+	if (seconds < 5) return "vừa xong";
+	if (seconds < 60) return `${seconds} giây trước`;
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes} phút trước`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 24) return `${hours} giờ trước`;
+	return `${Math.round(hours / 24)} ngày trước`;
+}
+
+/**
+ * The one-line verdict on the top of the home screen. Order matters: a blocked
+ * agent is more urgent than a missing config file, and both outrank "fine".
+ */
+export function overallHealth({ status, graph, permits } = {}) {
+	if (!status) {
+		return { level: "bad", headline: "Chưa đọc được tình trạng hệ thống", detail: "Kiểm tra xem Paseo đã chạy chưa." };
+	}
+	const pending = permits?.count ?? 0;
+	if (pending > 0) {
+		return {
+			level: "attention",
+			headline: pending === 1 ? "Có 1 việc đang chờ bạn duyệt" : `Có ${pending} việc đang chờ bạn duyệt`,
+			detail: "Agent đang dừng lại chờ bạn đồng ý — xử lý sớm để công việc chạy tiếp.",
+		};
+	}
+	if (graph && graph.ok === false) {
+		return { level: "bad", headline: "Không lấy được danh sách agent", detail: "Paseo có thể chưa chạy hoặc đang bận." };
+	}
+	const missing = missingSetup(status);
+	if (missing.length > 0) {
+		return {
+			level: "attention",
+			headline: "Cài đặt chưa hoàn tất",
+			detail: `Còn thiếu: ${missing.join(", ")}. Chạy: npm run paseo-team -- install`,
+		};
+	}
+	const errored = graph?.nodes?.filter((node) => node.status === "error").length ?? 0;
+	if (errored > 0) {
+		return {
+			level: "attention",
+			headline: errored === 1 ? "1 agent đang gặp lỗi" : `${errored} agent đang gặp lỗi`,
+			detail: "Mở tab “Nhóm agent” để xem agent nào và đang mắc ở đâu.",
+		};
+	}
+	const running = graph?.nodes?.filter((node) => node.status === "running").length ?? 0;
+	return {
+		level: "good",
+		headline: running > 0 ? `Mọi thứ ổn — ${running} agent đang làm việc` : "Mọi thứ ổn — không có agent nào đang chạy",
+		detail: "Không có việc gì cần bạn xử lý ngay.",
+	};
+}
+
+/** Which pieces of the role pack are not installed yet, in plain words. */
+export function missingSetup(status) {
+	const missing = [];
+	if (status?.presence?.policyExtension === false) missing.push("bộ quy tắc phân quyền");
+	const prompts = status?.presence?.prompts ?? {};
+	const missingPrompts = Object.entries(prompts)
+		.filter(([, present]) => present === false)
+		.map(([role]) => roleLabel(role));
+	if (missingPrompts.length > 0) missing.push(`mô tả vai trò (${missingPrompts.join(", ")})`);
+	if (status?.presence?.paseoConfig === false) missing.push("cấu hình Paseo");
+	return missing;
+}
+
+/**
+ * Collection faults, said out loud. `degraded[]` exists so the UI never shows a
+ * confident-looking picture built from partial data — that promise is only kept
+ * if the wording is understandable.
+ */
+export function degradedSentence(degraded = [], pendingParents = 0) {
+	const parts = [];
+	const byReason = new Map();
+	for (const fault of degraded) {
+		byReason.set(fault.reason, (byReason.get(fault.reason) ?? 0) + 1);
+	}
+	if (byReason.has("PARENT_NOT_LISTED")) {
+		parts.push(`${byReason.get("PARENT_NOT_LISTED")} agent có người giao việc nằm ngoài danh sách này (thường là đã lưu trữ)`);
+	}
+	const unreachable = [...byReason.entries()]
+		.filter(([reason]) => reason !== "PARENT_NOT_LISTED" && reason !== "PERMIT_SHAPE_UNRECOGNIZED")
+		.reduce((sum, [, count]) => sum + count, 0);
+	if (unreachable > 0) parts.push(`${unreachable} mục không lấy được thông tin`);
+	if (byReason.has("PERMIT_SHAPE_UNRECOGNIZED")) parts.push("có yêu cầu xin phép không đọc được nội dung");
+	if (pendingParents > 0) parts.push(`đang dựng sơ đồ, còn ${pendingParents} agent chưa xếp xong`);
+	return parts.length === 0 ? "" : `Lưu ý: ${parts.join("; ")}.`;
+}

--- a/webui/public/index.html
+++ b/webui/public/index.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="vi">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Bảng điều khiển nhóm agent</title>
+		<link rel="stylesheet" href="/style.css" />
+	</head>
+	<body>
+		<header class="topbar">
+			<div class="brand">Nhóm agent</div>
+			<nav id="tabs" aria-label="Điều hướng chính">
+				<button data-tab="home" class="active">Trang chủ</button>
+				<button data-tab="graph">Nhóm agent</button>
+				<button data-tab="permissions">
+					Chờ duyệt<span id="permit-badge" class="badge hidden">0</span>
+				</button>
+				<button data-tab="chat">Trao đổi</button>
+				<button data-tab="roles" data-advanced>Vai trò</button>
+				<button data-tab="config" data-advanced>Cấu hình</button>
+			</nav>
+			<div class="status">
+				<label class="switch" title="Chế độ nâng cao hiện thêm phần chỉnh cấu hình và mô tả vai trò">
+					<input type="checkbox" id="advanced-toggle" />
+					<span>Chế độ nâng cao</span>
+				</label>
+				<span id="conn" class="conn">đang kết nối…</span>
+			</div>
+		</header>
+
+		<main>
+			<!-- ------------------------------------------------------------ -->
+			<section id="tab-home" class="tab active">
+				<div id="health" class="health">
+					<div class="health-icon" id="health-icon">…</div>
+					<div class="health-text">
+						<h1 id="health-headline">Đang kiểm tra hệ thống…</h1>
+						<p id="health-detail">Việc này mất khoảng vài giây.</p>
+					</div>
+					<div class="health-actions" id="health-actions"></div>
+				</div>
+
+				<div class="grid">
+					<article class="card stat">
+						<h2>Đang làm việc</h2>
+						<div class="stat-value" id="stat-running">–</div>
+						<p class="stat-hint">Agent đang thực sự chạy ngay lúc này.</p>
+					</article>
+					<article class="card stat">
+						<h2>Chờ bạn duyệt</h2>
+						<div class="stat-value" id="stat-permits">–</div>
+						<p class="stat-hint">Agent dừng lại vì cần bạn đồng ý.</p>
+					</article>
+					<article class="card stat">
+						<h2>Gặp lỗi</h2>
+						<div class="stat-value" id="stat-errors">–</div>
+						<p class="stat-hint">Agent dừng giữa chừng, cần xem lại.</p>
+					</article>
+					<article class="card stat">
+						<h2>Tổng số agent</h2>
+						<div class="stat-value" id="stat-total">–</div>
+						<p class="stat-hint">Gồm cả agent đang rảnh.</p>
+					</article>
+				</div>
+
+				<article class="card" id="setup-card">
+					<h2>Tình trạng cài đặt</h2>
+					<div id="setup-body" class="body">Đang kiểm tra…</div>
+				</article>
+
+				<details class="tech" data-advanced>
+					<summary>Kiểm tra kỹ thuật (preflight)</summary>
+					<div class="toolbar">
+						<button id="preflight-run">Chạy kiểm tra</button>
+						<span class="meta">Mất khoảng 30 giây vì phải hỏi từng nhà cung cấp mô hình.</span>
+					</div>
+					<div id="preflight-body" class="body">Chưa chạy lần nào.</div>
+				</details>
+			</section>
+
+			<!-- ------------------------------------------------------------ -->
+			<section id="tab-graph" class="tab">
+				<div class="toolbar">
+					<div class="segmented" role="group" aria-label="Kiểu hiển thị">
+						<button id="view-diagram" class="active">Sơ đồ</button>
+						<button id="view-list">Danh sách</button>
+					</div>
+					<button id="graph-refresh">Cập nhật</button>
+					<label class="check" data-advanced>
+						<input type="checkbox" id="graph-all" /> Hiện cả agent đã lưu trữ
+					</label>
+					<span id="graph-meta" class="meta"></span>
+				</div>
+
+				<p class="lead-in">
+					Sơ đồ đọc từ trái sang phải: người ở bên trái là người giao việc,
+					người bên phải là người nhận việc.
+				</p>
+
+				<div class="graph-wrap" id="diagram-wrap">
+					<svg id="graph" role="img" aria-label="Sơ đồ ai giao việc cho ai"></svg>
+					<aside id="node-drawer" class="drawer hidden" aria-label="Chi tiết agent">
+						<button id="drawer-close" class="close" aria-label="Đóng">×</button>
+						<div id="drawer-body"></div>
+					</aside>
+				</div>
+
+				<div id="list-wrap" class="hidden"><div id="agent-list"></div></div>
+
+				<div id="graph-degraded" class="notice hidden"></div>
+
+				<div class="legend">
+					<span><i class="swatch role-supervisor"></i>Giám sát</span>
+					<span><i class="swatch role-lead"></i>Trưởng nhóm</span>
+					<span><i class="swatch role-peer"></i>Thành viên</span>
+					<span><i class="swatch role-unknown"></i>Chưa rõ vai trò</span>
+					<span><i class="line solid"></i>giao việc</span>
+				</div>
+			</section>
+
+			<!-- ------------------------------------------------------------ -->
+			<section id="tab-permissions" class="tab">
+				<div class="toolbar">
+					<button id="permits-refresh">Cập nhật</button>
+					<span class="meta">Mỗi thẻ là một agent đang dừng lại chờ bạn trả lời.</span>
+				</div>
+				<div id="permits-body" class="body">Đang tải…</div>
+				<p class="footnote" data-advanced>
+					Đây là quyền cho <em>một hành động cụ thể, ngay lúc này</em>. Quyền chung
+					của từng vai trò nằm ở tab “Vai trò”.
+				</p>
+			</section>
+
+			<!-- ------------------------------------------------------------ -->
+			<section id="tab-chat" class="tab">
+				<div class="toolbar">
+					<select id="chat-room" aria-label="Chọn phòng"></select>
+					<button id="chat-load">Đọc tin nhắn</button>
+					<span class="meta">Nơi các agent trao đổi với nhau.</span>
+				</div>
+				<div id="chat-body" class="body">Đang tải…</div>
+			</section>
+
+			<!-- ------------------------------------------------------------ -->
+			<section id="tab-roles" class="tab">
+				<div class="toolbar">
+					<select id="role-select" aria-label="Chọn vai trò">
+						<option value="supervisor">Giám sát</option>
+						<option value="lead">Trưởng nhóm</option>
+						<option value="peer">Thành viên</option>
+					</select>
+					<button id="prompt-load">Tải lại</button>
+					<button id="prompt-save" class="primary">Lưu</button>
+					<span id="prompt-meta" class="meta"></span>
+				</div>
+				<p class="lead-in" id="role-hint"></p>
+				<textarea id="prompt-editor" spellcheck="false" aria-label="Mô tả vai trò"></textarea>
+				<article class="card">
+					<h2>Quyền chung của vai trò (chỉ xem)</h2>
+					<div class="body">
+						<p class="hint">
+							Đây là những gì một vai trò được phép làm nói chung. Nó do file
+							<code>extensions/paseo-team-policy.ts</code> và các biến môi trường
+							quyết định — sửa xong phải khởi động lại agent mới có hiệu lực.
+						</p>
+						<div id="env-table"></div>
+					</div>
+				</article>
+			</section>
+
+			<!-- ------------------------------------------------------------ -->
+			<section id="tab-config" class="tab">
+				<div class="notice warn">
+					Phần này sửa trực tiếp file cấu hình. Mỗi lần lưu đều tạo bản sao lưu
+					kèm thời gian, nhưng nếu không chắc thì đừng sửa.
+				</div>
+				<div class="toolbar">
+					<select id="config-section" aria-label="Chọn nhóm cấu hình">
+						<option value="providers">Nhà cung cấp mô hình</option>
+						<option value="routing">Định tuyến mô hình</option>
+						<option value="cluster">Nhiều máy (cluster)</option>
+						<option value="mcp">Công cụ MCP</option>
+					</select>
+					<button id="config-load">Tải lại</button>
+					<button id="config-save" class="primary">Lưu</button>
+					<span id="config-meta" class="meta"></span>
+				</div>
+				<textarea id="config-editor" spellcheck="false" aria-label="Nội dung cấu hình"></textarea>
+			</section>
+		</main>
+
+		<div id="toast" class="toast hidden" role="status" aria-live="polite"></div>
+		<script type="module" src="/app.js"></script>
+	</body>
+</html>

--- a/webui/public/style.css
+++ b/webui/public/style.css
@@ -1,0 +1,363 @@
+/*
+ * style.css
+ *
+ * Written for a reader who is not a developer: bigger type than a dev tool
+ * would use, real buttons instead of dense toolbars, and one obvious primary
+ * action per screen. Anything only a developer needs is marked [data-advanced]
+ * and stays hidden until "Chế độ nâng cao" is on.
+ */
+
+:root {
+	--bg: #0f1211;
+	--panel: #171b1a;
+	--panel-2: #1e2423;
+	--line: #2b3331;
+	--text: #e7edea;
+	--muted: #93a29e;
+	--accent: #5ad1a8;
+	--warn: #e8b552;
+	--danger: #e2695f;
+	--supervisor: #7aa2f7;
+	--lead: #5ad1a8;
+	--peer: #c99bf5;
+	--unknown: #78837f;
+	--mono: ui-monospace, "Cascadia Code", "JetBrains Mono", Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+body {
+	margin: 0;
+	background: var(--bg);
+	color: var(--text);
+	font: 15px/1.6 system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+/* Advanced-only affordances stay out of the way until asked for. */
+[data-advanced] { display: none; }
+body.advanced [data-advanced] { display: revert; }
+body.advanced nav [data-advanced] { display: inline-flex; }
+body.advanced label[data-advanced] { display: inline-flex; }
+
+.hidden { display: none !important; }
+
+/* --- top bar ------------------------------------------------------------ */
+
+.topbar {
+	display: flex;
+	align-items: center;
+	gap: 20px;
+	padding: 12px 20px;
+	background: var(--panel);
+	border-bottom: 1px solid var(--line);
+	position: sticky;
+	top: 0;
+	z-index: 5;
+	flex-wrap: wrap;
+}
+
+.brand { font-weight: 650; letter-spacing: 0.01em; color: var(--accent); font-size: 16px; }
+
+nav { display: flex; gap: 4px; flex: 1; flex-wrap: wrap; }
+
+nav button {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	background: transparent;
+	border: 1px solid transparent;
+	color: var(--muted);
+	padding: 8px 14px;
+	border-radius: 8px;
+	cursor: pointer;
+	font-size: 14.5px;
+}
+nav button:hover { color: var(--text); background: var(--panel-2); }
+nav button.active { color: var(--text); background: var(--panel-2); border-color: var(--line); }
+
+.badge {
+	background: var(--warn);
+	color: #171a19;
+	border-radius: 999px;
+	padding: 1px 8px;
+	font-size: 12.5px;
+	font-weight: 700;
+	min-width: 22px;
+	text-align: center;
+}
+
+.status { display: flex; align-items: center; gap: 16px; font-size: 13px; color: var(--muted); }
+
+.switch { display: inline-flex; align-items: center; gap: 7px; cursor: pointer; user-select: none; }
+.switch input { width: 16px; height: 16px; accent-color: var(--accent); }
+
+.conn::before {
+	content: "";
+	display: inline-block;
+	width: 8px; height: 8px;
+	border-radius: 50%;
+	margin-right: 7px;
+	background: var(--unknown);
+	vertical-align: middle;
+}
+.conn.ok::before { background: var(--accent); }
+.conn.busy::before { background: var(--warn); }
+.conn.err::before { background: var(--danger); }
+
+main { padding: 20px; max-width: 1400px; margin: 0 auto; }
+.tab { display: none; }
+.tab.active { display: block; }
+
+/* --- health banner ------------------------------------------------------ */
+
+.health {
+	display: flex;
+	align-items: center;
+	gap: 18px;
+	padding: 20px 22px;
+	border-radius: 14px;
+	border: 1px solid var(--line);
+	background: var(--panel);
+	margin-bottom: 18px;
+}
+.health-icon {
+	width: 46px; height: 46px;
+	flex: 0 0 46px;
+	border-radius: 50%;
+	display: grid;
+	place-items: center;
+	font-size: 24px;
+	font-weight: 700;
+	background: var(--panel-2);
+	color: var(--muted);
+}
+.health.good { border-color: color-mix(in srgb, var(--accent) 45%, var(--line)); }
+.health.good .health-icon { background: color-mix(in srgb, var(--accent) 22%, transparent); color: var(--accent); }
+.health.attention { border-color: color-mix(in srgb, var(--warn) 55%, var(--line)); }
+.health.attention .health-icon { background: color-mix(in srgb, var(--warn) 22%, transparent); color: var(--warn); }
+.health.bad { border-color: color-mix(in srgb, var(--danger) 55%, var(--line)); }
+.health.bad .health-icon { background: color-mix(in srgb, var(--danger) 22%, transparent); color: var(--danger); }
+
+.health-text { flex: 1; min-width: 220px; }
+.health-text h1 { margin: 0; font-size: 20px; font-weight: 640; }
+.health-text p { margin: 4px 0 0; color: var(--muted); font-size: 14px; }
+
+/* --- cards -------------------------------------------------------------- */
+
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 12px; margin-bottom: 18px; }
+
+.card {
+	background: var(--panel);
+	border: 1px solid var(--line);
+	border-radius: 12px;
+	padding: 16px 18px;
+	margin-bottom: 14px;
+}
+.card h2 { margin: 0 0 10px; font-size: 12.5px; text-transform: uppercase; letter-spacing: 0.09em; color: var(--muted); font-weight: 600; }
+
+.stat { margin-bottom: 0; }
+.stat-value { font-size: 34px; font-weight: 650; line-height: 1.1; }
+.stat-hint { margin: 6px 0 0; color: var(--muted); font-size: 12.5px; }
+
+.body { font-size: 14px; }
+.hint { color: var(--muted); font-size: 13.5px; }
+.lead-in { color: var(--muted); font-size: 13.5px; margin: 0 0 12px; }
+.footnote { color: var(--muted); font-size: 13px; margin-top: 18px; }
+
+.tech { margin-top: 8px; }
+.tech > summary { cursor: pointer; color: var(--muted); font-size: 13.5px; padding: 6px 0; }
+
+/* --- controls ----------------------------------------------------------- */
+
+.toolbar { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; flex-wrap: wrap; }
+.meta { color: var(--muted); font-size: 13px; }
+.check { display: inline-flex; align-items: center; gap: 7px; color: var(--muted); font-size: 13.5px; cursor: pointer; }
+
+button, select, input[type="text"] {
+	background: var(--panel-2);
+	color: var(--text);
+	border: 1px solid var(--line);
+	border-radius: 8px;
+	padding: 8px 14px;
+	font-size: 14px;
+	font-family: inherit;
+	cursor: pointer;
+}
+button:hover:not(:disabled), select:hover { border-color: #3c4644; }
+button:focus-visible, select:focus-visible, textarea:focus-visible, input:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+button.big { padding: 11px 22px; font-size: 15px; font-weight: 600; }
+button.primary { border-color: var(--accent); color: #10201a; background: var(--accent); }
+button.primary:hover:not(:disabled) { background: #6ee0b8; }
+button.danger { border-color: var(--danger); color: var(--danger); background: transparent; }
+button.danger:hover:not(:disabled) { background: color-mix(in srgb, var(--danger) 16%, transparent); }
+button:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.segmented { display: inline-flex; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+.segmented button { border: none; border-radius: 0; background: transparent; color: var(--muted); }
+.segmented button.active { background: var(--panel-2); color: var(--text); }
+
+textarea {
+	width: 100%;
+	min-height: 44vh;
+	background: var(--panel);
+	color: var(--text);
+	border: 1px solid var(--line);
+	border-radius: 10px;
+	padding: 14px;
+	font-family: var(--mono);
+	font-size: 13px;
+	line-height: 1.6;
+	resize: vertical;
+}
+textarea.drawer-input { min-height: 110px; font-family: inherit; font-size: 14px; margin: 8px 0 10px; }
+
+/* --- tables ------------------------------------------------------------- */
+
+table { width: 100%; border-collapse: collapse; font-size: 13.5px; }
+th, td { text-align: left; padding: 9px 10px; border-bottom: 1px solid var(--line); vertical-align: top; }
+th { color: var(--muted); font-weight: 500; }
+code, .v { font-family: var(--mono); font-size: 12.5px; }
+.k { color: var(--muted); }
+.ok { color: var(--accent); }
+.no { color: var(--danger); }
+
+table.list tr:hover td { background: var(--panel-2); }
+table.list .row-error td { background: color-mix(in srgb, var(--danger) 8%, transparent); }
+
+.dot-role { display: inline-block; width: 9px; height: 9px; border-radius: 50%; margin-right: 9px; vertical-align: middle; }
+.dot-role.supervisor { background: var(--supervisor); }
+.dot-role.lead { background: var(--lead); }
+.dot-role.peer { background: var(--peer); }
+.dot-role.unknown { background: var(--unknown); }
+
+.pill {
+	display: inline-block;
+	margin-left: 10px;
+	padding: 1px 9px;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--warn) 22%, transparent);
+	color: var(--warn);
+	font-size: 12px;
+	font-weight: 600;
+}
+
+/* --- graph -------------------------------------------------------------- */
+
+.graph-wrap { position: relative; border: 1px solid var(--line); border-radius: 12px; background: var(--panel); overflow: auto; }
+#graph { width: 100%; display: block; }
+.node-box { cursor: pointer; }
+.node-box:hover .node-rect { stroke-width: 3; }
+.node-label { font: 12px var(--mono); fill: var(--text); pointer-events: none; }
+.node-sub { font: 11px system-ui, sans-serif; fill: var(--muted); pointer-events: none; }
+.edge { fill: none; stroke: #46534f; stroke-width: 1.6; }
+.edge.message { stroke: var(--warn); stroke-dasharray: 5 4; }
+.badge-permit { fill: var(--warn); }
+.badge-text { font: 11px var(--mono); font-weight: 700; fill: #171a19; }
+
+.drawer {
+	position: absolute; top: 0; right: 0; width: min(430px, 92%); height: 100%;
+	background: var(--panel-2); border-left: 1px solid var(--line);
+	padding: 18px 20px; overflow: auto;
+}
+.drawer h3 { margin: 0 26px 2px 0; font-size: 17px; }
+.drawer h4 { margin: 20px 0 0; font-size: 13px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.drawer-sub { margin: 0 0 10px; color: var(--muted); font-size: 13.5px; }
+.close { position: absolute; top: 10px; right: 12px; background: transparent; border: none; font-size: 22px; color: var(--muted); padding: 2px 8px; }
+
+.legend { display: flex; gap: 18px; flex-wrap: wrap; margin-top: 12px; font-size: 13px; color: var(--muted); align-items: center; }
+.swatch { display: inline-block; width: 11px; height: 11px; border-radius: 3px; margin-right: 7px; vertical-align: middle; }
+.swatch.role-supervisor { background: var(--supervisor); }
+.swatch.role-lead { background: var(--lead); }
+.swatch.role-peer { background: var(--peer); }
+.swatch.role-unknown { background: var(--unknown); }
+.line { display: inline-block; width: 24px; height: 0; border-top: 2px solid #46534f; margin-right: 7px; vertical-align: middle; }
+
+/* --- notices, permits, empty states ------------------------------------- */
+
+.notice {
+	margin-top: 12px;
+	padding: 11px 14px;
+	border-radius: 10px;
+	border: 1px solid color-mix(in srgb, var(--warn) 45%, var(--line));
+	background: color-mix(in srgb, var(--warn) 9%, transparent);
+	color: var(--warn);
+	font-size: 13.5px;
+}
+.notice.warn { margin: 0 0 14px; }
+
+.permit {
+	position: relative;
+	border: 1px solid var(--line);
+	border-left: 4px solid var(--unknown);
+	border-radius: 12px;
+	padding: 18px 20px;
+	margin-bottom: 14px;
+	background: var(--panel);
+}
+.permit.risk-high { border-left-color: var(--danger); }
+.permit.risk-medium { border-left-color: var(--warn); }
+.permit.risk-low { border-left-color: var(--accent); }
+.permit.unclassified { border-left-color: var(--warn); }
+
+.risk-tag {
+	position: absolute; top: 16px; right: 18px;
+	font-size: 12px; font-weight: 600; color: var(--muted);
+	border: 1px solid var(--line); border-radius: 999px; padding: 2px 10px;
+}
+.risk-high .risk-tag { color: var(--danger); border-color: color-mix(in srgb, var(--danger) 45%, var(--line)); }
+.risk-medium .risk-tag { color: var(--warn); border-color: color-mix(in srgb, var(--warn) 45%, var(--line)); }
+
+.permit-headline { margin: 0 120px 12px 0; font-size: 16px; font-weight: 600; line-height: 1.45; }
+.permit-actions { display: flex; gap: 10px; margin-top: 16px; }
+.permit p { margin: 6px 0; }
+.permit pre, .error-block pre, .tech pre {
+	margin: 8px 0 0; background: var(--bg); padding: 10px 12px; border-radius: 8px;
+	overflow: auto; font-size: 12px; white-space: pre-wrap; word-break: break-word;
+}
+.permit details summary, .error-block details summary { cursor: pointer; color: var(--muted); font-size: 13px; margin-top: 10px; }
+
+.facts { display: grid; grid-template-columns: max-content 1fr; gap: 4px 16px; margin: 0; font-size: 13.5px; }
+.facts dt { color: var(--muted); }
+.facts dd { margin: 0; word-break: break-word; }
+
+.empty { text-align: center; padding: 48px 20px; color: var(--muted); }
+.empty-icon {
+	width: 52px; height: 52px; margin: 0 auto 14px;
+	border-radius: 50%; display: grid; place-items: center;
+	background: color-mix(in srgb, var(--accent) 16%, transparent);
+	color: var(--accent); font-size: 26px;
+}
+.empty p { margin: 4px 0; }
+
+.error-block {
+	border: 1px solid color-mix(in srgb, var(--danger) 45%, var(--line));
+	background: color-mix(in srgb, var(--danger) 8%, transparent);
+	border-radius: 10px;
+	padding: 14px 16px;
+}
+.error-block p { margin: 6px 0 0; color: var(--text); font-size: 13.5px; }
+
+.message { border: 1px solid var(--line); border-radius: 10px; padding: 12px 14px; margin-bottom: 10px; background: var(--panel); }
+.message .meta { margin-bottom: 6px; }
+
+.cmd { font-family: var(--mono); font-size: 11.5px; color: var(--muted); margin-top: 16px; word-break: break-all; }
+
+/* --- toast -------------------------------------------------------------- */
+
+.toast {
+	position: fixed; bottom: 22px; left: 50%; transform: translateX(-50%);
+	background: var(--panel-2); border: 1px solid var(--line); border-radius: 10px;
+	padding: 13px 20px; font-size: 14px; max-width: min(80ch, 92vw); z-index: 20;
+	box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+}
+.toast.err { border-color: var(--danger); color: var(--danger); }
+
+@media (max-width: 700px) {
+	.topbar { gap: 10px; }
+	.status { width: 100%; justify-content: space-between; }
+	.permit-headline { margin-right: 0; }
+	.risk-tag { position: static; display: inline-block; margin-bottom: 10px; }
+}

--- a/webui/server.mjs
+++ b/webui/server.mjs
@@ -1,0 +1,464 @@
+/**
+ * server.mjs — the WebUI transport. It owns no truth.
+ *
+ * The whole contract of this file: an HTTP request is mapped onto a fixed
+ * `paseo-team` argv template, the CLI is spawned, and its stdout is returned
+ * verbatim. This file must never read a config file, never call `paseo`, and
+ * never merge, patch or synthesize a response. If you find yourself wanting to
+ * "just" compute something here, it belongs in the CLI — that is what makes
+ * the UI reproducible from a terminal.
+ *
+ * Two things it *is* allowed to do, because neither invents data:
+ *   - cache a CLI response verbatim for a few seconds (see CACHEABLE), and
+ *   - collapse concurrent identical requests into one spawn (single-flight).
+ * Both exist because one paseo round trip costs ~3s; without them, three open
+ * browser tabs would triple the load on the daemon for identical answers.
+ *
+ * Security posture — this UI can approve permission requests and rewrite
+ * config, so it is treated as privileged even on localhost:
+ *   - binds 127.0.0.1 only;
+ *   - /api/* requires a per-run bearer token, handed to the SPA through the
+ *     URL fragment (a fragment is never sent to a server and never lands in an
+ *     access log);
+ *   - Origin/Host are checked, which is what stops a DNS-rebinding page in
+ *     another tab from driving this API;
+ *   - no CORS headers are ever emitted.
+ */
+
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join, dirname, normalize, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(HERE, "..");
+const PUBLIC_DIR = join(HERE, "public");
+const CLI = join(ROOT, "cli", "paseo-team.mjs");
+
+export const DEFAULT_PORT = 4321;
+export const MAX_BODY_BYTES = 4 * 1024 * 1024;
+
+// --- request -> argv -------------------------------------------------------
+
+const CONFIG_SECTIONS = ["providers", "routing", "cluster", "mcp", "paseo"];
+const ROLES = ["supervisor", "lead", "peer"];
+const AGENT_REF = /^[0-9a-fA-F][0-9a-fA-F-]{5,63}$/;
+const TOKEN_LIKE = /^[A-Za-z0-9._:-]{1,128}$/;
+const SKILL_NAME = /^[A-Za-z0-9._-]{1,64}$/;
+
+class RouteError extends Error {
+	constructor(status, code, message) {
+		super(message);
+		this.status = status;
+		this.code = code;
+	}
+}
+
+function pick(value, allowed, label) {
+	if (!allowed.includes(value)) {
+		throw new RouteError(400, "PARAM_INVALID", `${label} must be one of: ${allowed.join(", ")}`);
+	}
+	return value;
+}
+
+function match(value, pattern, label) {
+	if (typeof value !== "string" || !pattern.test(value)) {
+		throw new RouteError(400, "PARAM_INVALID", `${label} is missing or malformed`);
+	}
+	return value;
+}
+
+/**
+ * The complete set of things the browser can ask for. A request that does not
+ * match a key here is a 404 — there is no dynamic argv assembly, and no path
+ * from user input to a command name.
+ */
+export const ROUTES = {
+	"GET /api/status": { build: () => ({ args: ["status"] }), cacheMs: 2_000 },
+	// Preflight probes providers and models: ~25-30s on the reference machine,
+	// and slower still when a graph poll is competing for the same daemon. It
+	// gets its own timeout and a long TTL because its answer barely moves.
+	"GET /api/preflight": { build: () => ({ args: ["preflight", "--json"] }), cacheMs: 60_000, timeoutMs: 180_000 },
+	"GET /api/env": { build: () => ({ args: ["env", "list"] }), cacheMs: 10_000 },
+
+	"GET /api/agents": {
+		build: (q) => ({ args: q.all === "1" ? ["agents", "--all"] : ["agents"] }),
+		cacheMs: 4_000,
+	},
+	"GET /api/agent": {
+		build: (q) => ({ args: ["agent", "inspect", match(q.id, AGENT_REF, "id")] }),
+		cacheMs: 4_000,
+	},
+	"POST /api/agent/send": {
+		build: (q, body) => ({
+			args: ["agent", "send", match(body?.agentId, AGENT_REF, "agentId")],
+			stdin: String(body?.prompt ?? ""),
+		}),
+	},
+
+	"GET /api/graph": {
+		build: (q) => ({
+			args: [
+				"graph",
+				...(q.all === "1" ? ["--all"] : []),
+				...(q.maxInspect ? ["--max-inspect", match(q.maxInspect, /^\d{1,3}$/, "maxInspect")] : []),
+			],
+		}),
+		// Slightly under the UI's poll interval so a poll usually gets a fresh
+		// snapshot rather than the same one twice.
+		cacheMs: 4_000,
+	},
+
+	"GET /api/permits": { build: () => ({ args: ["permits", "list"] }), cacheMs: 3_000 },
+	"POST /api/permits/decide": {
+		build: (q, body) => ({
+			args: [
+				"permits",
+				pick(body?.action, ["allow", "deny"], "action"),
+				match(body?.agentId, AGENT_REF, "agentId"),
+				match(body?.requestId, TOKEN_LIKE, "requestId"),
+			],
+		}),
+	},
+
+	"GET /api/config": {
+		build: (q) => ({ args: ["config", "read", pick(q.section, CONFIG_SECTIONS, "section")] }),
+	},
+	"POST /api/config": {
+		build: (q, body, raw) => ({
+			args: ["config", "write", pick(q.section, CONFIG_SECTIONS, "section")],
+			stdin: raw,
+		}),
+	},
+	"GET /api/prompts": {
+		build: (q) => ({ args: ["prompts", "read", pick(q.role, ROLES, "role")] }),
+	},
+	"POST /api/prompts": {
+		build: (q, body) => ({
+			args: ["prompts", "write", pick(q.role, ROLES, "role")],
+			stdin: String(body?.content ?? ""),
+		}),
+	},
+	"GET /api/skills": { build: () => ({ args: ["skills", "list"] }), cacheMs: 5_000 },
+	"GET /api/skill": {
+		build: (q) => ({ args: ["skills", "read", match(q.name, SKILL_NAME, "name")] }),
+	},
+	"POST /api/skill": {
+		build: (q, body) => ({
+			args: ["skills", "write", match(body?.name, SKILL_NAME, "name")],
+			stdin: String(body?.content ?? ""),
+		}),
+	},
+
+	"GET /api/chat": { build: () => ({ args: ["chat", "list"] }), cacheMs: 5_000 },
+	"GET /api/chat/read": {
+		build: (q) => ({
+			args: ["chat", "read", match(q.room, TOKEN_LIKE, "room"), ...(q.limit ? ["--limit", match(q.limit, /^\d{1,4}$/, "limit")] : [])],
+		}),
+		cacheMs: 2_000,
+	},
+	"POST /api/chat/post": {
+		build: (q, body) => ({
+			args: ["chat", "post", match(body?.room, TOKEN_LIKE, "room")],
+			stdin: String(body?.message ?? ""),
+		}),
+	},
+
+	"GET /api/watchdog": { build: () => ({ args: ["watchdog"] }), cacheMs: 10_000 },
+};
+
+// --- CLI invocation --------------------------------------------------------
+
+/**
+ * Spawn the CLI. `shell: false` is the whole point: argv elements travel as
+ * argv, so no quoting rule anywhere can turn a config value into a command.
+ */
+export function runCli(args, stdin = null, options = {}) {
+	return new Promise((resolve) => {
+		const child = spawn(process.execPath, [CLI, ...args], {
+			cwd: ROOT,
+			env: process.env,
+			shell: false,
+			windowsHide: true,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		let out = "";
+		let err = "";
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (!settled) {
+				child.kill();
+				settled = true;
+				resolve({ exitCode: null, stdout: "", stderr: "paseo-team timed out", timedOut: true });
+			}
+		}, options.timeoutMs ?? 60_000);
+		child.stdout.on("data", (chunk) => { out += chunk; });
+		child.stderr.on("data", (chunk) => { err += chunk; });
+		child.on("error", (error) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolve({ exitCode: null, stdout: "", stderr: String(error?.message ?? error) });
+		});
+		child.on("close", (code) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolve({ exitCode: code, stdout: out, stderr: err });
+		});
+		if (stdin !== null) child.stdin.end(stdin, "utf8");
+		else child.stdin.end();
+	});
+}
+
+// --- cache + single flight -------------------------------------------------
+
+export function createCache() {
+	const entries = new Map();
+	const inflight = new Map();
+	return {
+		async run(key, ttlMs, producer) {
+			const now = Date.now();
+			const hit = entries.get(key);
+			if (hit && ttlMs > 0 && now - hit.at < ttlMs) return { ...hit.value, cached: true, ageMs: now - hit.at };
+			const pending = inflight.get(key);
+			if (pending) return { ...(await pending), coalesced: true };
+			const promise = producer().finally(() => inflight.delete(key));
+			inflight.set(key, promise);
+			const value = await promise;
+			// Only successful answers are cached: caching a failure would keep
+			// showing a stale error after the daemon came back.
+			if (value.exitCode === 0) entries.set(key, { at: Date.now(), value });
+			return value;
+		},
+		clear() { entries.clear(); },
+		size() { return entries.size; },
+	};
+}
+
+// --- HTTP plumbing ---------------------------------------------------------
+
+function safeEqual(a, b) {
+	const left = Buffer.from(String(a));
+	const right = Buffer.from(String(b));
+	if (left.length !== right.length) return false;
+	return timingSafeEqual(left, right);
+}
+
+export function bearerToken(req) {
+	const header = req.headers?.authorization ?? "";
+	const match = /^Bearer\s+(.+)$/i.exec(String(header).trim());
+	return match ? match[1] : null;
+}
+
+/**
+ * A browser will not let a cross-origin page set an Authorization header, so
+ * the token already blocks CSRF. The Host check closes the other door: a
+ * rebound DNS name resolving to 127.0.0.1 arrives with a Host that is not
+ * localhost, and is refused before any argv is built.
+ */
+export function isAllowedHost(req, port) {
+	const host = String(req.headers?.host ?? "");
+	const allowed = new Set([
+		`127.0.0.1:${port}`,
+		`localhost:${port}`,
+		`[::1]:${port}`,
+	]);
+	if (!allowed.has(host)) return false;
+	const origin = req.headers?.origin;
+	if (origin === undefined) return true;
+	return [`http://127.0.0.1:${port}`, `http://localhost:${port}`, `http://[::1]:${port}`].includes(String(origin));
+}
+
+function readBody(req) {
+	return new Promise((resolve, reject) => {
+		let size = 0;
+		const chunks = [];
+		req.on("data", (chunk) => {
+			size += chunk.length;
+			if (size > MAX_BODY_BYTES) {
+				reject(new RouteError(413, "BODY_TOO_LARGE", `request body exceeds ${MAX_BODY_BYTES} bytes`));
+				req.destroy();
+				return;
+			}
+			chunks.push(chunk);
+		});
+		req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+		req.on("error", reject);
+	});
+}
+
+const MIME = {
+	".html": "text/html; charset=utf-8",
+	".js": "text/javascript; charset=utf-8",
+	".css": "text/css; charset=utf-8",
+	".svg": "image/svg+xml",
+	".json": "application/json; charset=utf-8",
+};
+
+async function serveStatic(pathname, res) {
+	const requested = pathname === "/" ? "/index.html" : pathname;
+	// normalize() then a prefix check: the classic ../ escape has to fail
+	// before readFile ever sees the path.
+	const resolved = join(PUBLIC_DIR, normalize(requested).replace(/^([/\\])+/, ""));
+	if (!resolved.startsWith(PUBLIC_DIR + sep)) {
+		res.writeHead(403, { "content-type": "text/plain" });
+		res.end("forbidden");
+		return;
+	}
+	try {
+		const body = await readFile(resolved);
+		const ext = resolved.slice(resolved.lastIndexOf("."));
+		res.writeHead(200, {
+			"content-type": MIME[ext] ?? "application/octet-stream",
+			"cache-control": "no-store",
+			// The SPA is entirely self-contained; nothing it renders should be
+			// able to pull in a remote script.
+			"content-security-policy": "default-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'",
+			"x-content-type-options": "nosniff",
+		});
+		res.end(body);
+	} catch {
+		res.writeHead(404, { "content-type": "text/plain" });
+		res.end("not found");
+	}
+}
+
+function sendJson(res, status, payload) {
+	const body = JSON.stringify(payload);
+	res.writeHead(status, {
+		"content-type": "application/json; charset=utf-8",
+		"cache-control": "no-store",
+		"x-content-type-options": "nosniff",
+	});
+	res.end(body);
+}
+
+/**
+ * Handle one /api request. Exported and dependency-injected so the contract
+ * (auth, route allowlist, argv shape) is testable without a socket.
+ */
+export async function handleApi({ method, pathname, query, rawBody, exec }) {
+	const key = `${method} ${pathname}`;
+	const route = ROUTES[key];
+	if (!route) throw new RouteError(404, "NO_ROUTE", `no route for ${key}`);
+	let body = null;
+	if (method === "POST" && rawBody) {
+		try {
+			body = JSON.parse(rawBody);
+		} catch {
+			// config write posts a raw JSON document; every other POST posts an
+			// envelope. An unparseable envelope is only an error for the latter.
+			body = null;
+		}
+	}
+	const { args, stdin = null } = route.build(query, body, rawBody ?? "");
+	return { route, args, stdin, result: await exec(args, stdin, route) };
+}
+
+export async function startServer(options = {}) {
+	const port = Number.isInteger(options.port) ? options.port : DEFAULT_PORT;
+	const requireToken = options.requireToken !== false;
+	const token = requireToken ? (options.token ?? randomBytes(24).toString("base64url")) : null;
+	const cache = options.cache ?? createCache();
+	const exec = options.runCli ?? runCli;
+	// Resolved after listen(): port 0 asks the OS to choose, and the Host
+	// check must compare against the port actually bound, not the request.
+	let boundPort = port;
+
+	const server = createServer(async (req, res) => {
+		const url = new URL(req.url ?? "/", `http://127.0.0.1:${boundPort}`);
+		const query = Object.fromEntries(url.searchParams.entries());
+		try {
+			if (!isAllowedHost(req, boundPort)) {
+				sendJson(res, 403, { ok: false, code: "HOST_NOT_ALLOWED", message: "this server only answers to localhost" });
+				return;
+			}
+			if (!url.pathname.startsWith("/api/")) {
+				await serveStatic(url.pathname, res);
+				return;
+			}
+			if (requireToken && !safeEqual(bearerToken(req) ?? "", token)) {
+				sendJson(res, 401, { ok: false, code: "UNAUTHORIZED", message: "missing or invalid bearer token" });
+				return;
+			}
+			const rawBody = req.method === "POST" ? await readBody(req) : "";
+			const { args, result } = await handleApi({
+				method: req.method ?? "GET",
+				pathname: url.pathname,
+				query,
+				rawBody,
+				exec: (argv, stdin, route) => {
+					const ttl = req.method === "GET" ? (route.cacheMs ?? 0) : 0;
+					const key = `${argv.join(" ")}`;
+					const options = route.timeoutMs ? { timeoutMs: route.timeoutMs } : {};
+					return ttl > 0
+						? cache.run(key, ttl, () => exec(argv, stdin, options))
+						: exec(argv, stdin, options);
+				},
+			});
+			if (req.method === "POST") cache.clear(); // a write invalidates every read
+			if (result.exitCode !== 0) {
+				sendJson(res, 502, {
+					ok: false,
+					code: "CLI_FAILED",
+					command: ["paseo-team", ...args].join(" "),
+					exitCode: result.exitCode,
+					stderr: result.stderr?.slice(0, 4000) ?? "",
+					stdout: result.stdout?.slice(0, 4000) ?? "",
+				});
+				return;
+			}
+			let parsed;
+			try {
+				parsed = JSON.parse(result.stdout);
+			} catch {
+				sendJson(res, 502, {
+					ok: false,
+					code: "CLI_OUTPUT_NOT_JSON",
+					command: ["paseo-team", ...args].join(" "),
+					stdout: result.stdout.slice(0, 4000),
+				});
+				return;
+			}
+			// `command` travels with every answer so the UI can show exactly
+			// which CLI call produced what is on screen.
+			sendJson(res, 200, {
+				ok: true,
+				command: ["paseo-team", ...args].join(" "),
+				cached: Boolean(result.cached),
+				ageMs: result.ageMs ?? 0,
+				data: parsed,
+			});
+		} catch (error) {
+			const status = error instanceof RouteError ? error.status : 500;
+			sendJson(res, status, {
+				ok: false,
+				code: error?.code ?? "SERVER_ERROR",
+				message: String(error?.message ?? error),
+			});
+		}
+	});
+
+	await new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(port, "127.0.0.1", resolve);
+	});
+	boundPort = server.address()?.port ?? port;
+
+	const base = `http://127.0.0.1:${boundPort}/`;
+	const url = token ? `${base}#token=${token}` : base;
+	if (!options.quiet) {
+		process.stdout.write(`paseo-team web: ${url}\n`);
+		if (!token) {
+			process.stdout.write("paseo-team web: WARNING — running with --no-token; anything on this machine can approve permissions through this port\n");
+		}
+	}
+	if (options.open) {
+		const opener = process.platform === "win32" ? ["cmd", ["/c", "start", "", url]] : process.platform === "darwin" ? ["open", [url]] : ["xdg-open", [url]];
+		spawn(opener[0], opener[1], { detached: true, stdio: "ignore", windowsHide: true }).unref();
+	}
+	return { server, port: boundPort, token, url, close: () => new Promise((resolve) => server.close(resolve)) };
+}


### PR DESCRIPTION
## Plan
`TASK_STATE.md` (anchor + log, commit trong PR này)

## Đã làm
- **CLI là nguồn sự thật**: `cli/paseo-team.mjs` với config plane (config/prompts/skills/env read+write, install, preflight wrap `scripts/preflight.mjs` tái sử dụng không copy logic) và live plane (agents, agent inspect|send, permits list/allow/deny, chat, graph, watchdog, web). Mọi output JSON.
- **`cli/lib/`**: `config-walker` (resolve path + backup + atomic write), `paseo-bridge` (nơi duy nhất spawn `paseo`, timeout riêng), `graph-cache` (cây spawn cache TTL 15' vì `paseo ls` không có parent), `graph`.
- **WebUI extension**: `webui/server.mjs` zero-dep chỉ proxy sang spawn CLI + SPA 6 tab (Dashboard, Team graph, Permissions, Roles, Config, Chat). Không đụng file trực tiếp. Token bearer per-run (qua URL fragment), bind 127.0.0.1, check Origin/Host chống DNS rebinding.
- **`docs/webui-architecture.md`**: contract CLI↔WebUI + schema graph + lộ trình PR-1..PR-5.
- **Tên ngắn + cài từ GitHub**: bin `pteam` (giữ alias `paseo-team`), README có mục chạy thẳng từ GitHub (`npx --package github:Minnyat/paseo-pi-team pteam ...` / `npm i -g github:Minnyat/paseo-pi-team`), zero runtime deps nên không cần build.

## Test
- 5 test file mới viết cùng tính năng (trước PR: 0 test cho CLI/webui): `cli-contract`, `webui-server`, `graph`, `paseo-bridge`, `humanize` + fixture `fake-paseo-live`.
- `npm test` **18/18 pass**, `npm run typecheck` sạch (chạy lại trên branch này trước khi mở PR).
- Secret scan trên `cli/ webui/ test/ docs/`: sạch.

## Verify end-to-end
- `pteam web` chạy thật tại `http://127.0.0.1:4321`: `GET /` → 200 (SPA), `/api/status` → JSON đúng contract (server spawn `paseo-team status` phía sau, thấy đúng cây `~/.pi`, `~/.paseo` của máy).
- Theo log TASK_STATE (2026-08-21): verify với daemon local thật — 21 agent, 7 cạnh spawn, render trong Chrome; đo chi phí thật mỗi lệnh `paseo` ~3–3.5s, graph lạnh ~12s / ấm ~3.8s, preflight ~25–30s (timeout riêng 180s).
- `npm pack --dry-run`: tarball chứa đủ `cli/` + `webui/` (82 files) → cài qua `github:` hoạt động.

## Lệch so với plan
- MVP gộp PR-1 + PR-2 làm một (đã quyết định trong TASK_STATE, log 2026-08-21).
- Thêm scope 2026-08-22 theo yêu cầu user: bin ngắn `pteam` + docs cài trực tiếp từ GitHub.
- Chưa có (đã biết, để PR sau — xem PR-4/PR-5 trong `docs/webui-architecture.md`): cạnh message giữa agent (`graph --with-logs`, parse `PEER_MESSAGE_V1`) và multi-host.
