### PR TITLE
fix(pack): explicit files allowlist — silence npm install warning, drop dev files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paseo-pi-team",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "description": "Paseo/pi multi-agent role pack — policy extension, role prompts, support scripts.",
   "type": "module",
@@ -9,6 +9,18 @@
     "type": "git",
     "url": "github:Minnyat/paseo-pi-team"
   },
+  "files": [
+    "cli",
+    "scripts",
+    "webui",
+    "prompts",
+    "skills",
+    "extensions",
+    "templates",
+    "config",
+    "examples",
+    "docs"
+  ],
   "bin": {
     "pteam": "cli/paseo-team.mjs",
     "paseo-team": "cli/paseo-team.mjs"


### PR DESCRIPTION
## Plan
User chạy `npm install -g github:Minnyat/paseo-pi-team` thấy warning "No .npmignore file found, using .gitignore for file exclusion"; bản cài còn kèm cả test/, tsconfig.ci.json, TASK_STATE.md.

## Đã làm
- Thêm `files` allowlist trong package.json: đúng những gì CLI cần khi chạy (cli, scripts, webui, prompts, skills, extensions, templates, config, examples, docs). README/LICENSE/package.json npm luôn tự kèm.
- Kết quả: warning mất, tarball 82 → 49 file, không còn file dev trong bản phát hành.
- Bump 1.1.2 (packaging fix = PATCH theo quy tắc SemVer đã chốt).

## Test
- `npm pack --dry-run`: không còn warning; cli/, webui/, scripts/preflight, prompts/ vẫn đủ.
- `npm test` 19/19, typecheck sạch.

## Verify end-to-end
- Bản global 1.1.1 user vừa cài đã verify chạy tốt (`pteam --version` = 1.1.1, `pteam status` đọc đúng ~/.pi) — thay đổi này chỉ ảnh hưởng *file list* của bản phát hành tiếp theo, không đổi code.

## Lệch so với plan
- Không có. Sau merge push tag `v1.1.2`.