### PR TITLE
feat(webui): schema-driven config forms for Paseo and Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ split is by whether a repeat can duplicate work:
 | `send`, `run` | **never** — delivery ambiguity would duplicate the message or task |
 | usage / authority / model / workspace / endpoint / malformed request | **never** — fails immediately |
 
+Model-API transient errors (overloaded, rate limit, 5xx, timeout) are retried
+by Pi itself per its `settings.retry` policy (defaults: 3 attempts, 2s base
+delay). The WebUI's **Pi — cấu hình chính** editor tunes that policy without
+reading Pi's docs — including a one-click preset for unstable providers — via
+`pteam config read/write pi-settings` (`~/.pi/agent/settings.json`). Changes
+take effect for agent sessions started after the save.
+
 ## OpenCodeReview delegation (Phase 1)
 
 `paseo-ocr-reviewer` is a strictly read-only Reviewer Peer skill.

--- a/cli/lib/config-schema.mjs
+++ b/cli/lib/config-schema.mjs
@@ -1,0 +1,453 @@
+/**
+ * config-schema.mjs — form metadata for every config section the WebUI edits.
+ *
+ * The UI renders forms from these tables and from nothing else: a field the
+ * CLI did not describe cannot appear on screen, so what the browser shows is
+ * always reproducible from a terminal. Labels and hints are Vietnamese
+ * because the WebUI's audience is; keys, paths and enums stay verbatim.
+ *
+ * Field shapes (paths are dot-separated; map item paths are relative to the
+ * item object):
+ *   scalar: { path, type: bool|number|string|enum, label, hint?, default?,
+ *             min?, max?, enum? }
+ *   lines:  { path, type: "lines" }            one string per textarea line
+ *   kv:     { path, type: "kv" }               object of string -> string
+ *   map:    { path, type: "map", keyLabel?, addLabel?, fixedKeys?, item? }
+ *
+ * `seed` is the skeleton a missing file starts from; `presets` are one-click
+ * patches the UI offers as buttons. An empty scalar control means "key
+ * absent — the default applies", which is why defaults double as placeholders.
+ */
+
+const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+const MODEL_CLASSES = ["MONITOR_ECONOMY", "FAST_READ", "CODING_MEDIUM", "REASONING_HIGH", "REVIEW_HIGH"];
+const ROLE_PROVIDERS = ["pi-supervisor", "pi-lead", "pi-peer"];
+
+/** Shared shape of one route card inside routing and every cluster host. */
+function routeFields() {
+	return [
+		{
+			path: "paseoProvider",
+			type: "enum",
+			enum: ROLE_PROVIDERS,
+			label: "Provider Paseo",
+			hint: "Chọn theo vai trò: giám sát / trưởng nhóm / thành viên.",
+		},
+		{
+			path: "model",
+			type: "string",
+			label: "Mô hình",
+			hint: "Dạng <pi-provider>/<model-id>, ví dụ Minnyat/deepseek-v4-flash.",
+		},
+		{
+			path: "thinking",
+			type: "enum",
+			enum: THINKING_LEVELS,
+			label: "Mức suy nghĩ",
+			hint: "Phải là mức mô hình hỗ trợ, nếu không sẽ bị ép về mức thấp hơn.",
+		},
+	];
+}
+
+export const CONFIG_SCHEMAS = {
+	"pi-settings": {
+		label: "Pi — cấu hình chính",
+		intro:
+			"Hành vi của Pi (trình agent đọc cấu hình này). Ô nào để trống thì dùng giá trị mặc định hiển thị dưới nhãn. Thay đổi có hiệu lực từ phiên agent mới.",
+		presets: [
+			{
+				id: "unstable-provider",
+				label: "Chống provider lỗi tạm thời",
+				hint: "Thử lại tối đa 6 lần, chờ lâu dần giữa các lần (3s → 6s → 12s → 24s → 48s → 96s) và cắt yêu cầu bị treo sau 10 phút.",
+				patch: {
+					retry: {
+						enabled: true,
+						maxRetries: 6,
+						baseDelayMs: 3000,
+						provider: { timeoutMs: 600000, maxRetries: 0, maxRetryDelayMs: 60000 },
+					},
+				},
+			},
+		],
+		groups: [
+			{
+				id: "retry",
+				label: "Thử lại khi provider lỗi",
+				hint: "Chỉ áp dụng cho lỗi tạm thời (quá tải, giới hạn tốc độ, lỗi 5xx, mất kết nối). Lỗi xác thực hoặc sai yêu cầu không bao giờ được thử lại.",
+				fields: [
+					{
+						path: "retry.enabled",
+						type: "bool",
+						default: true,
+						label: "Tự thử lại khi lỗi tạm thời",
+					},
+					{
+						path: "retry.maxRetries",
+						type: "number",
+						default: 3,
+						min: 0,
+						max: 20,
+						label: "Số lần thử lại tối đa",
+					},
+					{
+						path: "retry.baseDelayMs",
+						type: "number",
+						default: 2000,
+						min: 0,
+						max: 600000,
+						label: "Thời gian chờ ban đầu (ms)",
+						hint: "Nhân đôi sau mỗi lần thử: để 3000 thì chờ 3s, 6s, 12s…",
+					},
+					{
+						path: "retry.provider.timeoutMs",
+						type: "number",
+						default: 0,
+						min: 0,
+						max: 3600000,
+						label: "Thời gian chờ mỗi yêu cầu (ms)",
+						hint: "0 = để thư viện tự quyết. Đặt 600000 (10 phút) để cắt yêu cầu bị treo rồi thử lại.",
+					},
+					{
+						path: "retry.provider.maxRetries",
+						type: "number",
+						default: 0,
+						min: 0,
+						max: 10,
+						label: "Số lần thử lại của tầng thư viện",
+						hint: "Khuyến cáo giữ 0: đặt lớn hơn có thể che lỗi vượt hạn mức và treo agent rất lâu.",
+					},
+					{
+						path: "retry.provider.maxRetryDelayMs",
+						type: "number",
+						default: 60000,
+						min: 0,
+						max: 600000,
+						label: "Chờ dài nhất theo yêu cầu của máy chủ (ms)",
+						hint: "Nếu máy chủ yêu cầu chờ lâu hơn mức này thì lỗi được trả về ngay thay vì đợi im lặng.",
+					},
+				],
+			},
+			{
+				id: "model",
+				label: "Mô hình & mức suy nghĩ",
+				fields: [
+					{
+						path: "defaultProvider",
+						type: "string",
+						label: "Nhà cung cấp mặc định",
+						hint: "Tên provider như trong ~/.pi/agent/models.json (ví dụ Minnyat).",
+					},
+					{ path: "defaultModel", type: "string", label: "Mô hình mặc định" },
+					{
+						path: "defaultThinkingLevel",
+						type: "enum",
+						enum: THINKING_LEVELS,
+						label: "Mức suy nghĩ mặc định",
+					},
+					{
+						path: "hideThinkingBlock",
+						type: "bool",
+						default: false,
+						label: "Ẩn khối suy nghĩ trong kết quả",
+					},
+				],
+			},
+			{
+				id: "network",
+				label: "Mạng & gửi tin",
+				fields: [
+					{
+						path: "transport",
+						type: "enum",
+						enum: ["auto", "sse", "websocket", "websocket-cached"],
+						default: "auto",
+						label: "Kiểu truyền với provider",
+					},
+					{
+						path: "httpIdleTimeoutMs",
+						type: "number",
+						default: 300000,
+						min: 0,
+						max: 3600000,
+						label: "Thời gian im lặng tối đa qua HTTP (ms)",
+					},
+					{
+						path: "websocketConnectTimeoutMs",
+						type: "number",
+						default: 15000,
+						min: 0,
+						max: 600000,
+						label: "Thời gian kết nối WebSocket (ms)",
+					},
+					{
+						path: "steeringMode",
+						type: "enum",
+						enum: ["one-at-a-time", "all"],
+						default: "one-at-a-time",
+						label: "Gửi tin chen ngang",
+						hint: "one-at-a-time: lần lượt từng tin; all: dồn hết vào lượt kế tiếp.",
+					},
+					{
+						path: "followUpMode",
+						type: "enum",
+						enum: ["one-at-a-time", "all"],
+						default: "one-at-a-time",
+						label: "Gửi tin nối tiếp",
+					},
+				],
+			},
+			{
+				id: "compaction",
+				label: "Nén ngữ cảnh",
+				hint: "Khi hội thoại sắp đầy, Pi tóm tắt phần cũ để chạy tiếp thay vì dừng giữa việc.",
+				fields: [
+					{
+						path: "compaction.enabled",
+						type: "bool",
+						default: true,
+						label: "Tự nén khi hội thoại dài",
+					},
+					{
+						path: "compaction.reserveTokens",
+						type: "number",
+						default: 16384,
+						min: 0,
+						max: 200000,
+						label: "Token dành cho câu trả lời",
+					},
+					{
+						path: "compaction.keepRecentTokens",
+						type: "number",
+						default: 20000,
+						min: 0,
+						max: 200000,
+						label: "Token gần đây được giữ nguyên (không tóm tắt)",
+					},
+				],
+			},
+			{
+				id: "ui",
+				label: "Giao diện",
+				fields: [
+					{ path: "theme", type: "string", default: "dark", label: "Giao diện (theme)" },
+					{
+						path: "defaultProjectTrust",
+						type: "enum",
+						enum: ["ask", "always", "never"],
+						default: "ask",
+						label: "Tin thư mục dự án mặc định",
+						hint: "ask: hỏi khi chạy tương tác. Chạy tự động (kể cả agent) dùng luôn giá trị này.",
+					},
+					{ path: "quietStartup", type: "bool", default: false, label: "Ẩn lời chào khi khởi động" },
+				],
+			},
+		],
+	},
+
+	paseo: {
+		label: "Paseo — daemon & nhà cung cấp",
+		intro:
+			"Cấu hình của daemon Paseo và các hob provider (supervisor / lead / peer). Sửa xong nên khởi động lại daemon để chắc chắn áp dụng.",
+		seed: { version: 1 },
+		groups: [
+			{
+				id: "daemon",
+				label: "Daemon",
+				fields: [
+					{
+						path: "daemon.mcp.enabled",
+						type: "bool",
+						default: true,
+						label: "Bật máy chủ MCP của daemon",
+					},
+					{
+						path: "daemon.mcp.injectIntoAgents",
+						type: "bool",
+						default: true,
+						label: "Cấp công cụ MCP cho agent",
+					},
+				],
+			},
+			{
+				id: "providers",
+				label: "Nhà cung cấp (hob provider)",
+				fields: [
+					{
+						path: "agents.providers",
+						type: "map",
+						keyLabel: "Tên provider",
+						addLabel: "Thêm provider",
+						item: {
+							fields: [
+								{ path: "label", type: "string", label: "Tên hiển thị" },
+								{
+									path: "extends",
+									type: "string",
+									default: "pi",
+									label: "Kế thừa",
+									hint: "Thường là pi — hob chạy trên trình agent Pi.",
+								},
+								{
+									path: "env",
+									type: "kv",
+									label: "Biến môi trường",
+									hint: "Ví dụ PASEO_PI_ROLE = supervisor.",
+								},
+							],
+						},
+					},
+				],
+			},
+		],
+	},
+
+	mcp: {
+		label: "Pi — công cụ MCP",
+		intro: "Các công cụ MCP mà Pi được phép dùng. Thêm một mục tương đương thêm một máy chủ MCP vào ~/.pi/agent/mcp.json.",
+		seed: { mcpServers: {} },
+		groups: [
+			{
+				id: "servers",
+				label: "Máy chủ MCP",
+				fields: [
+					{
+						path: "mcpServers",
+						type: "map",
+						keyLabel: "Tên công cụ",
+						addLabel: "Thêm công cụ",
+						item: {
+							seed: { lifecycle: "lazy" },
+							fields: [
+								{ path: "command", type: "string", label: "Lệnh chạy" },
+								{
+									path: "args",
+									type: "lines",
+									label: "Tham số lệnh",
+									hint: "Mỗi dòng một tham số, theo đúng thứ tự.",
+								},
+								{ path: "env", type: "kv", label: "Biến môi trường" },
+								{
+									path: "lifecycle",
+									type: "string",
+									default: "lazy",
+									label: "Kiểu khởi động",
+									hint: "lazy: chỉ khởi động khi agent dùng tới. Đang dùng phổ biến nhất là lazy.",
+								},
+							],
+						},
+					},
+				],
+			},
+		],
+	},
+
+	routing: {
+		label: "Định tuyến mô hình",
+		intro:
+			"Chọn mô hình cho từng lớp việc trên máy này. Lấy tên mô hình chính xác bằng lệnh: paseo provider models pi-peer --json",
+		seed: { version: 1, routes: {} },
+		groups: [
+			{
+				id: "host",
+				label: "Máy này",
+				fields: [{ path: "hostId", type: "string", label: "Mã máy (hostId)" }],
+			},
+			{
+				id: "routes",
+				label: "Lớp việc → mô hình",
+				hint: "Năm lớp việc cố định; điền đủ để agent không phải đoán khi nhận việc.",
+				fields: [
+					{
+						path: "routes",
+						type: "map",
+						keyLabel: "Lớp việc",
+						fixedKeys: MODEL_CLASSES,
+						item: { fields: routeFields() },
+					},
+				],
+			},
+		],
+	},
+
+	cluster: {
+		label: "Nhiều máy (cluster)",
+		intro:
+			"Mỗi máy một thẻ: kết nối, khả năng, giới hạn song song và định tuyến mô hình. Giá trị endpoint chỉ chứa TÊN biến môi trường — không ghi giá trị thật vào file này.",
+		seed: { version: 1, hosts: {} },
+		groups: [
+			{
+				id: "hosts",
+				label: "Máy trong cụm",
+				fields: [
+					{
+						path: "hosts",
+						type: "map",
+						keyLabel: "Tên máy",
+						addLabel: "Thêm máy",
+						item: {
+							seed: { connection: { type: "local" }, required: true, capabilities: [], limits: { writers: 0, readers: 2 }, routes: {} },
+							fields: [
+								{
+									path: "connection.type",
+									type: "enum",
+									enum: ["local", "remote"],
+									default: "local",
+									label: "Kiểu kết nối",
+								},
+								{
+									path: "connection.endpointEnv",
+									type: "string",
+									label: "Biến môi trường chứa endpoint",
+									hint: "Chỉ tên biến (ví dụ PASEO_MAC_REVIEW); giá trị nằm trong môi trường của máy điều khiển.",
+									showIf: { path: "connection.type", equals: "remote" },
+								},
+								{
+									path: "required",
+									type: "bool",
+									default: true,
+									label: "Máy bắt buộc",
+									hint: "Nếu bắt buộc mà máy vắng mặt thì cụm không chạy.",
+								},
+								{
+									path: "capabilities",
+									type: "lines",
+									label: "Khả năng",
+									hint: "Mỗi dòng một khả năng: git-read, git-write, focused-test, docker, integration-test, independent-review…",
+								},
+								{
+									path: "limits.writers",
+									type: "number",
+									default: 0,
+									min: 0,
+									max: 16,
+									label: "Số agent được ghi file cùng lúc",
+								},
+								{
+									path: "limits.readers",
+									type: "number",
+									default: 2,
+									min: 0,
+									max: 32,
+									label: "Số agent chỉ đọc cùng lúc",
+								},
+								{
+									path: "routes",
+									type: "map",
+									keyLabel: "Lớp việc",
+									fixedKeys: MODEL_CLASSES,
+									item: { fields: routeFields() },
+								},
+							],
+						},
+					},
+				],
+			},
+		],
+	},
+};
+
+/** Sections sharing one file share one schema: `providers` and `paseo`. */
+export function schemaForSection(section) {
+	if (section === "providers" || section === "paseo") return CONFIG_SCHEMAS.paseo;
+	return CONFIG_SCHEMAS[section] ?? null;
+}

--- a/cli/lib/config-walker.mjs
+++ b/cli/lib/config-walker.mjs
@@ -43,6 +43,14 @@ export function mcpConfigPath() {
 	return join(agentDir(), "mcp.json");
 }
 
+/**
+ * Pi's own settings file (`~/.pi/agent/settings.json`). It is shared with the
+ * interactive `pi` CLI, so every write must merge, never clobber.
+ */
+export function piSettingsPath() {
+	return join(agentDir(), "settings.json");
+}
+
 export function promptsDir() {
 	return join(agentDir(), "extensions", "prompts");
 }

--- a/cli/paseo-team.mjs
+++ b/cli/paseo-team.mjs
@@ -29,6 +29,7 @@ import { existsSync, readFileSync, readdirSync, appendFileSync, unlinkSync, writ
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as cw from "./lib/config-walker.mjs";
+import { schemaForSection } from "./lib/config-schema.mjs";
 import { runPaseoJson, PaseoError } from "./lib/paseo-bridge.mjs";
 import * as graphCache from "./lib/graph-cache.mjs";
 import { collectGraph, inferRole, normalizePermits } from "./lib/graph.mjs";
@@ -116,6 +117,7 @@ const CONFIG_SECTIONS = {
 	cluster: () => join(cw.teamConfigDir(), "cluster-routing.local.json"),
 	mcp: () => cw.mcpConfigPath(),
 	paseo: () => cw.paseoConfigPath(),
+	"pi-settings": () => cw.piSettingsPath(),
 };
 
 function resolveSection(section) {
@@ -128,11 +130,14 @@ function resolveSection(section) {
 function cmdConfigRead(section) {
 	const path = resolveSection(section);
 	const data = cw.readJsonOrNull(path);
+	// The form schema rides along with the data: the WebUI renders fields the
+	// CLI described and nothing else, so a form is reproducible from a terminal.
+	const schema = schemaForSection(section);
 	if (data === null) {
-		json({ exists: false, path, data: {} });
+		json({ exists: false, path, data: {}, ...(schema ? { schema } : {}) });
 		return;
 	}
-	json({ exists: true, path, data });
+	json({ exists: true, path, data, ...(schema ? { schema } : {}) });
 }
 
 function cmdConfigWrite(section) {

--- a/docs/webui-architecture.md
+++ b/docs/webui-architecture.md
@@ -82,6 +82,9 @@ CLI hiện có: `status`, `preflight`, `config read|write`, `prompts read|write`
 một-JSON-object-mỗi-lệnh):
 
 ```text
+paseo-team config read|write pi-settings       -> ~/.pi/agent/settings.json (file riêng của Pi; ghi nguyên file + backup)
+                                               -> response kem `schema`: bang field (label/hint/default/enum/min/max)
+                                                  de WebUI render form; field nao CLI khong mo ta thi UI khong hien thi
 paseo-team agents [--all]                      -> node list chuan hoa + role suy ra tu provider
 paseo-team agent inspect <ref>                 -> inspect + pending permit + parent
 paseo-team agent send <ref>                    -> prompt qua stdin -> file -> paseo send --prompt-file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paseo-pi-team",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "private": true,
   "description": "Paseo/pi multi-agent role pack — policy extension, role prompts, support scripts.",
   "type": "module",

--- a/test/cli-contract.test.mjs
+++ b/test/cli-contract.test.mjs
@@ -165,6 +165,47 @@ try {
 		assert.notEqual(invalid.status, 0);
 	}
 
+	// --- every section carries the form schema the WebUI renders -------------
+	{
+		for (const section of ["providers", "routing", "cluster", "mcp", "paseo", "pi-settings"]) {
+			const read = run(["config", "read", section]);
+			assert.equal(read.status, 0, `${section}: ${read.stderr}`);
+			assert.ok(Array.isArray(read.json.schema?.groups), `${section} read carries a form schema`);
+		}
+
+		// pi-settings points at Pi's own settings file and works before it exists
+		const pi = run(["config", "read", "pi-settings"]);
+		assert.equal(pi.json.exists, false);
+		assert.match(pi.json.path, /[\\/]settings\.json$/);
+		const retryGroup = pi.json.schema.groups.find((group) => group.id === "retry");
+		assert.ok(retryGroup, "the retry group is described even before any file exists");
+		const preset = pi.json.schema.presets.find((entry) => entry.id === "unstable-provider");
+		assert.equal(preset?.patch?.retry?.maxRetries, 6, "the unstable-provider preset ships its retry budget");
+
+		// A save must never drop keys the form does not know about.
+		const settingsPath = join(sandbox, "pi", "agent", "settings.json");
+		mkdirSync(dirname(settingsPath), { recursive: true });
+		writeFileSync(settingsPath, JSON.stringify({ packages: ["npm:pi-web-access"], theme: "dark" }));
+		const saved = run(["config", "write", "pi-settings"], {
+			__stdin: JSON.stringify({ packages: ["npm:pi-web-access"], theme: "dark", retry: { maxRetries: 6 } }),
+		});
+		assert.equal(saved.status, 0, saved.stderr);
+		const after = JSON.parse(readFileSync(settingsPath, "utf8"));
+		assert.equal(after.packages[0], "npm:pi-web-access", "alien keys survive the write");
+		assert.equal(after.retry.maxRetries, 6);
+		assert.ok(
+			readdirSync(dirname(settingsPath)).some((file) => /^settings\.json\.bak-\d+$/.test(file)),
+			"a pi-settings rewrite leaves a .bak-* sibling",
+		);
+
+		const help = run(["--help"]);
+		assert.ok(help.stdout.includes("pi-settings"), "help lists the pi-settings section");
+
+		const unknown = run(["config", "read", "pi"]);
+		assert.notEqual(unknown.status, 0);
+		assert.match(unknown.stderr, /unknown config section/);
+	}
+
 	// --- version + update -----------------------------------------------------
 	{
 		const pkg = JSON.parse(readFileSync(join(HERE, "..", "package.json"), "utf8"));

--- a/test/config-form.test.mjs
+++ b/test/config-form.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import {
+	clone,
+	deepMerge,
+	deletePath,
+	getPath,
+	numberRangeProblems,
+	parseLines,
+	pruneEmpty,
+	setPath,
+} from "../webui/public/config-form.js";
+
+// --- path get/set/delete ----------------------------------------------------
+
+{
+	const doc = {};
+	setPath(doc, "retry.provider.timeoutMs", 600000);
+	assert.deepEqual(doc, { retry: { provider: { timeoutMs: 600000 } } }, "setPath creates missing parents");
+
+	assert.equal(getPath(doc, "retry.provider.timeoutMs"), 600000);
+	assert.equal(getPath(doc, "retry.provider.maxRetries"), undefined);
+	assert.equal(getPath(undefined, "a.b"), undefined, "a missing root reads as undefined");
+
+	deletePath(doc, "retry.provider.timeoutMs");
+	assert.deepEqual(doc, {}, "deleting the only leaf prunes the empty parents it leaves behind");
+
+	const keep = { retry: { enabled: true, provider: { timeoutMs: 1 } } };
+	deletePath(keep, "retry.provider.timeoutMs");
+	assert.deepEqual(keep, { retry: { enabled: true } }, "a surviving sibling keeps the branch");
+
+	const alien = { packages: ["npm:x"] };
+	deletePath(alien, "retry.enabled");
+	assert.deepEqual(alien, { packages: ["npm:x"] }, "deleting an absent path changes nothing");
+}
+
+// --- preset merge ------------------------------------------------------------
+
+{
+	const doc = { retry: { enabled: true, provider: { timeoutMs: 0 } } };
+	deepMerge(doc, { retry: { maxRetries: 6, provider: { timeoutMs: 600000 } } });
+	assert.deepEqual(doc, { retry: { enabled: true, maxRetries: 6, provider: { timeoutMs: 600000 } } });
+}
+
+// --- prune: emptiness is structural, never a value ---------------------------
+
+{
+	assert.equal(pruneEmpty({}), undefined);
+	assert.equal(pruneEmpty({ a: [], b: {} }), undefined);
+	assert.deepEqual(
+		pruneEmpty({ a: {}, b: [], c: 0, d: false, e: "", f: { g: { h: 1 } } }),
+		{ c: 0, d: false, e: "", f: { g: { h: 1 } } },
+		"0, false and empty-string are values, not emptiness",
+	);
+}
+
+// --- range validation reaches into map items ---------------------------------
+
+{
+	const schema = {
+		groups: [
+			{
+				fields: [
+					{ path: "retry.maxRetries", type: "number", label: "Số lần thử lại", min: 0, max: 20 },
+					{
+						path: "hosts",
+						type: "map",
+						item: { fields: [{ path: "limits.writers", type: "number", label: "Số agent ghi", min: 0, max: 16 }] },
+					},
+				],
+			},
+		],
+	};
+	assert.deepEqual(numberRangeProblems(schema, { retry: { maxRetries: 6 } }), []);
+	assert.equal(numberRangeProblems(schema, { retry: { maxRetries: 99 } }).length, 1);
+	assert.equal(
+		numberRangeProblems(schema, { hosts: { "win-primary": { limits: { writers: 44 } } } }).length,
+		1,
+		"number fields inside map cards are checked too",
+	);
+}
+
+// --- misc ---------------------------------------------------------------------
+
+{
+	assert.deepEqual(parseLines("a\n b\r\n\r\n  c \n"), ["a", "b", "c"]);
+	assert.deepEqual(parseLines(""), []);
+	assert.deepEqual(parseLines(null), []);
+
+	assert.deepEqual(clone({ a: { b: 1 } }), { a: { b: 1 } });
+	assert.notEqual(clone({ a: { b: 1 } }).a, { a: { b: 1 } }.a);
+	assert.equal(clone(undefined), undefined);
+}
+
+console.log("config-form tests passed");

--- a/test/webui-server.test.mjs
+++ b/test/webui-server.test.mjs
@@ -78,6 +78,24 @@ import {
 	assert.equal(seen.stdin, raw, "the CLI receives the document byte-for-byte");
 }
 
+// --- pi-settings is a first-class section: same argv shape as the others ---
+{
+	const echo = () => Promise.resolve({ exitCode: 0, stdout: "{}", stderr: "" });
+	const read = await handleApi({ method: "GET", pathname: "/api/config", query: { section: "pi-settings" }, exec: echo });
+	assert.deepEqual(read.args, ["config", "read", "pi-settings"]);
+
+	const raw = '{"retry":{"maxRetries":6}}';
+	const written = await handleApi({
+		method: "POST",
+		pathname: "/api/config",
+		query: { section: "pi-settings" },
+		rawBody: raw,
+		exec: (args, stdin) => Promise.resolve({ exitCode: 0, stdout: "{}", stderr: "", stdin }),
+	});
+	assert.deepEqual(written.args, ["config", "write", "pi-settings"]);
+	assert.equal(written.stdin, raw);
+}
+
 // --- host / origin checks --------------------------------------------------
 assert.equal(isAllowedHost({ headers: { host: "127.0.0.1:4321" } }, 4321), true);
 assert.equal(isAllowedHost({ headers: { host: "localhost:4321" } }, 4321), true);

--- a/webui/public/app.js
+++ b/webui/public/app.js
@@ -17,6 +17,16 @@
  */
 
 import {
+	clone,
+	deepMerge,
+	deletePath,
+	getPath,
+	numberRangeProblems,
+	parseLines,
+	pruneEmpty,
+	setPath,
+} from "./config-form.js";
+import {
 	ROLE_HINT,
 	degradedSentence,
 	humanizeError,
@@ -768,13 +778,320 @@ async function loadEnvTable() {
 }
 
 // --- config ----------------------------------------------------------------
+//
+// The tab is a schema-driven form editor: the CLI describes every field
+// (label, hint, default, type) in `config read <section>`, and this engine
+// renders controls for exactly those fields. An empty control means "key
+// absent — the default applies"; saving always starts from the file's own
+// JSON, so a key the schema does not know about survives every edit.
+
+const configState = {
+	section: null,
+	schema: null,
+	doc: {},
+	mode: "form",
+};
+
+function joinPath(prefix, path) {
+	return prefix ? `${prefix}.${path}` : path;
+}
+
+function defaultValueLabel(field) {
+	if (field.default === undefined) return "";
+	const shown = field.type === "bool" ? (field.default ? "có" : "không") : String(field.default);
+	return `mặc định: ${shown}`;
+}
+
+function stringControl(field, path) {
+	const input = el("input", { type: "text", class: "cfg-input" });
+	input.placeholder = field.default !== undefined ? String(field.default) : "";
+	input.value = String(getPath(configState.doc, path) ?? "");
+	input.addEventListener("input", () => {
+		if (input.value === "") deletePath(configState.doc, path);
+		else setPath(configState.doc, path, input.value);
+	});
+	return input;
+}
+
+function boolControl(field, path) {
+	const box = el("input", { type: "checkbox" });
+	const label = el("span");
+	const paint = () => {
+		label.textContent = box.checked ? "Bật" : "Tắt";
+	};
+	box.checked = getPath(configState.doc, path) === undefined ? Boolean(field.default) : Boolean(getPath(configState.doc, path));
+	box.addEventListener("change", () => {
+		setPath(configState.doc, path, box.checked);
+		paint();
+	});
+	paint();
+	return el("label", { class: "cfg-bool" }, [box, label]);
+}
+
+function numberControl(field, path) {
+	const input = el("input", { type: "number", class: "cfg-input", step: "1" });
+	if (field.min !== undefined) input.min = String(field.min);
+	if (field.max !== undefined) input.max = String(field.max);
+	input.placeholder = field.default !== undefined ? String(field.default) : "";
+	const current = getPath(configState.doc, path);
+	if (current !== undefined && current !== null) input.value = String(current);
+	input.addEventListener("input", () => {
+		if (input.value.trim() === "") deletePath(configState.doc, path);
+		else setPath(configState.doc, path, Number(input.value));
+	});
+	return input;
+}
+
+function enumControl(field, path) {
+	const select = el("select", { class: "cfg-input" });
+	select.appendChild(
+		el("option", { value: "", text: field.default !== undefined ? `— mặc định (${field.default}) —` : "— mặc định —" }),
+	);
+	for (const value of field.enum ?? []) select.appendChild(el("option", { value, text: value }));
+	const current = getPath(configState.doc, path);
+	select.value = current === undefined ? "" : String(current);
+	if (current !== undefined && ![...select.options].some((option) => option.value === select.value)) {
+		// A value outside the enum (hand-written, or from a newer version) stays
+		// visible instead of silently snapping back to the default.
+		select.appendChild(el("option", { value: String(current), text: `${String(current)} (ngoài danh sách)` }));
+	}
+	select.addEventListener("change", () => {
+		if (select.value === "") deletePath(configState.doc, path);
+		else setPath(configState.doc, path, select.value);
+	});
+	return select;
+}
+
+function linesControl(field, path) {
+	const area = el("textarea", { class: "cfg-lines", rows: "3", spellcheck: "false" });
+	const current = getPath(configState.doc, path);
+	if (Array.isArray(current)) area.value = current.join("\n");
+	area.addEventListener("input", () => {
+		const lines = parseLines(area.value);
+		if (lines.length === 0) deletePath(configState.doc, path);
+		else setPath(configState.doc, path, lines);
+	});
+	return area;
+}
+
+function kvControl(field, path) {
+	const wrap = el("div", { class: "cfg-kv" });
+	const rebuild = () => {
+		const next = {};
+		for (const row of wrap.querySelectorAll(".cfg-kv-row")) {
+			const key = row.querySelector(".cfg-kv-key").value.trim();
+			if (key) next[key] = row.querySelector(".cfg-kv-value").value;
+		}
+		if (Object.keys(next).length === 0) deletePath(configState.doc, path);
+		else setPath(configState.doc, path, next);
+	};
+	const addRow = (key = "", value = "") => {
+		const keyInput = el("input", { type: "text", class: "cfg-input cfg-kv-key", placeholder: "TÊN_BIẾN" });
+		const valueInput = el("input", { type: "text", class: "cfg-input cfg-kv-value", placeholder: "giá trị" });
+		keyInput.value = key;
+		valueInput.value = value;
+		keyInput.addEventListener("input", rebuild);
+		valueInput.addEventListener("input", rebuild);
+		const row = el("div", { class: "cfg-kv-row" }, [
+			keyInput,
+			valueInput,
+			el("button", { type: "button", class: "cfg-icon", text: "×", title: "Bỏ dòng này", onclick: () => { row.remove(); rebuild(); } }),
+		]);
+		wrap.insertBefore(row, wrap.querySelector(".cfg-add"));
+	};
+	for (const [key, value] of Object.entries(getPath(configState.doc, path) ?? {})) addRow(key, String(value ?? ""));
+	wrap.appendChild(el("button", { type: "button", class: "cfg-add", text: "+ Thêm biến", onclick: () => addRow() }));
+	return wrap;
+}
+
+function mapControl(field, path) {
+	const wrap = el("div", { class: "cfg-map" });
+	const fixed = field.fixedKeys ?? null;
+	const existing = () => getPath(configState.doc, path) ?? {};
+
+	const cardForKey = (key, isFixed) => {
+		const card = el("div", { class: "cfg-card" });
+		card.dataset.key = key;
+		const head = el("div", { class: "cfg-card-head" });
+		if (isFixed) {
+			head.appendChild(el("span", { class: "cfg-card-title", text: key }));
+		} else {
+			const keyInput = el("input", { type: "text", class: "cfg-input cfg-card-key", placeholder: field.keyLabel ?? "Khóa" });
+			keyInput.value = key;
+			keyInput.addEventListener("change", () => {
+				const next = keyInput.value.trim();
+				if (!next || next === key) {
+					keyInput.value = key;
+					return;
+				}
+				if (next in existing()) {
+					toast(`Đã có mục tên "${next}" rồi.`, true);
+					keyInput.value = key;
+					return;
+				}
+				setPath(configState.doc, joinPath(path, next), existing()[key]);
+				deletePath(configState.doc, joinPath(path, key));
+				renderConfigForm();
+			});
+			head.appendChild(keyInput);
+			head.appendChild(
+				el("button", {
+					type: "button",
+					class: "cfg-icon",
+					text: "×",
+					title: "Xóa mục này",
+					onclick: () => {
+						deletePath(configState.doc, joinPath(path, card.dataset.key));
+						renderConfigForm();
+					},
+				}),
+			);
+		}
+		card.appendChild(head);
+		const body = el("div", { class: "cfg-card-body" });
+		for (const child of field.item?.fields ?? []) body.appendChild(fieldRow(child, joinPath(path, key)));
+		card.appendChild(body);
+		return card;
+	};
+
+	const keys = fixed
+		? [...fixed, ...Object.keys(existing()).filter((key) => !fixed.includes(key))]
+		: Object.keys(existing());
+	for (const key of keys) wrap.appendChild(cardForKey(key, fixed?.includes(key) === true));
+	if (!fixed) {
+		wrap.appendChild(
+			el("button", {
+				type: "button",
+				class: "cfg-add",
+				text: field.addLabel ?? "+ Thêm mục",
+				onclick: () => {
+					let key = "moi";
+					let index = 1;
+					while (key in existing()) key = `moi-${(index += 1)}`;
+					setPath(configState.doc, joinPath(path, key), clone(field.item?.seed ?? {}));
+					renderConfigForm();
+					const fresh = wrap.querySelector(`.cfg-card[data-key="${key}"] .cfg-card-key`);
+					fresh?.focus();
+					fresh?.select();
+				},
+			}),
+		);
+	}
+	return wrap;
+}
+
+function fieldControl(field, path) {
+	if (field.type === "bool") return boolControl(field, path);
+	if (field.type === "number") return numberControl(field, path);
+	if (field.type === "enum") return enumControl(field, path);
+	if (field.type === "lines") return linesControl(field, path);
+	if (field.type === "kv") return kvControl(field, path);
+	if (field.type === "map") return mapControl(field, path);
+	return stringControl(field, path);
+}
+
+function fieldRow(field, prefix) {
+	const path = joinPath(prefix, field.path);
+	const row = el("div", { class: `cfg-field${field.type === "map" ? " cfg-field-wide" : ""}` });
+	row.appendChild(
+		el("div", { class: "cfg-label" }, [
+			el("label", { text: field.label }),
+			field.default !== undefined ? el("span", { class: "cfg-default", text: defaultValueLabel(field) }) : null,
+		]),
+	);
+	if (field.hint && field.type !== "map") row.appendChild(el("p", { class: "cfg-hint", text: field.hint }));
+	row.appendChild(fieldControl(field, path));
+	if (field.type === "map" && field.hint) row.appendChild(el("p", { class: "cfg-hint", text: field.hint }));
+	if (field.showIf) {
+		row.dataset.showIfPath = joinPath(prefix, field.showIf.path);
+		row.dataset.showIfEquals = String(field.showIf.equals);
+	}
+	return row;
+}
+
+/** showIf rows hide and show as the field they depend on changes. */
+function refreshShowIf() {
+	for (const row of $("config-form").querySelectorAll(".cfg-field[data-show-if-path]")) {
+		const current = getPath(configState.doc, row.dataset.showIfPath);
+		row.classList.toggle("hidden", String(current) !== row.dataset.showIfEquals);
+	}
+}
+
+function renderConfigForm() {
+	const schema = configState.schema;
+	const form = clear($("config-form"));
+	clear($("config-presets"));
+	$("config-intro").textContent = schema?.intro ?? "";
+	if (!schema) return;
+
+	for (const preset of schema.presets ?? []) {
+		$("config-presets").appendChild(
+			el("div", { class: "preset-item" }, [
+				el("button", {
+					type: "button",
+					class: "preset",
+					text: preset.label,
+					onclick: () => {
+						deepMerge(configState.doc, clone(preset.patch));
+						renderConfigForm();
+						toast(`Đã điền sẵn: ${preset.label}. Xem lại rồi bấm Lưu.`);
+					},
+				}),
+				preset.hint ? el("span", { class: "cfg-hint preset-hint", text: preset.hint }) : null,
+			]),
+		);
+	}
+
+	for (const group of schema.groups ?? []) {
+		const fieldset = el("fieldset", { class: "cfg-group" });
+		fieldset.appendChild(el("legend", { text: group.label }));
+		if (group.hint) fieldset.appendChild(el("p", { class: "cfg-hint", text: group.hint }));
+		for (const field of group.fields ?? []) fieldset.appendChild(fieldRow(field, ""));
+		form.appendChild(fieldset);
+	}
+	refreshShowIf();
+}
+
+/** Flip visibility only. `loadConfig` uses this directly: the freshly loaded
+ *  document is the truth, so it must not round-trip through the textarea. */
+function applyConfigMode(mode) {
+	configState.mode = mode;
+	$("config-mode-form").classList.toggle("active", mode === "form");
+	$("config-mode-raw").classList.toggle("active", mode === "raw");
+	for (const id of ["config-form", "config-presets", "config-intro"]) {
+		$(id).classList.toggle("hidden", mode !== "form");
+	}
+	$("config-raw").classList.toggle("hidden", mode !== "raw");
+	if (mode === "form") renderConfigForm();
+}
+
+function setConfigMode(mode) {
+	if (mode === "raw") {
+		// Serialize the working document so form edits carry into the textarea.
+		$("config-editor").value = JSON.stringify(configState.doc, null, 2);
+		applyConfigMode("raw");
+		return;
+	}
+	try {
+		configState.doc = JSON.parse($("config-editor").value);
+	} catch (cause) {
+		toast(`JSON chưa hợp lệ, chưa chuyển về form được: ${cause.message}`, true);
+		return;
+	}
+	applyConfigMode("form");
+}
 
 async function loadConfig() {
 	const section = $("config-section").value;
 	try {
 		const { data } = await api(`/api/config?section=${encodeURIComponent(section)}`);
-		$("config-editor").value = JSON.stringify(data.data ?? {}, null, 2);
-		$("config-meta").textContent = `${data.path}${data.exists ? "" : " (chưa tồn tại)"}`;
+		configState.section = section;
+		configState.schema = data.schema ?? null;
+		configState.doc = data.exists ? clone(data.data) : clone(configState.schema?.seed ?? {});
+		$("config-meta").textContent = `${data.path}${data.exists ? "" : " (chưa tồn tại — lưu sẽ tạo mới)"}`;
+		$("config-editor").value = JSON.stringify(configState.doc, null, 2);
+		// A section without a schema keeps the old raw-JSON editor.
+		applyConfigMode(configState.schema ? "form" : "raw");
 	} catch (error) {
 		toastError(error);
 	}
@@ -782,9 +1099,21 @@ async function loadConfig() {
 
 $("config-load").addEventListener("click", loadConfig);
 $("config-section").addEventListener("change", loadConfig);
+$("config-mode-form").addEventListener("click", () => setConfigMode("form"));
+$("config-mode-raw").addEventListener("click", () => setConfigMode("raw"));
 $("config-save").addEventListener("click", async () => {
-	const section = $("config-section").value;
-	const text = $("config-editor").value;
+	const section = configState.section ?? $("config-section").value;
+	let text;
+	if (configState.mode === "raw") {
+		text = $("config-editor").value;
+	} else {
+		const problems = numberRangeProblems(configState.schema, configState.doc);
+		if (problems.length > 0) {
+			toast(problems.join(" · "), true);
+			return;
+		}
+		text = JSON.stringify(pruneEmpty(configState.doc) ?? {}, null, 2);
+	}
 	try {
 		JSON.parse(text); // fail here, before anything touches the file
 	} catch (cause) {
@@ -794,13 +1123,14 @@ $("config-save").addEventListener("click", async () => {
 	try {
 		await api(`/api/config?section=${encodeURIComponent(section)}`, { method: "POST", raw: text });
 		toast("Đã lưu. Bản cũ được sao lưu kèm thời gian.");
+		await loadConfig();
 	} catch (error) {
 		toastError(error);
 	}
 });
 
 loaders.config = async () => {
-	if (!$("config-editor").value) await loadConfig();
+	if (configState.section !== $("config-section").value) await loadConfig();
 };
 
 // --- chat ------------------------------------------------------------------

--- a/webui/public/app.js
+++ b/webui/public/app.js
@@ -970,7 +970,8 @@ function mapControl(field, path) {
 					while (key in existing()) key = `moi-${(index += 1)}`;
 					setPath(configState.doc, joinPath(path, key), clone(field.item?.seed ?? {}));
 					renderConfigForm();
-					const fresh = wrap.querySelector(`.cfg-card[data-key="${key}"] .cfg-card-key`);
+					// A key with quotes or spaces would break a naive selector.
+					const fresh = wrap.querySelector(`.cfg-card[data-key="${CSS.escape(key)}"] .cfg-card-key`);
 					fresh?.focus();
 					fresh?.select();
 				},

--- a/webui/public/config-form.js
+++ b/webui/public/config-form.js
@@ -1,0 +1,112 @@
+/**
+ * config-form.js — pure helpers for the schema-driven config editor.
+ *
+ * No DOM here on purpose: every function is plain data-in/data-out so the
+ * merge semantics (a save may never drop a key the form does not know about)
+ * are testable from Node like any other contract.
+ */
+
+export function clone(value) {
+	return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+export function getPath(root, path) {
+	let node = root;
+	for (const part of path.split(".")) {
+		if (node === null || typeof node !== "object") return undefined;
+		node = node[part];
+	}
+	return node;
+}
+
+export function setPath(root, path, value) {
+	const parts = path.split(".");
+	let node = root;
+	for (const part of parts.slice(0, -1)) {
+		if (typeof node[part] !== "object" || node[part] === null) node[part] = {};
+		node = node[part];
+	}
+	node[parts[parts.length - 1]] = value;
+}
+
+/** Delete a leaf and any now-empty parents, so a reset field leaves no `"retry": {}` husk. */
+export function deletePath(root, path) {
+	if (typeof root !== "object" || root === null) return;
+	deleteRec(root, path.split("."));
+
+	function deleteRec(node, parts) {
+		if (parts.length === 1) {
+			delete node[parts[0]];
+			return;
+		}
+		const child = node[parts[0]];
+		if (typeof child !== "object" || child === null) return;
+		deleteRec(child, parts.slice(1));
+		if (Object.keys(child).length === 0) delete node[parts[0]];
+	}
+}
+
+/** Deep-merge a preset patch onto the working document (arrays and scalars replace). */
+export function deepMerge(target, patch) {
+	for (const [key, value] of Object.entries(patch ?? {})) {
+		if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+			if (typeof target[key] !== "object" || target[key] === null) target[key] = {};
+			deepMerge(target[key], value);
+		} else {
+			target[key] = value;
+		}
+	}
+	return target;
+}
+
+/**
+ * Drop empty objects/arrays so a save writes the smallest document that still
+ * means the same thing. False, 0 and "" are values, not emptiness.
+ */
+export function pruneEmpty(value) {
+	if (Array.isArray(value)) return value.length > 0 ? value : undefined;
+	if (value !== null && typeof value === "object") {
+		const out = {};
+		for (const [key, child] of Object.entries(value)) {
+			const kept = pruneEmpty(child);
+			if (kept !== undefined) out[key] = kept;
+		}
+		return Object.keys(out).length > 0 ? out : undefined;
+	}
+	return value;
+}
+
+/** One entry per number field outside its range, with the label to show the user. */
+export function numberRangeProblems(schema, doc, prefix = "") {
+	const problems = [];
+	for (const group of schema?.groups ?? []) {
+		for (const field of group.fields ?? []) collectField(field, prefix);
+	}
+	function collectField(field, base) {
+		const path = base ? `${base}.${field.path}` : field.path;
+		if (field.type === "number") {
+			const value = getPath(doc, path);
+			if (value !== undefined && value !== null && value !== "") {
+				const numeric = Number(value);
+				if (!Number.isFinite(numeric) || numeric < (field.min ?? -Infinity) || numeric > (field.max ?? Infinity)) {
+					problems.push(`${field.label} phải là số từ ${field.min ?? "−∞"} đến ${field.max ?? "∞"}`);
+				}
+			}
+		}
+		if (field.type === "map" && field.item) {
+			const object = getPath(doc, path);
+			for (const key of Object.keys(object ?? {})) {
+				for (const child of field.item.fields ?? []) collectField(child, `${path}.${key}`);
+			}
+		}
+	}
+	return problems;
+}
+
+/** Split a textarea into argv-style lines: trimmed, blanks dropped. */
+export function parseLines(text) {
+	return String(text ?? "")
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+}

--- a/webui/public/index.html
+++ b/webui/public/index.html
@@ -176,16 +176,26 @@
 				</div>
 				<div class="toolbar">
 					<select id="config-section" aria-label="Chọn nhóm cấu hình">
-						<option value="providers">Nhà cung cấp mô hình</option>
+						<option value="pi-settings">Pi — cấu hình chính</option>
+						<option value="mcp">Pi — công cụ MCP</option>
+						<option value="providers">Paseo — nhà cung cấp</option>
 						<option value="routing">Định tuyến mô hình</option>
 						<option value="cluster">Nhiều máy (cluster)</option>
-						<option value="mcp">Công cụ MCP</option>
 					</select>
+					<div class="segmented" role="group" aria-label="Kiểu chỉnh">
+						<button id="config-mode-form" class="active" type="button">Form</button>
+						<button id="config-mode-raw" type="button">JSON thô</button>
+					</div>
 					<button id="config-load">Tải lại</button>
 					<button id="config-save" class="primary">Lưu</button>
 					<span id="config-meta" class="meta"></span>
 				</div>
-				<textarea id="config-editor" spellcheck="false" aria-label="Nội dung cấu hình"></textarea>
+				<p class="lead-in" id="config-intro"></p>
+				<div id="config-presets" class="presets"></div>
+				<div id="config-form" aria-live="polite"></div>
+				<div id="config-raw" class="hidden">
+					<textarea id="config-editor" spellcheck="false" aria-label="Nội dung cấu hình"></textarea>
+				</div>
 			</section>
 		</main>
 

--- a/webui/public/style.css
+++ b/webui/public/style.css
@@ -345,6 +345,108 @@ table.list .row-error td { background: color-mix(in srgb, var(--danger) 8%, tran
 
 .cmd { font-family: var(--mono); font-size: 11.5px; color: var(--muted); margin-top: 16px; word-break: break-all; }
 
+/* --- config form --------------------------------------------------------- */
+
+.presets { display: flex; flex-direction: column; gap: 8px; margin-bottom: 14px; }
+.preset-item { display: flex; flex-direction: column; gap: 3px; }
+.preset-item .preset-hint { margin: 0; }
+button.preset {
+	border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+	color: var(--accent);
+	background: color-mix(in srgb, var(--accent) 10%, transparent);
+	align-self: flex-start;
+}
+button.preset:hover:not(:disabled) { background: color-mix(in srgb, var(--accent) 18%, transparent); }
+
+.cfg-group {
+	border: 1px solid var(--line);
+	border-radius: 12px;
+	background: var(--panel);
+	padding: 12px 18px 14px;
+	margin: 0 0 14px;
+}
+.cfg-group > legend {
+	padding: 0 8px;
+	font-size: 12.5px;
+	text-transform: uppercase;
+	letter-spacing: 0.09em;
+	color: var(--muted);
+	font-weight: 600;
+}
+.cfg-group > .cfg-hint { margin: 0 0 4px; }
+
+.cfg-field {
+	display: grid;
+	grid-template-columns: minmax(200px, 270px) 1fr;
+	gap: 4px 18px;
+	align-items: center;
+	padding: 9px 0;
+	border-bottom: 1px solid color-mix(in srgb, var(--line) 55%, transparent);
+}
+.cfg-field:last-child { border-bottom: none; padding-bottom: 2px; }
+.cfg-field-wide { display: block; padding-bottom: 12px; }
+.cfg-field-wide .cfg-map { margin-top: 8px; }
+
+.cfg-label { display: flex; flex-direction: column; gap: 2px; }
+.cfg-label label { font-size: 14px; font-weight: 570; }
+.cfg-default { color: var(--muted); font-size: 12px; font-family: var(--mono); }
+.cfg-hint { margin: 0 0 8px; color: var(--muted); font-size: 12.5px; }
+.cfg-field > .cfg-hint { grid-column: 1 / -1; margin: -2px 0 4px; }
+
+.cfg-input {
+	width: 100%;
+	background: var(--panel-2);
+	color: var(--text);
+	border: 1px solid var(--line);
+	border-radius: 8px;
+	padding: 8px 12px;
+	font-size: 14px;
+	font-family: inherit;
+}
+input[type="number"].cfg-input { font-family: var(--mono); max-width: 230px; }
+textarea.cfg-lines {
+	min-height: 72px;
+	font-family: var(--mono);
+	font-size: 13px;
+	padding: 9px 12px;
+}
+
+.cfg-bool { display: inline-flex; gap: 9px; align-items: center; cursor: pointer; }
+.cfg-bool input { width: 18px; height: 18px; accent-color: var(--accent); }
+
+.cfg-kv { display: flex; flex-direction: column; gap: 6px; }
+.cfg-kv-row { display: grid; grid-template-columns: 1fr 1.4fr auto; gap: 8px; align-items: center; }
+
+.cfg-map { display: flex; flex-direction: column; gap: 10px; }
+.cfg-card {
+	border: 1px solid var(--line);
+	border-radius: 10px;
+	background: var(--panel-2);
+	padding: 12px 14px;
+}
+.cfg-card-head { display: flex; gap: 10px; align-items: center; margin-bottom: 4px; }
+.cfg-card-key { max-width: 320px; }
+.cfg-card-title { font-family: var(--mono); font-size: 13.5px; color: var(--accent); }
+.cfg-card-body .cfg-field { grid-template-columns: minmax(170px, 220px) 1fr; }
+.cfg-icon {
+	background: transparent;
+	border: none;
+	color: var(--muted);
+	font-size: 19px;
+	line-height: 1;
+	padding: 2px 9px;
+	cursor: pointer;
+}
+.cfg-icon:hover { color: var(--danger); }
+.cfg-add { align-self: flex-start; }
+
+@media (max-width: 700px) {
+	.cfg-field { grid-template-columns: 1fr; align-items: start; }
+	.cfg-card-body .cfg-field { grid-template-columns: 1fr; }
+	.cfg-kv-row { grid-template-columns: 1fr auto; }
+	.cfg-kv-value { grid-column: 1 / -1; }
+}
+
 /* --- toast -------------------------------------------------------------- */
 
 .toast {

--- a/webui/server.mjs
+++ b/webui/server.mjs
@@ -42,7 +42,7 @@ export const MAX_BODY_BYTES = 4 * 1024 * 1024;
 
 // --- request -> argv -------------------------------------------------------
 
-const CONFIG_SECTIONS = ["providers", "routing", "cluster", "mcp", "paseo"];
+const CONFIG_SECTIONS = ["providers", "routing", "cluster", "mcp", "paseo", "pi-settings"];
 const ROLES = ["supervisor", "lead", "peer"];
 const AGENT_REF = /^[0-9a-fA-F][0-9a-fA-F-]{5,63}$/;
 const TOKEN_LIKE = /^[A-Za-z0-9._:-]{1,128}$/;


### PR DESCRIPTION
## What

The **Cấu hình** tab is now a real form editor instead of a raw JSON textarea — for both Paseo and Pi configs, editable without reading any docs.

- **New section `pi-settings`** → `~/.pi/agent/settings.json` (Pi's own settings, whole-file atomic write + `.bak` backup like every section).
- Every `config read` now carries a **form schema** (label / hint / default / enum / min-max, Vietnamese labels). The WebUI renders exactly the fields the CLI describes — the CLI-as-truth rule holds: what you see is reproducible from a terminal.
- Field types: toggle (bool), dropdown (enum), number with range, text, one-per-line lists (args/capabilities), key–value rows (env), and **add/remove cards** for maps (providers, MCP servers, cluster hosts) plus **fixed cards** for the five MODEL_CLASSES routes (also nested inside each cluster host).
- **Empty control = key absent = default applies**; the default is shown under every label as the placeholder ("mặc định: 3").
- Saves always start from the file's own JSON, so **keys the schema doesn't know (e.g. `packages`, `$comment`) survive every edit**. Tested in cli-contract + config-form tests.
- **One-click preset "Chống provider lỗi tạm thời"** fills Pi's `retry` block for unstable model providers: 6 attempts, 3s base backoff, 10-min per-request timeout (cuts hung requests so the agent-level retry kicks in). Pi already retries transient model-API errors itself — this makes the budget tunable.
- **Form ↔ JSON thô toggle**: switching serializes the working document; switching back parses it (invalid JSON refuses the switch with a toast). Raw mode saves byte-for-byte like before.
- `showIf` support: the remote-endpoint env field only appears when a cluster host's connection type is `remote`.

## Why

Pi runs were failing on an unstable provider; Pi's built-in retry defaults (3 attempts, ~14s total window) are too small for a flaky proxy, and tuning it required reading Pi's docs and hand-editing `settings.json`.

## Verification

- `npm run check`: 20/20 tests + typecheck (new: `config-form.test.mjs`; extended: `cli-contract`, `webui-server`).
- Live browser pass (Chromium, sandboxed HOME with realistic configs): all 5 sections render real data; preset fills 6/3000/600000; **Lưu** wrote the retry block while preserving the alien `packages` key and creating a `settings.json.bak-*`; cluster section shows "chưa tồn tại — lưu sẽ tạo mới"; Form ↔ JSON round-trip works.
- Found & fixed during the live pass: first load fell into raw mode because the mode switch round-tripped the empty textarea (`applyConfigMode` split from `setConfigMode`).

## Version

1.1.5 → **1.2.0** (MINOR — new CLI capability).