### PR TITLE
feat(topology): agent-state identity + team_chat coordination bus (PR-A + PR-B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,9 @@ When the `claude` CLI is present, the installers also run
 skips that step; it is not an error.
 
 The support scripts are `lib-common`, `reliability`, `watchdog`,
-`team-communication`, `ocr-review`, `remote-paseo`, `model-routing`,
-`team-scripts-path`, `claude-hook` and `claude-team-mcp`. They are copied **flat**, so every import between them
+`team-communication`, `team-chat`, `ocr-review`, `remote-paseo`,
+`model-routing`, `team-scripts-path`, `claude-hook` and `claude-team-mcp`.
+They are copied **flat**, so every import between them
 must stay `./<name>.mjs`. `installer-contract.test.mjs` guards that: every
 shipped file must exist, and every support script it imports must be shipped
 too.

--- a/cli/lib/agent-state.mjs
+++ b/cli/lib/agent-state.mjs
@@ -58,6 +58,12 @@ export function buildStateIndex(root = paseoAgentsDir()) {
 	try {
 		slugs = readdirSync(root, { withFileTypes: true });
 	} catch (error) {
+		// A missing root is the normal state of a machine Paseo has not written
+		// agent state on — a fresh host, a sandbox, another PASEO_HOME. The
+		// enrichment is simply unavailable; the graph still renders from `ls`.
+		// Anything else (permissions, a file where the directory should be) IS a
+		// fault, because it means the data exists and we could not read it.
+		if (error?.code === "ENOENT") return { index, degraded: [] };
 		return {
 			index,
 			degraded: [{ reason: "AGENT_STATE_ROOT_UNREADABLE", detail: `${root}: ${String(error?.message ?? error)}` }],

--- a/cli/lib/agent-state.mjs
+++ b/cli/lib/agent-state.mjs
@@ -1,0 +1,173 @@
+/**
+ * agent-state.mjs — read what Paseo already knows about an agent, off disk.
+ *
+ * Paseo persists one JSON file per agent at
+ * `$PASEO_HOME/agents/<cwd-slug>/<agent-id>.json`, and it carries everything
+ * the team graph previously had to buy with `paseo inspect`:
+ *
+ *   labels["paseo.parent-agent-id"]  -> the spawn edge   (was: inspect, ~3s each)
+ *   labels["team.domain"]            -> which supervisor/lead owns this seat
+ *   runtimeInfo.model / thinking     -> what the agent ACTUALLY runs
+ *   runtimeInfo.sessionId            -> the pi session id
+ *   persistence.nativeHandle         -> the pi session JSONL path (fork/handoff)
+ *
+ * Two deliberate rules, both measured on 2026-08-28:
+ *
+ *   - `runtimeInfo.model` wins over `config.model`, and
+ *     `persistence.metadata.model` is NEVER a model source: it is a
+ *     creation-time snapshot that Paseo does not rewrite when the model is
+ *     changed through `update_agent`, so trusting it reports a model the agent
+ *     is not running.
+ *   - Agents are found by SCANNING the agents root, not by recomputing the
+ *     cwd slug. The slug rule (drop `:`, separators to `-`) is undocumented
+ *     and would silently mis-resolve the day it changes; an id-keyed scan
+ *     cannot.
+ *
+ * The whole surface (`paseo import`, this file layout) is undocumented — see
+ * docs/multi-supervisor-topology.md §1.13 — so every read here degrades into
+ * data rather than throwing: a graph that admits a gap beats one that lies.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { paseoAgentsDir } from "./config-walker.mjs";
+
+export const AGENT_DOMAIN_LABEL = "team.domain";
+export const AGENT_PARENT_LABEL = "paseo.parent-agent-id";
+
+/** Paseo agent ids are UUIDs. Anything else never becomes a path segment. */
+const AGENT_ID = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+export function isAgentId(value) {
+	return typeof value === "string" && AGENT_ID.test(value);
+}
+
+function str(value) {
+	return typeof value === "string" && value.trim() !== "" ? value : null;
+}
+
+/**
+ * Build `{ [agentId]: absoluteFilePath }` by scanning one level of cwd-slug
+ * directories. One pass serves a whole snapshot, which is the access pattern
+ * every caller has (`agents`, `graph`).
+ */
+export function buildStateIndex(root = paseoAgentsDir()) {
+	const index = {};
+	const degraded = [];
+	let slugs;
+	try {
+		slugs = readdirSync(root, { withFileTypes: true });
+	} catch (error) {
+		return {
+			index,
+			degraded: [{ reason: "AGENT_STATE_ROOT_UNREADABLE", detail: `${root}: ${String(error?.message ?? error)}` }],
+		};
+	}
+	for (const slug of slugs) {
+		if (!slug.isDirectory()) continue;
+		const dir = join(root, slug.name);
+		let files;
+		try {
+			files = readdirSync(dir);
+		} catch (error) {
+			degraded.push({ reason: "AGENT_STATE_DIR_UNREADABLE", detail: `${dir}: ${String(error?.message ?? error)}` });
+			continue;
+		}
+		for (const file of files) {
+			if (!file.endsWith(".json")) continue;
+			const id = file.slice(0, -".json".length);
+			if (!isAgentId(id)) continue;
+			index[id] = join(dir, file);
+		}
+	}
+	return { index, degraded };
+}
+
+/**
+ * Normalize one raw state object. Pure: same input, same output, no I/O.
+ * Returns null for anything that is not an object, so a junk file is a fault
+ * about one agent instead of an exception that ends the snapshot.
+ */
+export function normalizeAgentState(raw, agentId) {
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+	const labels =
+		raw.labels && typeof raw.labels === "object" && !Array.isArray(raw.labels)
+			? { ...raw.labels }
+			: {};
+	const runtime = raw.runtimeInfo && typeof raw.runtimeInfo === "object" ? raw.runtimeInfo : {};
+	const config = raw.config && typeof raw.config === "object" ? raw.config : {};
+	const persistence = raw.persistence && typeof raw.persistence === "object" ? raw.persistence : {};
+
+	const runtimeModel = str(runtime.model);
+	const configModel = str(config.model);
+	const model = runtimeModel ?? configModel;
+
+	return {
+		agentId: str(raw.id) ?? agentId,
+		provider: str(raw.provider),
+		cwd: str(raw.cwd),
+		workspaceId: str(raw.workspaceId),
+		title: str(raw.title),
+		labels,
+		domain: str(labels[AGENT_DOMAIN_LABEL]),
+		parentAgentId: str(labels[AGENT_PARENT_LABEL]),
+		model,
+		modelSource: runtimeModel ? "runtime" : configModel ? "config" : null,
+		// Only a real disagreement counts: a missing runtimeInfo (agent not
+		// started yet) is not drift, it is "not known yet".
+		modelDrift: Boolean(runtimeModel && configModel && runtimeModel !== configModel),
+		thinking: str(runtime.thinkingOptionId),
+		sessionId: str(runtime.sessionId) ?? str(persistence.sessionId),
+		sessionFile: str(persistence.nativeHandle),
+	};
+}
+
+/**
+ * Read normalized state for the given agent ids.
+ *
+ * @param {string[]} ids
+ * @param {{ root?: string, index?: Record<string,string> }} [options]
+ * @returns {{ states: Record<string, object>, degraded: Array<object>, index: Record<string,string> }}
+ */
+export function readAgentStates(ids, options = {}) {
+	const root = options.root ?? paseoAgentsDir();
+	const built = options.index ? { index: options.index, degraded: [] } : buildStateIndex(root);
+	const states = {};
+	const degraded = [...built.degraded];
+
+	for (const id of Array.isArray(ids) ? ids : []) {
+		if (!isAgentId(id)) {
+			degraded.push({ agentId: typeof id === "string" ? id : String(id), reason: "AGENT_STATE_ID_INVALID" });
+			continue;
+		}
+		const path = built.index[id];
+		if (!path) {
+			degraded.push({ agentId: id, reason: "AGENT_STATE_MISSING" });
+			continue;
+		}
+		let normalized = null;
+		try {
+			normalized = normalizeAgentState(JSON.parse(readFileSync(path, "utf8")), id);
+		} catch (error) {
+			degraded.push({ agentId: id, reason: "AGENT_STATE_UNREADABLE", detail: String(error?.message ?? error) });
+			continue;
+		}
+		if (!normalized) {
+			degraded.push({ agentId: id, reason: "AGENT_STATE_UNREADABLE", detail: "state file is not a JSON object" });
+			continue;
+		}
+		states[id] = normalized;
+	}
+	return { states, degraded, index: built.index };
+}
+
+/** Present only so callers can report the root they actually read. */
+export function agentStateRoot() {
+	try {
+		const root = paseoAgentsDir();
+		statSync(root);
+		return root;
+	} catch {
+		return null;
+	}
+}

--- a/cli/lib/config-walker.mjs
+++ b/cli/lib/config-walker.mjs
@@ -39,6 +39,21 @@ export function paseoConfigPath() {
 	return process.env.PASEO_CONFIG_JSON || join(homedir(), ".paseo", "config.json");
 }
 
+/**
+ * Paseo's own home. `PASEO_HOME` is Paseo's documented override, so honor the
+ * same variable rather than inventing a pack-specific one — a machine that
+ * moved its daemon home must not end up with the CLI reading a different tree
+ * than the daemon writes.
+ */
+export function paseoHome() {
+	return process.env.PASEO_HOME || join(homedir(), ".paseo");
+}
+
+/** Per-agent state files: `$PASEO_HOME/agents/<cwd-slug>/<agent-id>.json`. */
+export function paseoAgentsDir() {
+	return join(paseoHome(), "agents");
+}
+
 export function mcpConfigPath() {
 	return join(agentDir(), "mcp.json");
 }

--- a/cli/lib/graph.mjs
+++ b/cli/lib/graph.mjs
@@ -249,6 +249,17 @@ export function buildGraph({ agents = [], parents = {}, states = {}, permits = [
 		const hasParentInfo = hasInspectParent || hasStateParent;
 		const parentId = hasInspectParent ? parents[agent.id] : (state?.parentAgentId ?? null);
 		const parentSource = hasInspectParent ? "inspect" : hasStateParent ? "state" : null;
+		// Neither source carries a timestamp we can compare, so precedence cannot
+		// also mean "fresher". When they disagree the inspect answer still wins —
+		// but saying so out loud beats resolving it invisibly, the same way
+		// modelDrift is surfaced rather than smoothed over.
+		if (hasInspectParent && hasStateParent && (state?.parentAgentId ?? null) !== parents[agent.id]) {
+			faults.push({
+				agentId: agent.id,
+				reason: "PARENT_SOURCE_DISAGREEMENT",
+				detail: `inspect=${parents[agent.id] ?? "null"} state=${state?.parentAgentId ?? "null"}`,
+			});
+		}
 		// An agent whose parent exists but is not in the listing (archived, or
 		// living in a directory this listing did not cover) must not be drawn
 		// as a root: that would silently flatten the tree.
@@ -289,12 +300,16 @@ export function buildGraph({ agents = [], parents = {}, states = {}, permits = [
 			edges.push({ type: "spawn", from: node.parentId, to: node.id, confidence: "confirmed" });
 		}
 	}
-	// Message edges are keyed by correlationId: the same PEER_MESSAGE_V1 block
-	// can be seen twice (sender log and recipient prompt) and must draw once.
+	// The same block can be seen twice (a sender log and a recipient prompt, or
+	// one room read overlapping another) and must draw once. The key includes the
+	// participants and the room, NOT correlationId alone: that id is chosen by the
+	// sender, so keying on it lets one message — careless or crafted — erase a
+	// different real edge that happens to share it.
 	const seen = new Set();
 	for (const message of messages) {
 		if (!message || typeof message.from !== "string" || typeof message.to !== "string") continue;
-		const key = message.correlationId ?? `${message.from}->${message.to}:${message.ts ?? ""}`;
+		const identity = message.correlationId ?? `${message.ts ?? ""}`;
+		const key = `${message.room ?? ""}|${message.from}->${message.to}|${identity}`;
 		if (seen.has(key)) continue;
 		seen.add(key);
 		edges.push({

--- a/cli/lib/graph.mjs
+++ b/cli/lib/graph.mjs
@@ -21,8 +21,10 @@
  */
 
 import { MESSAGE_KINDS } from "../../scripts/team-communication.mjs";
+import { TEAM_MESSAGE_HEADER, parseTeamMessage } from "../../scripts/team-chat.mjs";
 import { runPaseoJson, mapWithConcurrency, PaseoError } from "./paseo-bridge.mjs";
 import * as cache from "./graph-cache.mjs";
+import { readAgentStates, isAgentId } from "./agent-state.mjs";
 
 export const ROLES = Object.freeze(["supervisor", "lead", "peer"]);
 
@@ -98,6 +100,66 @@ export function parsePeerMessage(text) {
 	};
 }
 
+/** Paseo stamps a human's `paseo chat post` with this author. */
+const HUMAN_AUTHOR = "manual";
+const MENTION = /@([A-Za-z0-9-]{4,64})/g;
+
+/**
+ * Turn one room's messages into message edges.
+ *
+ * This is the one message path that is a FACT rather than a reconstruction:
+ * `paseo chat read --json` reports the real author agent id, so the edge does
+ * not have to be inferred from a Lead's tool log. Recipients come from the
+ * `@mention` tokens the sender wrote — the same tokens Paseo uses to deliver —
+ * resolved back to full ids through the current listing.
+ *
+ * A mention nobody in the listing answers to is KEPT and flagged. Dropping it
+ * would hide exactly the case an operator needs: a message aimed at an agent
+ * that is archived, on another host, or misaddressed.
+ *
+ * @param {Array}  messages rows from `paseo chat read --json`
+ * @param {Array}  roster   rows from `paseo ls` (for shortId -> id)
+ * @param {string} room
+ */
+export function chatEdges(messages, roster = [], room = null) {
+	const byShort = new Map();
+	for (const agent of Array.isArray(roster) ? roster : []) {
+		if (typeof agent?.id !== "string") continue;
+		byShort.set(typeof agent.shortId === "string" ? agent.shortId : agent.id.slice(0, 7), agent.id);
+		byShort.set(agent.id, agent.id);
+	}
+	const edges = [];
+	for (const message of Array.isArray(messages) ? messages : []) {
+		const body = typeof message?.body === "string" ? message.body : "";
+		const envelope = parseTeamMessage(body);
+		// No envelope means ordinary room chatter. It is a real message, but it
+		// carries no protocol meaning, so it is not a graph edge.
+		if (!envelope) continue;
+		const author = typeof message?.author === "string" ? message.author : null;
+		const human = author === HUMAN_AUTHOR || !author;
+		const head = body.slice(0, body.indexOf(TEAM_MESSAGE_HEADER));
+		const mentions = [...head.matchAll(MENTION)].map((match) => match[1]);
+		for (const mention of mentions.length > 0 ? mentions : [null]) {
+			if (mention === null) continue;
+			const resolved = byShort.get(mention) ?? null;
+			edges.push({
+				type: "message",
+				from: human ? "human" : author,
+				to: resolved ?? mention,
+				kind: envelope.kind,
+				taskId: envelope.topic,
+				correlationId: envelope.correlationId,
+				ts: message?.createdAt ?? null,
+				room,
+				origin: human ? "human" : "agent",
+				unresolvedRecipient: resolved === null,
+				confidence: "confirmed",
+			});
+		}
+	}
+	return edges;
+}
+
 const PERMIT_AGENT_KEYS = ["agentId", "AgentId", "agent_id", "agent", "AgentID"];
 const PERMIT_REQUEST_KEYS = ["requestId", "RequestId", "request_id", "reqId", "ReqId", "id", "Id"];
 const PERMIT_TOOL_KEYS = ["tool", "Tool", "toolName", "ToolName", "name", "Name"];
@@ -152,12 +214,13 @@ export function normalizePermits(list) {
  * @param {object} input
  * @param {Array}  input.agents      rows from `paseo ls -g --json`
  * @param {object} input.parents     { [agentId]: parentId|null } — the known subset
+ * @param {object} [input.states]    { [agentId]: normalized agent-state.mjs record }
  * @param {Array}  input.permits     rows from `paseo permit ls --json`
  * @param {Array}  [input.messages]  reconstructed message edges
  * @param {Array}  [input.degraded]  collection faults to surface verbatim
  * @param {number} input.now
  */
-export function buildGraph({ agents = [], parents = {}, permits = [], messages = [], degraded = [], now = 0 } = {}) {
+export function buildGraph({ agents = [], parents = {}, states = {}, permits = [], messages = [], degraded = [], now = 0 } = {}) {
 	const rows = Array.isArray(agents) ? agents.filter((a) => a && typeof a.id === "string") : [];
 	const known = new Set(rows.map((a) => a.id));
 	const { permits: normalizedPermits, unclassified } = normalizePermits(permits);
@@ -176,8 +239,16 @@ export function buildGraph({ agents = [], parents = {}, permits = [], messages =
 	}
 
 	const nodes = rows.map((agent) => {
-		const hasParentInfo = Object.hasOwn(parents, agent.id);
-		const parentId = hasParentInfo ? parents[agent.id] : null;
+		const state = states[agent.id] ?? null;
+		// Precedence is deliberate: a `paseo inspect` answer was paid for and is
+		// the field Paseo documents, so it wins. The state file fills in the
+		// (usually much larger) rest for free. Recording which source answered
+		// keeps a stale state file from looking like a fresh inspect.
+		const hasInspectParent = Object.hasOwn(parents, agent.id);
+		const hasStateParent = Boolean(state);
+		const hasParentInfo = hasInspectParent || hasStateParent;
+		const parentId = hasInspectParent ? parents[agent.id] : (state?.parentAgentId ?? null);
+		const parentSource = hasInspectParent ? "inspect" : hasStateParent ? "state" : null;
 		// An agent whose parent exists but is not in the listing (archived, or
 		// living in a directory this listing did not cover) must not be drawn
 		// as a root: that would silently flatten the tree.
@@ -200,8 +271,15 @@ export function buildGraph({ agents = [], parents = {}, permits = [], messages =
 			created: typeof agent.created === "string" ? agent.created : null,
 			parentId: hasParentInfo ? parentId : null,
 			parentKnown: hasParentInfo,
+			parentSource,
 			orphan,
 			pendingPermissions: permitCount.get(agent.id) ?? 0,
+			// From Paseo's own agent state file. A node without one still renders;
+			// these are simply null, and the read fault is in degraded[].
+			domain: state?.domain ?? null,
+			model: state?.model ?? null,
+			modelDrift: state?.modelDrift ?? false,
+			sessionId: state?.sessionId ?? null,
 		};
 	});
 
@@ -227,16 +305,28 @@ export function buildGraph({ agents = [], parents = {}, permits = [], messages =
 			taskId: message.taskId ?? null,
 			correlationId: message.correlationId ?? null,
 			ts: message.ts ?? null,
+			// Chat-derived edges carry provenance the UI needs to draw them
+			// honestly: which room, whether a person or an agent spoke, and
+			// whether the recipient could be resolved at all.
+			room: message.room ?? null,
+			origin: message.origin ?? null,
+			unresolvedRecipient: message.unresolvedRecipient ?? false,
 			confidence: message.confidence ?? "suspected",
 		});
 	}
 
 	const byRole = {};
 	const byStatus = {};
+	const byDomain = {};
 	for (const node of nodes) {
 		const role = node.role ?? "unknown";
 		byRole[role] = (byRole[role] ?? 0) + 1;
 		byStatus[node.status] = (byStatus[node.status] ?? 0) + 1;
+		// "unknown" is a real bucket, not a skip: with several supervisors on
+		// the board, an unlabelled seat is exactly the thing an operator needs
+		// to notice.
+		const domain = node.domain ?? "unknown";
+		byDomain[domain] = (byDomain[domain] ?? 0) + 1;
 	}
 
 	return {
@@ -247,6 +337,7 @@ export function buildGraph({ agents = [], parents = {}, permits = [], messages =
 			pendingPermissions: normalizedPermits.length + unclassified.length,
 			byRole,
 			byStatus,
+			byDomain,
 		},
 		nodes,
 		edges,
@@ -299,7 +390,30 @@ export async function collectGraph(options = {}) {
 
 	const store = options.cache ?? cache.readParentCache();
 	const ids = agents.map((agent) => agent.id).filter((id) => typeof id === "string");
-	const stale = cache.staleIds(ids, store, { now, ttlMs: options.parentTtlMs });
+
+	// Paseo's own state files answer parent + domain + model for free. Read them
+	// first so the `inspect` budget is spent only on what they could not answer
+	// — on a healthy machine that is nothing, turning a multi-poll cold start
+	// into a single round trip.
+	const readStates = options.readStates ?? ((wanted) => readAgentStates(wanted));
+	let states = {};
+	try {
+		// Only ask about ids that could name a state file. An id shape we do not
+		// recognize is Paseo's business, not a read fault worth reporting.
+		const read = readStates(ids.filter(isAgentId));
+		states = read?.states ?? {};
+		for (const fault of read?.degraded ?? []) {
+			// A per-agent MISSING is expected (an agent Paseo has not flushed yet)
+			// and would drown the report; only surface the structural faults.
+			if (fault?.reason !== "AGENT_STATE_MISSING") degraded.push(fault);
+		}
+	} catch (error) {
+		degraded.push({ reason: "AGENT_STATE_READ_FAILED", detail: String(error?.message ?? error) });
+	}
+
+	const stale = cache
+		.staleIds(ids, store, { now, ttlMs: options.parentTtlMs })
+		.filter((id) => !states[id]);
 	const budget = stale.slice(0, maxInspect);
 
 	const inspected = await mapWithConcurrency(budget, options.concurrency ?? 4, (id) =>
@@ -334,7 +448,23 @@ export async function collectGraph(options = {}) {
 		if (entry) parents[id] = entry.parentId;
 	}
 
-	const graph = buildGraph({ agents, parents, permits, degraded, now });
+	// Chat rooms are opt-in per call: reading them costs one round trip each,
+	// and most snapshots do not need the coordination layer.
+	const rooms = Array.isArray(options.chatRooms) ? options.chatRooms : [];
+	const messages = [];
+	if (rooms.length > 0) {
+		const read = await mapWithConcurrency(rooms, options.concurrency ?? 4, (room) =>
+			run(["chat", "read", room], { timeoutMs }),
+		);
+		read.forEach((result, index) => {
+			const room = rooms[index];
+			if (result.ok) messages.push(...chatEdges(result.value, agents, room));
+			// One unreadable room must not cost the others, nor the graph.
+			else degraded.push({ reason: "CHAT_READ_FAILED", detail: `${room}: ${String(result.error?.message ?? result.error)}` });
+		});
+	}
+
+	const graph = buildGraph({ agents, parents, states, permits, messages, degraded, now });
 	return {
 		...graph,
 		ok: true,

--- a/cli/paseo-team.mjs
+++ b/cli/paseo-team.mjs
@@ -34,6 +34,7 @@ import { schemaForSection } from "./lib/config-schema.mjs";
 import { runPaseoJson, PaseoError } from "./lib/paseo-bridge.mjs";
 import * as graphCache from "./lib/graph-cache.mjs";
 import { collectGraph, inferRole, normalizePermits } from "./lib/graph.mjs";
+import { readAgentStates, isAgentId } from "./lib/agent-state.mjs";
 import * as su from "./lib/self-update.mjs";
 import * as un from "./lib/uninstall.mjs";
 
@@ -217,6 +218,9 @@ const DOC_ENV = [
 	{ key: "PASEO_TEAM_EXTRA_TOOLS", scope: "host", where: "machine env", purpose: "comma-separated extra tools per profile" },
 	{ key: "PASEO_TEAM_PROMPTS_DIR", scope: "host", where: "machine env", purpose: "override prompts directory" },
 	{ key: "PASEO_TEAM_SCRIPTS_DIR", scope: "host", where: "machine env", purpose: "override support-scripts directory" },
+	{ key: "PASEO_TEAM_DOMAIN", scope: "per-agent", where: "paseo run --env / provider env", purpose: "jurisdiction of this seat; also set it as the team.domain label so `ls --label` and team_chat 'domain:<name>' broadcasts can find it" },
+	{ key: "PASEO_TEAM_ROOMS", scope: "per-agent", where: "paseo run --env / provider env", purpose: "comma-separated chat-room allowlist for team_chat; unset = any room (chat rooms have no ACL of their own)" },
+	{ key: "PASEO_HOME", scope: "host", where: "machine env", purpose: "Paseo's own home; the CLI reads agent state from $PASEO_HOME/agents (defaults to ~/.paseo)" },
 ];
 
 function cmdEnvList() {
@@ -336,13 +340,33 @@ async function live(args, label) {
 }
 
 async function cmdAgents(argv) {
-	rejectUnknownFlags(argv, ["--all"]);
+	rejectUnknownFlags(argv, ["--all", "--domain"]);
+	const domainFilter = flagValue(argv, "--domain");
 	const listed = await live(flag(argv, "--all") ? ["ls", "-g", "-a"] : ["ls", "-g"], "agents");
 	const rows = Array.isArray(listed) ? listed : [];
+	// `paseo ls` carries neither labels nor the parent link; Paseo's own state
+	// files carry both, and reading them costs no daemon round trip.
+	const ids = rows.map((agent) => agent?.id).filter(isAgentId);
+	const { states, degraded } = readAgentStates(ids);
+	const agents = rows.map((agent) => {
+		const state = states[agent?.id] ?? null;
+		return {
+			...agent,
+			role: inferRole(agent?.provider),
+			domain: state?.domain ?? null,
+			parentId: state?.parentAgentId ?? null,
+			resolvedModel: state?.model ?? null,
+			modelDrift: state?.modelDrift ?? false,
+			sessionId: state?.sessionId ?? null,
+		};
+	});
+	const filtered = domainFilter === undefined ? agents : agents.filter((a) => a.domain === domainFilter);
 	json({
 		ok: true,
-		count: rows.length,
-		agents: rows.map((agent) => ({ ...agent, role: inferRole(agent?.provider) })),
+		count: filtered.length,
+		domain: domainFilter ?? null,
+		agents: filtered,
+		degraded: degraded.filter((fault) => fault.reason !== "AGENT_STATE_MISSING"),
 	});
 }
 
@@ -444,16 +468,21 @@ async function cmdChatPost(room) {
 // --- graph -----------------------------------------------------------------
 
 async function cmdGraph(argv) {
-	rejectUnknownFlags(argv, ["--all", "--max-inspect", "--refresh"]);
+	rejectUnknownFlags(argv, ["--all", "--max-inspect", "--refresh", "--with-chat"]);
 	if (flag(argv, "--refresh")) graphCache.clearParentCache();
 	const maxInspect = flagValue(argv, "--max-inspect");
 	if (maxInspect !== undefined && !/^\d{1,3}$/.test(maxInspect)) {
 		fail("--max-inspect must be a number (max 3 digits)");
 	}
+	// Opt-in: each room costs one round trip, and only the coordination view
+	// needs them. Rooms are validated here so a typo never reaches argv.
+	const withChat = flagValue(argv, "--with-chat");
+	const chatRooms = withChat === undefined ? [] : withChat.split(",").map((room) => safeRoom(room.trim()));
 	json(
 		await collectGraph({
 			all: flag(argv, "--all"),
 			maxInspect: maxInspect === undefined ? undefined : Number(maxInspect),
+			chatRooms,
 		}),
 	);
 }
@@ -574,7 +603,7 @@ live plane (talks to the Paseo daemon):
   pteam chat list
   pteam chat read <room> [--limit <n>]
   pteam chat post <room>                   (message on stdin)
-  pteam graph [--all] [--max-inspect <n>] [--refresh]
+  pteam graph [--all] [--max-inspect <n>] [--refresh] [--with-chat <room[,room]>]
   pteam watchdog [--stale-after <ms>]
   pteam web [--port <n>] [--open] [--no-token]
 

--- a/docs/multi-supervisor-topology.md
+++ b/docs/multi-supervisor-topology.md
@@ -1,0 +1,547 @@
+# Mở rộng topology: nhiều Supervisor, nhiều Lead, fork/handoff
+
+Plan cho bước mở rộng từ mô hình hiện tại (1 Supervisor → 1 Lead → N Peer) sang
+**N Supervisor ↔ N Lead ↔ N Peer**, cộng cơ chế fork/handoff context giữa các
+Lead cùng vai.
+
+Mọi quyết định ở §3 đều neo vào bằng chứng đo thật ở §1. Không mục nào dựa trên
+suy đoán về khả năng của Paseo/Pi.
+
+Môi trường đo: Windows, `paseo` 0.3.0 (daemon local, 21 agent thật), `pi` 0.84.2,
+ngày 2026-08-27/28.
+
+---
+
+## 1. Bằng chứng đã đo
+
+### 1.1 Fork + import context — HOẠT ĐỘNG
+
+| Kiểm chứng | Kết quả |
+|---|---|
+| `pi --fork <session-id>` giữ nguyên context | ✅ hỏi lại codeword → trả đúng |
+| Session gốc sau khi fork | ✅ không đổi 1 byte |
+| `paseo import <session-id> --provider pi-lead` | ✅ ra agent Paseo thật |
+| Context sống sót qua import | ✅ `paseo logs` hiện đủ lịch sử cũ |
+| `PASEO_PI_ROLE` được inject sau import | ✅ agent tự nhận vai "Project Lead" |
+| `ParentAgentId` của agent import | ✅ `null` → là root sẵn, không cần detach |
+| Hiện trong `paseo ls -g` với prefix role | ✅ `pi-lead/...` → `inferRole()` chạy được, không phải sửa |
+| Fork session do **Paseo quản lý** | ✅ chạy đúng y hệt phiên `pi` chạy tay |
+
+### 1.2 Fork = copy file, KHÔNG tốn lượt LLM
+
+So sánh cấu trúc file gốc và file fork:
+
+- Bản fork **copy nguyên mọi entry**, giữ nguyên chuỗi `id`/`parentId` (5 entry
+  đầu trùng id từng chữ với bản gốc).
+- Header mới có `id` = session UUID mới, `timestamp` mới, và
+  `parentSession` = **đường dẫn tuyệt đối tới file nguồn**.
+
+⇒ Fork materialize được bằng **thao tác file thuần**: ghi header mới (UUIDv7) +
+append nguyên các entry cũ. Không cần spawn `pi`, không tốn lượt LLM, gần như
+tức thời kể cả với session lớn.
+
+**Đã kiểm chứng end-to-end**: file fork tự dựng bằng script → `paseo import` →
+agent trả lời đúng codeword kế thừa (`FALCON-9920, LEAD-L2`).
+
+### 1.3 Model của agent import — SỬA ĐƯỢC, nhưng chỉ qua MCP
+
+Khi import, model **không** lấy từ session mà lấy **phần tử đầu trong inventory
+của provider**:
+
+| Session nguồn | Provider import | Model nhận được |
+|---|---|---|
+| `Minnyat/deepseek-v4-flash` | `pi-lead` | `Minnyat/claude-opus-5` |
+| `Minnyat/glm-5.2` | `pi-lead` | `Minnyat/claude-opus-5` |
+| `Minnyat/deepseek-v4-flash` | `pi-peer` (không có `additionalModels`) | `Minnyat/claude-opus-5` |
+
+(`paseo provider models pi-lead --json` → index 0 = `Minnyat/claude-opus-5`.)
+
+**CLI không sửa được** — `import` không có `--model`, `agent update` chỉ có
+`--name` / `--thinking` / `--label`, `send` không có override.
+
+**MCP thì sửa được.** `update_agent { agentId, settings: { model, thinkingOptionId } }`
+đổi model thật — đã đo: `config.model` và `runtimeInfo.model` cùng chuyển từ
+`claude-opus-5` sang `glm-5.2`, và agent chạy tiếp đúng trên model mới.
+
+⚠️ `persistence.metadata.model` **không** được cập nhật (giữ giá trị lúc tạo)
+⇒ khi verify routing phải đọc `runtimeInfo.model`, không đọc `persistence`.
+
+⇒ Đây **không còn là chặn đường**, nhưng là một bước bắt buộc: import xong phải
+`update_agent` ép đúng route rồi mới verify.
+
+> Hậu quả thật khi bỏ qua bước này: agent kẹt `claude-opus-5`, gateway trả `524`
+> rồi `Stream ended without finish_reason` nhiều lần, không cách nào re-route
+> bằng CLI, phải bỏ agent.
+
+### 1.4 Paseo đã lưu sẵn mọi metadata cần thiết
+
+`$PASEO_HOME/agents/<cwd-slug>/<agent-id>.json` chứa:
+
+```jsonc
+{
+  "labels":      { "team.experiment": "copyfork" },     // đọc ngược được
+  "config":      { "model": "Minnyat/glm-5.2" },
+  "runtimeInfo": { "sessionId": "01a04613-…", "model": "…", "thinkingOptionId": "off" },
+  "persistence": { "sessionId": "01a04613-…",
+                   "nativeHandle": "C:\\…\\sessions\\…\\<ts>_<sessionId>.jsonl" }
+}
+```
+
+⇒ **Không cần tự dựng registry.** `agentId ↔ sessionId ↔ file session ↔ labels ↔
+model` đều có sẵn trong state file của Paseo. Đây là nguồn tốt hơn registry tự
+ghi: không phụ thuộc extension có được nạp hay không, không có ghi đua.
+
+(Chỉ `paseo ls`/`inspect` là không trả `labels`; `ls --label k=v` lọc được, và
+state file đọc ngược được.)
+
+### 1.5 Chat room — là bus N↔N thật
+
+| Kiểm chứng | Kết quả |
+|---|---|
+| `author` của message | ✅ **UUID agent thật** + `authorName` → cạnh graph `confirmed`, không heuristic |
+| Trường có sẵn | `replyTo`, `mentionAgentIds`, `mentionLabels`, `--since`, `--agent` filter |
+| `@mention` với agent **idle** | ✅ **đánh thức** — idle → running sau **34ms** |
+| `@mention` với agent **đang bận** | ✅ **xếp hàng, không mất** |
+| `@mention` theo **label** | ❌ **không delivery** — control test bằng shortId thì thức ngay ⇒ `mentionLabels` chỉ là tokenizer |
+| Membership / ACL của room | ❌ không có |
+| 4 post đồng thời (trong 123ms) | ✅ không mất, không trùng, mỗi cái 1 timestamp ms riêng, **total order** |
+| CAS / atomic claim | ❌ không có — cả 4 claim đều thành công |
+
+⇒ Chat vừa là **sổ cái** vừa là **chuông cửa**. Bỏ được mô hình 2 lớp
+"post room + send prompt trỏ tới room".
+
+### 1.6 Giới hạn kích thước message (~32 KB, Windows)
+
+`paseo chat post <room> <message>` nhận message **chỉ qua argv** — không có
+`--message-file` / stdin.
+
+| Kích thước | Kết quả |
+|---|---|
+| 4 000 / 10 000 / 32 000 ký tự | ✅ lưu đủ |
+| 100 000 ký tự | ❌ `spawnSync … ENAMETOOLONG` |
+
+Trần là giới hạn `CreateProcess` của Windows (~32767 ký tự cho cả command line);
+Linux cao hơn nhiều ⇒ **protocol phải lấy trần của nền thấp nhất**.
+
+⇒ `TEAM_MESSAGE_V1` cap payload **8 KB** (giữ nguyên cap đang có ở
+`cli/paseo-team.mjs:401`), và **mọi bằng chứng lớn đi bằng con trỏ** (đường dẫn,
+SHA, agent-ref) — diff/log/OCR manifest đều vượt trần nếu inline.
+
+### 1.7 Chat không có trong MCP
+
+Agent Lead thật `mcp {"connect":"paseo"}` → **60 tools**; search `"chat"` /
+`"room"` / `"message"` đều không có kết quả. Đối chiếu code: `PASEO_TOOLS`
+(`extensions/paseo-team-policy.ts:64-96`) không có tool chat nào.
+
+⇒ Lead/Supervisor chạm chat **chỉ qua bash** — một bề mặt **policy không soi
+được**: không gate room, không ép envelope, không audit. Quan sát phụ: agent tự
+đoán sai cú pháp (`paseo chat send` thay vì `post`) ⇒ CLI trần là bề mặt dễ sai.
+
+### 1.8 Peer bị chặn chat — invariant còn nguyên
+
+`PASEO_CLI_RE` (`extensions/paseo-team-policy.ts:349`) có `chat` trong danh sách
+subcommand, peer bị chặn Paseo CLI qua bash (dòng 1303-1309), và peer không có
+MCP. ⇒ Peer **không** chạm được chat bằng đường nào.
+
+### 1.9 Detach — một chiều, làm peer câm
+
+- `paseo agent detach` xoá `ParentAgentId` → `null`, agent vẫn sống.
+- **Không có lệnh nghịch đảo** ⇒ irreversible.
+- Peer đã detach gọi `peer_ask_lead` → `PARENT_LEAD_UNAVAILABLE`, fail-closed
+  ⇒ **peer câm, không escalate được**.
+- Thứ tự gate: check brief V3 chạy **trước** resolve parent.
+- **Docs Paseo nói rõ**: *"Detach is an explicit user action in the subagents
+  track, not an agent tool"* và *"Do not … invoke CLI or wire-level detach
+  operations."* ⇒ trong plan này detach là **thao tác của Human**, agent không
+  được tự gọi.
+
+### 1.10 Parentage là khai báo, không xác thực
+
+Set `PASEO_AGENT_ID=<id-lead>` trong env của shell rồi `paseo run` → agent mới
+nhận `ParentAgentId = <id-lead>`, dù lead đó **không hề tạo nó**.
+
+- Lợi: dựng được topology tuỳ ý từ CLI.
+- Hại: `peer_ask_lead` fail-closed **dựa trên đúng trường này** ⇒ với N lead,
+  giả mạo parent = escalate đi nhầm lead.
+
+(Docs chỉ mô tả ngữ nghĩa — *"When an agent creates another agent without a
+workspace ID, the new agent is its subagent"* — không nói gì về xác thực.)
+
+### 1.11 `send_agent_prompt` không có arg guard
+
+`send_agent_prompt` nằm trong `PASEO_TOOLS.orchestration` → có trong
+`LEAD_ALLOWED_MCP_TARGETS`. Chỉ `create_agent` có argument guard
+(`supervisorCreateAgentBlockReason`, dòng 455). ⇒ Lead A prompt được **bất kỳ
+agent nào**, kể cả Peer thuộc Lead B — bypass hoàn toàn B.
+
+### 1.12 Auto-compaction: fork KHÔNG giải quyết được giới hạn context
+
+`docs/compaction.md` của pi: auto-compaction kích hoạt khi
+`contextTokens > contextWindow - reserveTokens`, và có `reason: "overflow"` kèm
+`willRetry` — pi tự nén rồi chạy lại lượt bị tràn.
+
+⇒ Fork một Lead sắp full context sẽ cho ra một Lead **đã bị nén**, chứ không
+phải bản sao trung thực — đúng bằng cái mà `/compact` tại chỗ đã làm.
+**Fork giải quyết bàn giao và chạy song song, KHÔNG giải quyết giới hạn context.**
+Đây là điều chỉnh tiền đề, cần ghi vào prompt để Lead không dùng fork sai mục đích.
+
+### 1.13 Bề mặt đang dựa vào KHÔNG có trong docs chính thức
+
+Đọc `paseo.sh/docs` (`/docs`, `/docs/cli`, `/docs/orchestration`,
+`/docs/workspaces`, `/docs/providers`):
+
+| Lệnh | Có trong docs? |
+|---|---|
+| `paseo agent detach` | ✅ có, kèm quy tắc "user action" |
+| `paseo run` (một phần flag) | ✅ có |
+| `paseo schedule` | ✅ có |
+| **`paseo import`** | ❌ **không hề xuất hiện** |
+| **`paseo chat` (mọi subcommand)** | ❌ **không hề xuất hiện** |
+| `paseo agent update` | ❌ không có (nhưng MCP `update_agent` thì có trong skill chính thức) |
+| `paseo loop`, `paseo heartbeat` | ❌ không có ở trang CLI |
+
+⇒ **Hai primitive mà PR-B và PR-E dựa vào nhiều nhất đều là bề mặt không có tài
+liệu** — không có hợp đồng ổn định, có thể đổi bất cứ lúc nào. Bắt buộc phải có
+contract test riêng, theo đúng khuôn `test/paseo-contract.test.mjs` đang có.
+
+### 1.14 Paseo đã ship sẵn orchestration skills
+
+Cài sẵn tại `~/.claude/skills/`: `paseo`, `paseo-handoff`, `paseo-committee`,
+`paseo-advisor`, `paseo-loop`.
+
+Điểm quan trọng — **handoff chính thức của Paseo KHÔNG phải fork session**:
+
+> "Transfer the current task — context, decisions, failed attempts, constraints —
+> to a fresh agent. The receiving agent starts with **zero context**, so the
+> handoff prompt must be a self-contained briefing."
+
+⇒ Có **hai** cơ chế bàn giao, khác nhau về bản chất:
+
+| | Briefing handoff (Paseo chính thức) | Session fork (§1.1-1.3) |
+|---|---|---|
+| Context bên nhận | Zero + brief tự soạn | Nguyên văn lịch sử |
+| Độ trung thực | Mất, do phải tóm tắt | Cao |
+| Thiên kiến kế thừa | Không | **Có** — kế thừa cả framing |
+| Bề mặt phụ thuộc | Có tài liệu | **Không có tài liệu** |
+| Chi phí | Một lượt soạn brief | Gần như 0 (copy file) |
+
+Chúng bổ sung nhau, không thay thế nhau — xem quy tắc chọn ở §3 PR-E.
+
+Ngoài ra skill chính thức còn cho biết:
+
+- `notifyOnFinish` là cơ chế **native**; *"Don't poll `list_agents` or
+  `get_agent_status` to 'check on' a running agent."*
+- `create_heartbeat` gửi prompt định kỳ **về lại conversation hiện tại**;
+  `create_schedule` chạy agent mới theo cron.
+- `~/.paseo/orchestration-preferences.json` là nơi chính thức chọn provider theo
+  vai (`impl`/`ui`/`research`/`planning`/`audit`) — **trùng vai trò** với
+  `cluster-routing.local.json` của pack; phải chốt cái nào là nguồn sự thật.
+
+---
+
+## 2. Ràng buộc thiết kế rút ra
+
+1. **Chat là mặt phẳng phối hợp duy nhất giữa Lead/Supervisor** — thứ duy nhất
+   vừa query được (graph) vừa đánh thức được (delivery).
+2. **Broadcast theo domain phải tự expand** — mention theo label không tới nơi.
+3. **Lease chỉ advisory nếu chỉ dựa vào chat** — muốn cứng phải chặn ở
+   tool-call time trong extension.
+4. **Model sau import phải ép lại qua MCP `update_agent`** rồi mới verify
+   `runtimeInfo` (không đọc `persistence`).
+5. **Fork kế thừa niềm tin, không kế thừa quyền** — authority tính lại mỗi lượt
+   từ brief V3 (thiết kế cũ đúng), nhưng identity/ownership thì đi theo.
+   Bằng chứng: agent fork tự nhận là `LEAD-A` và **từ chối** hành động dưới danh
+   nghĩa `lead-B` ("would put a false identity into a shared coordination room").
+6. **Fork không dùng để cứu context sắp tràn** (§1.12) và không dùng cho vai cần
+   độc lập (anti-pattern 8.13).
+7. **Detach là thao tác của Human**, không phải của agent (§1.9).
+8. **Metadata đọc từ state file của Paseo**, không tự dựng registry (§1.4).
+9. **`import` và `chat` là bề mặt không tài liệu** ⇒ phải có contract test.
+10. **Không poll** — dùng `notifyOnFinish` / heartbeat thay vòng lặp thăm dò.
+
+---
+
+## 3. Lộ trình PR
+
+Chuỗi phụ thuộc: **A → B → C → E**, D chạy song song sau A.
+(C cần B để đọc room lease; E cần C, vì fork không có lease = 2 writer;
+D cần A để biết ai sở hữu agent nào.)
+
+### PR-A — Identity: đọc metadata từ state file của Paseo — ✅ ĐÃ LÀM
+
+**Vấn đề.** `ROLES` (`cli/lib/graph.mjs:27`) chỉ có 3 giá trị, `inferRole()` suy
+từ prefix provider ⇒ N supervisor trông y hệt nhau.
+
+**Làm.**
+
+- `cli/lib/agent-state.mjs`: đọc `$PASEO_HOME/agents/<cwd-slug>/<id>.json` →
+  `{ labels, config.model, runtimeInfo.{sessionId,model,thinkingOptionId}, persistence.nativeHandle }`.
+  Fail mềm khi thiếu file (agent mới, hoặc `PASEO_HOME` khác) → `degraded[]`.
+- `domain` = `labels["team.domain"]`, đặt lúc tạo bằng `--label` /
+  `create_agent labels`. Không cần registry riêng (§1.4).
+- `pteam agents` thêm cột `domain` + `model`; `pteam graph` gắn `domain` vào node
+  và group theo domain.
+- Contract test cho hình dạng state file (§1.13).
+
+**DoD.** Đọc đúng cả 3 role; thiếu file → `degraded`, không crash; graph hiển thị
+domain; test chạy bằng fixture, không cần daemon.
+
+---
+
+### PR-B — `team_chat` tool + `TEAM_MESSAGE_V1` + cạnh message — ✅ ĐÃ LÀM
+
+**Vấn đề.** MCP không có tool chat (§1.7); Lead/Supervisor chạm chat qua bash →
+không policy, không audit, dễ sai cú pháp.
+
+**Làm.**
+
+- Custom tool `team_chat` (cùng khuôn `peer_ask_lead` / `team_watchdog`), wrap
+  `paseo chat` CLI, **chỉ** cấp cho lead + supervisor.
+  Actions: `post` / `read` / `rooms`.
+- Ép envelope `TEAM_MESSAGE_V1`: `FROM_AGENT_ID`, `FROM_ROLE`, `FROM_DOMAIN`,
+  `KIND`, `TOPIC`, `CORRELATION_ID`, `HOP`, `TTL`.
+  Kind: `handoff | dependency | claim | release | question | decision | progress`.
+  - `HOP`/`TTL` chống ping-pong (lead↔lead đối xứng, khác peer→lead một chiều).
+  - Dedup theo `CORRELATION_ID` phía đọc.
+  - **Cap payload 8 KB** (§1.6); bằng chứng lớn đi bằng con trỏ.
+- Wake: tool tự chèn `@<shortId>` cho từng recipient. Broadcast theo domain →
+  tự expand `@domain:<d>` bằng `paseo ls --label team.domain=<d>` rồi mention
+  từng shortId (label-mention không delivery — §1.5).
+- Room allowlist theo agent (bù cho việc room không có ACL).
+- **Siết bash**: mở rộng chặn `paseo chat` qua bash cho **cả** lead/supervisor,
+  buộc đi qua `team_chat`.
+- `pteam graph --with-chat`: cạnh `type: "message"`, `confidence: "confirmed"`
+  từ `paseo chat read --json`. **Đóng PR-4 trong `docs/webui-architecture.md`.**
+- Contract test cho `paseo chat` (§1.13).
+
+**DoD.** Lead A → Lead B qua `team_chat` đánh thức B; envelope sai → từ chối;
+`HOP > max` → chặn; payload > 8 KB → chặn kèm gợi ý dùng con trỏ; graph vẽ đúng
+cạnh confirmed; bash `paseo chat` bị chặn cho mọi role.
+
+---
+
+#### Đã giao (PR-A + PR-B)
+
+| Thành phần | Nơi |
+|---|---|
+| Đọc state file của Paseo (labels, parent, model, sessionId, sessionFile) | `cli/lib/agent-state.mjs` |
+| `paseoHome()` / `paseoAgentsDir()` (tôn trọng `PASEO_HOME`) | `cli/lib/config-walker.mjs` |
+| Node mang `domain`/`model`/`modelDrift`/`sessionId`, `counts.byDomain`, `parentSource` | `cli/lib/graph.mjs` |
+| Cây spawn dựng từ đĩa; `inspect` chỉ tốn cho agent KHÔNG có state file | `cli/lib/graph.mjs` |
+| Envelope `TEAM_MESSAGE_V1` + expand `domain:<x>` + cap 8 KB + hop/TTL + room allowlist | `scripts/team-chat.mjs` |
+| Tool `team_chat` (lead + supervisor), chặn `paseo chat` qua bash cho MỌI role | `extensions/paseo-team-policy.ts` |
+| `pteam agents [--domain <d>]`, `pteam graph --with-chat <room[,room]>` | `cli/paseo-team.mjs` |
+| Env `PASEO_TEAM_DOMAIN`, `PASEO_TEAM_ROOMS`, `PASEO_HOME` | `pteam env list` |
+| Ship `team-chat.mjs` | `scripts/install.{sh,ps1}` + `installer-contract.test.mjs` |
+
+Test: `test/agent-state.test.mjs` (mới), `test/team-chat.test.mjs` (mới),
+`test/graph.test.mjs` + `test/policy.test.mts` (mở rộng). 22/22 xanh, typecheck sạch.
+
+**Verify thật trên daemon (30 agent):**
+
+- `pteam graph --refresh` cold: **`inspectSpent: 0`**, 9 cạnh spawn, **3.66s**
+  (trước: ~12s và phải poll nhiều lượt mới đủ cây, tối đa 6 `inspect`/lượt).
+- `team-chat.mjs post` từ Lead thật → người nhận đang `idle` chuyển `running`
+  ⇒ envelope + mention giao được.
+- `pteam graph --with-chat exp-room-1` → 1 cạnh `message`
+  `confidence: "confirmed"`, `origin: agent`, đúng from/to/kind/topic/room,
+  `inspectSpent: 0`, `degraded: 0`.
+- Lead thật chạy `paseo chat ls` qua bash → bị chặn, trả đúng thông báo
+  chuyển hướng sang `team_chat`.
+
+**Lệch so với plan, có chủ đích:** PR-A không dựng registry riêng như dự kiến —
+state file của Paseo (§1.4) đã có đủ, nên module chỉ đọc. Phần thưởng ngoài dự
+kiến: label `paseo.parent-agent-id` cho luôn cây spawn (177/259 agent có), nên
+`inspect` gần như không còn cần.
+
+### PR-C — Scope lease (bắt buộc trước khi bật multi-lead)
+
+**Vấn đề.** Invariant "một writer cho một moving scope" hiện được giữ *tình cờ*
+vì chỉ có 1 Lead. N Lead + fork phá thẳng nó.
+
+**Làm — 2 tầng.**
+
+1. **Ledger (advisory).** Room `leases`: `CLAIM` / `RENEW` / `RELEASE` qua
+   `team_chat`, có `SCOPE`, `TTL`, `AGENT_ID`. Winner = CLAIM sớm nhất còn hạn
+   (dựa vào total order theo timestamp server — §1.5).
+2. **Enforcement (cứng).** Policy extension chặn `create_agent` của Lead khi args
+   mang `MODE: write` / `EDIT_AUTHORITY: allowed` mà Lead **chưa là winner**.
+   Guard chạy ở tool-call time ngay trong agent — cùng khuôn
+   `supervisorCreateAgentBlockReason`.
+
+**Quyết định phải chốt trước khi code:** guard phải spawn `paseo chat read`
+(~3s) đồng bộ mỗi lần `create_agent`. Hành vi khi lệnh đó lỗi:
+**fail-closed** (Lead không tạo được writer) hay **fail-open** (lease vô nghĩa)?
+Đề xuất: **fail-closed kèm mã `BLOCKED: LEASE_UNVERIFIABLE`** — nhất quán với
+mọi guard khác của pack, và một Lead không tạo được writer là sự cố nhìn thấy
+được, còn hai writer thì không.
+
+- Watchdog: phát hiện lease quá hạn của Lead đã chết → **báo cáo, không tự thu hồi**.
+
+**DoD.** 2 Lead cùng claim 1 scope → chỉ 1 tạo được writer, cái kia nhận
+`BLOCKED: SCOPE_LEASE_HELD`; lease hết hạn thì giải phóng; `chat read` lỗi →
+`BLOCKED: LEASE_UNVERIFIABLE`; test bằng fixture, không cần daemon.
+
+---
+
+### PR-D — Governance nhiều Supervisor
+
+**Làm.**
+
+- `SUPERVISOR_OBSERVATION` / `SUPERVISOR_DECISION` thêm `DOMAIN:`. Lead **từ chối**
+  decision ngoài domain đã khai.
+- Jurisdiction chồng lấn = fail-closed, escalate Human.
+- Siết `supervisorCreateAgentBlockReason`: `labels.recovery_for` phải ⊆ domain
+  của chính supervisor đó (đọc từ state file — §1.4).
+- **Guard cho `send_agent_prompt`** (§1.11): target phải là con của mình, hoặc là
+  một Lead/Supervisor — **không** được prompt thẳng Peer của Lead khác.
+- Observation loop dùng **`create_heartbeat`** thay vì tự poll (§1.14), scope
+  theo domain.
+- Ghi vào docs: parentage là khai báo qua env, không xác thực (§1.10) — trust
+  boundary mà `peer_ask_lead` đang tin.
+
+**DoD.** Decision ngoài domain bị Lead từ chối; recovery ngoài domain bị chặn;
+`send_agent_prompt` tới peer của lead khác bị chặn; heartbeat thay thế vòng poll.
+
+---
+
+### PR-E — Fork / handoff
+
+**Quy tắc chọn cơ chế** (§1.14) — Lead phải nêu rõ lý do chọn:
+
+| Tình huống | Cơ chế |
+|---|---|
+| Vai cần **độc lập** (reviewer, challenger, supervisor) | **Briefing handoff** — fork bị **cấm** (anti-pattern 8.13) |
+| Bàn giao khi ngữ cảnh gọn, tóm tắt được | Briefing handoff (đường có tài liệu, ưu tiên mặc định) |
+| Cần **giữ nguyên** lịch sử suy luận: chia tải, đổi host/model, tiếp quản giữa chừng | **Session fork** |
+| Lead sắp **full context** | **Không phải fork** — dùng `/compact` (§1.12) |
+
+**Làm.**
+
+- `scripts/team-fork.mjs`:
+  1. Đọc `persistence.nativeHandle` + `runtimeInfo.sessionId` từ state file (§1.4).
+  2. Materialize fork bằng **copy file** (§1.2) — 0 lượt LLM.
+  3. `paseo import --provider <role-provider> --cwd <path> --label …`
+  4. **MCP `update_agent { settings: { model, thinkingOptionId } }`** ép đúng route (§1.3).
+  5. Verify `runtimeInfo.model` / `runtimeInfo.thinkingOptionId` — **không** đọc
+     `persistence.metadata.model` (stale).
+  6. Lệch → `BLOCKED: FORK_MODEL_UNROUTABLE`, xoá agent vừa import.
+- **Fork seed bắt buộc**: prompt đầu tiên vô hiệu hoá mọi ownership claim kế
+  thừa — nêu rõ B sở hữu gì, A giữ gì, và B **không** hành động dưới danh nghĩa A.
+- **Peer của Lead cũ**: không cướp. A giữ đến khi peer xong (không có API
+  reparent; detach làm peer câm và là thao tác của Human — §1.9).
+- Handoff phải kèm `CLAIM`/`RELEASE` của PR-C, nếu không fork = 2 writer.
+
+**DoD.** Copy-fork → import → `update_agent` → agent trả lời đúng context cũ,
+chạy đúng model route; model lệch → chặn đúng mã lỗi + dọn agent; fork cho vai
+độc lập bị từ chối; fork khi lý do là "hết context" bị từ chối kèm gợi ý `/compact`.
+
+---
+
+### PR-F — Multi-host (khoanh vùng để sau)
+
+`scripts/remote-paseo.mjs` không cover `chat`, và chưa biết chat room là
+per-daemon hay có đồng bộ. Toàn bộ §1 đo trên daemon local.
+
+---
+
+## 4. Việc phải làm xuyên suốt mọi PR
+
+1. **Tương thích ngược.** Mô hình 1-Lead đang chạy thật. `prompts/lead.md`,
+   `prompts/supervisor.md`, `skills/paseo-team-lead/SKILL.md` (450 dòng) đều giả
+   định đúng một Lead và một Supervisor. Thêm cờ
+   `PASEO_TEAM_TOPOLOGY=single|multi`; `multi` là opt-in cho tới khi PR-C xong.
+2. **WebUI.** 6 tab là bề mặt hạng nhất. N supervisor/lead + cạnh message đổi
+   hẳn tab Team graph và Roles. Mỗi PR phải kèm phần UI tương ứng.
+3. **Contract test cho bề mặt không tài liệu** (§1.13): `paseo import`,
+   `paseo chat`, hình dạng state file — theo khuôn `test/paseo-contract.test.mjs`.
+4. **Chốt nguồn sự thật routing**: `~/.paseo/orchestration-preferences.json`
+   (chính thức) vs `cluster-routing.local.json` (của pack) — §1.14.
+
+---
+
+## 5. Còn chưa biết
+
+| Chưa biết | Chặn PR nào | Xử lý |
+|---|---|---|
+| Chat retention / hiệu năng room hàng nghìn message | PR-B (nhẹ) | Dùng cursor `--since`, đo lúc làm |
+| Ngưỡng số agent làm wake/chat chậm | PR-B (nhẹ) | Đo lúc làm |
+| Chat cross-host | PR-F | Đã khoanh ra ngoài |
+| Fork một session **rất lớn** (vài MB) — thời gian copy + hành vi compaction thực tế | PR-E (nhẹ) | Cơ chế đã rõ (§1.2, §1.12); chỉ còn đo số |
+
+---
+
+## 6. Câu hỏi gửi upstream Paseo
+
+1. `paseo import` và `paseo chat` có được hỗ trợ chính thức không? Cả hai đều
+   **không có trong docs** nhưng là primitive chính của thiết kế này.
+2. CLI `paseo agent update` có thêm `--model` được không, cho ngang MCP
+   `update_agent settings.model`?
+3. `mentionLabels` có kế hoạch fan-out delivery theo label không?
+4. Có API nghịch đảo `detach` (re-attach / reparent) không?
+
+---
+
+## 7. Test plan — PR-A và PR-B
+
+Theo quy ước repo: liệt kê case trước, viết test cho ĐỎ, rồi mới implement.
+
+### 7.1 PR-A — `cli/lib/agent-state.mjs` + hiển thị domain
+
+Test thuần bằng fixture (thư mục `PASEO_HOME` giả), không cần daemon.
+
+| # | Case | Kỳ vọng |
+|---|---|---|
+| A1 | State file đầy đủ | Trả `{labels, model, sessionId, sessionFile, thinkingOptionId}` |
+| A2 | Thiếu file state | `null` + 1 mục `degraded`, **không throw** |
+| A3 | JSON hỏng | `degraded` kèm lý do, không làm hỏng cả snapshot |
+| A4 | Thiếu `runtimeInfo` (agent vừa tạo, chưa khởi động) | `sessionId: null`, không coi là lỗi |
+| A5 | `labels` rỗng / không có `team.domain` | `domain: null`, node vẫn render |
+| A6 | `PASEO_HOME` bị override qua env | Đọc đúng thư mục override |
+| A7 | cwd-slug có ký tự lạ (space, unicode, `..`) | Slug hoá đúng, không thoát khỏi thư mục |
+| A8 | `config.model` ≠ `runtimeInfo.model` | Ưu tiên `runtimeInfo`, và cảnh báo lệch |
+| A9 | `persistence.metadata.model` stale (§1.3) | **Không** được dùng làm nguồn model |
+| A10 | `buildGraph` với node có domain | Node mang `domain`, `counts` group theo domain |
+| A11 | 2 supervisor khác domain | Hiển thị tách bạch, không gộp thành 1 role bucket |
+| A12 | Contract: hình dạng state file thật | Test riêng cần daemon, ngoài CI (khuôn `paseo-contract.test.mjs`) |
+
+### 7.2 PR-B — `team_chat` + `TEAM_MESSAGE_V1` + cạnh message
+
+Test bằng fake `paseo` CLI (đã có khuôn `test/fixtures/fake-paseo.mjs`).
+
+**Envelope**
+
+| # | Case | Kỳ vọng |
+|---|---|---|
+| B1 | Envelope hợp lệ | Post thành công, trả `correlationId` |
+| B2 | Thiếu trường bắt buộc | Từ chối, không gọi CLI |
+| B3 | `KIND` ngoài danh sách | Từ chối |
+| B4 | Trùng trường / trường lạ | Từ chối (fail-closed, giống parser V3) |
+| B5 | Payload 8 KB + 1 byte | Từ chối kèm gợi ý dùng con trỏ |
+| B6 | Payload có ký tự đa byte sát ngưỡng | Đo theo **byte UTF-8**, không theo số ký tự |
+| B7 | `HOP` ≥ max | Chặn, không post |
+| B8 | `TTL` đã hết | Chặn |
+| B9 | Body chứa chuỗi `TEAM_MESSAGE_V1` giả trong phần text | Không được parse thành envelope thứ hai |
+
+**Quyền và định tuyến**
+
+| # | Case | Kỳ vọng |
+|---|---|---|
+| B10 | Peer gọi `team_chat` | Bị chặn (tool không có trong allowlist của peer) |
+| B11 | Lead gọi `paseo chat` qua bash | Bị chặn, hướng sang `team_chat` |
+| B12 | Supervisor gọi `paseo chat` qua bash | Bị chặn |
+| B13 | Post vào room ngoài allowlist | Bị chặn |
+| B14 | Broadcast `@domain:x` | Expand thành N mention shortId, đúng số agent khớp label |
+| B15 | Broadcast domain không có agent nào | Trả rõ "0 recipient", **không** post âm thầm |
+| B16 | `paseo ls --label` lỗi khi expand | Fail-closed, không post nửa vời |
+
+**Đồ thị**
+
+| # | Case | Kỳ vọng |
+|---|---|---|
+| B17 | `chat read` trả message có `author` là UUID | Cạnh `message` + `confidence: "confirmed"` |
+| B18 | `author: "manual"` (người post) | Cạnh gắn nguồn `human`, không phải agent |
+| B19 | Cùng `correlationId` xuất hiện 2 lần | Chỉ vẽ 1 cạnh (dedup đã có ở `buildGraph`) |
+| B20 | `chat read` lỗi/timeout | `degraded[]`, đồ thị vẫn render |
+| B21 | Mention tới agent không có trong listing | Cạnh `orphan`, không âm thầm bỏ |
+| B22 | Contract: `chat post/read` thật | Test riêng cần daemon, ngoài CI |

--- a/docs/multi-supervisor-topology.md
+++ b/docs/multi-supervisor-topology.md
@@ -329,7 +329,10 @@ cạnh confirmed; bash `paseo chat` bị chặn cho mọi role.
 | Node mang `domain`/`model`/`modelDrift`/`sessionId`, `counts.byDomain`, `parentSource` | `cli/lib/graph.mjs` |
 | Cây spawn dựng từ đĩa; `inspect` chỉ tốn cho agent KHÔNG có state file | `cli/lib/graph.mjs` |
 | Envelope `TEAM_MESSAGE_V1` + expand `domain:<x>` + cap 8 KB + hop/TTL + room allowlist | `scripts/team-chat.mjs` |
-| Tool `team_chat` (lead + supervisor), chặn `paseo chat` qua bash cho MỌI role | `extensions/paseo-team-policy.ts` |
+| **Luật** `team_chat`: allowlist, role gate, chặn `paseo chat` qua bash | `extensions/paseo-team-core/policy-core.ts` (**trung lập runtime**) |
+| Bind luật vào Pi (đăng ký tool + hook bash) | `extensions/paseo-team-policy.ts` |
+| Bind luật vào Claude Code (hook bash) | `extensions/paseo-team-core/claude-policy.ts` |
+| Tool `team_chat` cho Claude qua MCP | `scripts/claude-team-mcp.mjs` |
 | `pteam agents [--domain <d>]`, `pteam graph --with-chat <room[,room]>` | `cli/paseo-team.mjs` |
 | Env `PASEO_TEAM_DOMAIN`, `PASEO_TEAM_ROOMS`, `PASEO_HOME` | `pteam env list` |
 | Ship `team-chat.mjs` | `scripts/install.{sh,ps1}` + `installer-contract.test.mjs` |
@@ -346,8 +349,19 @@ Test: `test/agent-state.test.mjs` (mới), `test/team-chat.test.mjs` (mới),
 - `pteam graph --with-chat exp-room-1` → 1 cạnh `message`
   `confidence: "confirmed"`, `origin: agent`, đúng from/to/kind/topic/room,
   `inspectSpent: 0`, `degraded: 0`.
-- Lead thật chạy `paseo chat ls` qua bash → bị chặn, trả đúng thông báo
+- Lead thật (Pi) chạy `paseo chat ls` qua bash → bị chặn, trả đúng thông báo
   chuyển hướng sang `team_chat`.
+- Adapter Claude chặn y hệt cho `lead`/`supervisor`, vẫn cho qua
+  `paseo ls -g` / `remote-paseo.mjs` / `git status` (guard hẹp đúng chủ ý), và
+  Peer vẫn bị chặn bởi luật Paseo-CLI sẵn có.
+
+**Đặt luật ở đâu — điều kiện đúng/sai, không phải dọn dẹp.** `policy-core.ts`
+ghi rõ: *"a rule that lives in only one adapter is a rule the other runtime
+silently lacks"*. Bản nháp đầu của PR này đặt guard chat trong adapter Pi, nên
+một `claude-lead` sẽ đi vòng qua nó chỉ bằng cách chọn provider khác. Luật đã
+được chuyển vào core; test parity (`claude-policy.test.mjs`,
+`claude-team-mcp.test.mjs`, `installer-contract.test.mjs`) giữ cho hai runtime
+không lệch nhau nữa.
 
 **Lệch so với plan, có chủ đích:** PR-A không dựng registry riêng như dự kiến —
 state file của Paseo (§1.4) đã có đủ, nên module chỉ đọc. Phần thưởng ngoài dự

--- a/docs/webui-architecture.md
+++ b/docs/webui-architecture.md
@@ -266,12 +266,18 @@ chiếu với `roleProfiles` mà `paseo-team status` đã trả về.
 - **PR-3 — Permissions inbox** — *xong*: màn hình duyệt quyền, hàng không phân
   loại được thì hiện nhưng không cho một-chạm, audit tại
   `~/.paseo-pi-team/permit-audit.jsonl`.
-- **PR-4 — Cạnh message** — *chưa*: `graph --with-logs` parse `PEER_MESSAGE_V1`
-  từ timeline của Lead; drawer timeline per-agent. Đây là phần phụ thuộc
-  `paseo logs`, tức là phần dễ degrade nhất (§2).
+- **PR-4 — Cạnh message** — *xong* (qua chat room, không qua `paseo logs`):
+  `pteam graph --with-chat <room>` đọc `paseo chat read --json`, nơi `author`
+  là **agent id thật**, nên cạnh là `confidence: "confirmed"` chứ không phải
+  suy đoán. Hoá ra không cần `graph --with-logs` — phụ thuộc `paseo logs`
+  (thứ dễ timeout nhất, §2) đã tránh được hoàn toàn. Envelope là
+  `TEAM_MESSAGE_V1` (`scripts/team-chat.mjs`), recipient lấy từ `@mention`
+  trong thân tin nhắn — chính token Paseo dùng để giao. Drawer timeline
+  per-agent vẫn chưa làm.
 - **PR-5 — Multi-host** — *chưa*: host selector qua `remote-paseo.mjs`, endpoint
   bí mật không rời server.
 
-Trạng thái hiện tại của đồ thị: node + cạnh **spawn** + badge permit là dữ liệu
-thật; cạnh **message** chưa có (legend vẫn ghi rõ "suy đoán" để không ai đọc
+Trạng thái hiện tại của đồ thị: node + cạnh **spawn** + badge permit + cạnh
+**message** (từ chat room) đều là dữ liệu thật; cạnh message suy-đoán-từ-log
+vẫn chưa có (legend vẫn ghi rõ "suy đoán" để không ai đọc
 nhầm một đồ thị thiếu cạnh thành một đội không nói chuyện với nhau).

--- a/extensions/paseo-team-core/claude-policy.ts
+++ b/extensions/paseo-team-core/claude-policy.ts
@@ -28,6 +28,7 @@ import {
 	ALL_PASEO_TOOLS,
 	callsAgentBrowserCli,
 	callsPaseoCli,
+	coordinationCliBlockReason,
 	extraTools,
 	gitAuthorityBlockReason,
 	isAgentBrowserMcpTarget,
@@ -270,6 +271,12 @@ export function claudeToolBlockReason(
 	}
 
 	if (classified.kind === "write" || classified.kind === "edit") return null;
+
+	if (classified.kind === "bash" && (role === "lead" || role === "supervisor")) {
+		// Same wall as the Pi adapter: a Lead on Claude must not be able to reach
+		// the chat CLI either, or the typed channel is decoration on one runtime.
+		return coordinationCliBlockReason(role, bashCommand(input.toolInput));
+	}
 
 	if (classified.kind === "bash" && role === "peer") {
 		const command = bashCommand(input.toolInput);

--- a/extensions/paseo-team-core/claude-policy.ts
+++ b/extensions/paseo-team-core/claude-policy.ts
@@ -29,6 +29,7 @@ import {
 	callsAgentBrowserCli,
 	callsPaseoCli,
 	coordinationCliBlockReason,
+	supportScriptBlockReason,
 	extraTools,
 	gitAuthorityBlockReason,
 	isAgentBrowserMcpTarget,
@@ -286,6 +287,8 @@ export function claudeToolBlockReason(
 		if (callsAgentBrowserCli(command)) {
 			return "Peer cannot run agent-browser CLI through bash; BROWSER_MCP_AUTHORITY only permits the typed agent-browser MCP surface.";
 		}
+		const supportScriptReason = supportScriptBlockReason(role, command);
+		if (supportScriptReason) return supportScriptReason;
 		return gitAuthorityBlockReason(
 			command,
 			peerGitAuthority(brief),

--- a/extensions/paseo-team-core/policy-core.ts
+++ b/extensions/paseo-team-core/policy-core.ts
@@ -92,6 +92,19 @@ export const LEAD_ALLOWED_MCP_TARGETS: string[] = [
 export const MCP_TOOLS = ["mcp", "mcp_script"];
 export const PEER_COMMUNICATION_TOOL = "peer_ask_lead";
 export const TEAM_WATCHDOG_TOOL = "team_watchdog";
+export const TEAM_CHAT_TOOL = "team_chat";
+/** Payload ceiling, kept in sync with scripts/team-chat.mjs MAX_BODY_BYTES. */
+export const TEAM_CHAT_MAX_BODY_BYTES = 8192;
+/** Mirror of TEAM_MESSAGE_KINDS in scripts/team-chat.mjs (shapes tool schemas). */
+export const TEAM_MESSAGE_KIND_NAMES = [
+	"handoff",
+	"dependency",
+	"claim",
+	"release",
+	"question",
+	"decision",
+	"progress",
+] as const;
 export const PI_READ_ONLY = ["read", "bash", PEER_COMMUNICATION_TOOL];
 export const PI_WRITE = ["read", "write", "edit", "bash", PEER_COMMUNICATION_TOOL];
 
@@ -189,6 +202,7 @@ export function policyFor(role: TeamRole, peerMode: PeerMode): Policy {
 						(tool) => tool !== PEER_COMMUNICATION_TOOL,
 					),
 					TEAM_WATCHDOG_TOOL,
+					TEAM_CHAT_TOOL,
 					...LEAD_ALLOWED_MCP_TARGETS,
 					...MCP_TOOLS,
 				],
@@ -196,7 +210,7 @@ export function policyFor(role: TeamRole, peerMode: PeerMode): Policy {
 			};
 		case "supervisor":
 			return {
-				allow: ["read", "mcp", TEAM_WATCHDOG_TOOL, ...PASEO_TOOLS.monitoring, "send_agent_prompt"],
+				allow: ["read", "mcp", TEAM_WATCHDOG_TOOL, TEAM_CHAT_TOOL, ...PASEO_TOOLS.monitoring, "send_agent_prompt"],
 				deny: ["write", "edit", "mcp_script", ...ALL_PASEO_TOOLS],
 			};
 		case "peer":
@@ -280,6 +294,41 @@ const PASEO_CLI_RE =
 
 export function callsPaseoCli(command: string): boolean {
 	return PASEO_CLI_RE.test(command);
+}
+
+/**
+ * `paseo chat ...` in a bash command, in any spelling the shims use.
+ *
+ * Chat is the coordination bus between Leads and Supervisors, and it is the one
+ * Paseo surface with no MCP tool behind it (60 tools, none of them chat --
+ * measured 2026-08-27). Left on bash it is a channel no policy can inspect: no
+ * room allowlist, no TEAM_MESSAGE_V1 envelope, no size ceiling, no audit.
+ */
+const PASEO_CHAT_CLI_RE =
+	/\b(paseo|paseo-pi|pio)(?:\.(?:cmd|exe|ps1|sh))?\s+chat\b/i;
+
+export function callsPaseoChatCli(command: string): boolean {
+	return PASEO_CHAT_CLI_RE.test(command);
+}
+
+/**
+ * Lead/Supervisor bash guard: redirect the chat CLI to the typed tool.
+ *
+ * Deliberately narrow -- a chat-only redirect, not a new CLI ban. Every other
+ * Paseo command a Lead runs from bash (remote-paseo.mjs, `ls`, status checks)
+ * is untouched. Peers are already covered by the blanket callsPaseoCli() block
+ * and are not this function's business.
+ *
+ * This lives in the CORE, not in an adapter: a Lead running on Claude must hit
+ * the same wall as a Lead running on Pi, or the guard is decoration.
+ */
+export function coordinationCliBlockReason(
+	role: TeamRole,
+	command: string,
+): string | null {
+	if (role !== "lead" && role !== "supervisor") return null;
+	if (!callsPaseoChatCli(command)) return null;
+	return `Use the team_chat tool instead of the Paseo chat CLI. The typed tool enforces the TEAM_MESSAGE_V1 envelope, the room allowlist, the ${TEAM_CHAT_MAX_BODY_BYTES}-byte payload ceiling and hop/TTL loop protection - none of which exist when the command is typed by hand.`;
 }
 
 // ---------------------------------------------------------------------------
@@ -1167,6 +1216,27 @@ export function teamToolBlockReason(
 	}
 	if (toolName === TEAM_WATCHDOG_TOOL && role !== "lead" && role !== "supervisor") {
 		return "team_watchdog is restricted to Lead and Supervisor agents.";
+	}
+	const chatReason = teamChatToolBlockReason(role, toolName);
+	if (chatReason) return chatReason;
+	return null;
+}
+
+/**
+ * Who may hold the coordination channel. A Peer coordinates with exactly one
+ * agent -- its parent Lead -- and has peer_ask_lead for that; a room would hand
+ * it a broadcast surface the parent cannot see.
+ *
+ * Called with a role alone it answers "may this role hold team_chat at all",
+ * which is what the runtime adapters ask before exposing the tool.
+ */
+export function teamChatToolBlockReason(
+	role: TeamRole,
+	toolName: string = TEAM_CHAT_TOOL,
+): string | null {
+	if (toolName !== TEAM_CHAT_TOOL) return null;
+	if (role !== "lead" && role !== "supervisor") {
+		return "team_chat is restricted to Lead and Supervisor agents.";
 	}
 	return null;
 }

--- a/extensions/paseo-team-core/policy-core.ts
+++ b/extensions/paseo-team-core/policy-core.ts
@@ -312,6 +312,47 @@ export function callsPaseoChatCli(command: string): boolean {
 }
 
 /**
+ * Direct invocation of a pack support script that grants authority the caller's
+ * role does not have.
+ *
+ * Blocking `paseo chat` while leaving `node .../team-chat.mjs` open moves the
+ * bypass one word to the left: the script's own gate reads PASEO_PI_ROLE and
+ * PASEO_AGENT_ID from an environment the calling process owns, so it can only
+ * check what the caller asserts. This puts both spellings at the same bar.
+ *
+ * Two scripts are deliberately NOT listed:
+ *   - ocr-review.mjs        the Reviewer skill runs it directly, by design
+ *   - team-communication.mjs equivalent to peer_ask_lead — same parent-scoped,
+ *                            fail-closed sender, no authority a Peer lacks
+ *
+ * Like every bash rule in this file this is a HEURISTIC, not an authorization
+ * boundary: a determined process can always re-spell the invocation. It closes
+ * the obvious door, and the daemon remains the only real boundary.
+ */
+const AUTHORITY_SUPPORT_SCRIPTS = ["team-chat.mjs", "remote-paseo.mjs"];
+const SUPPORT_SCRIPT_RE = new RegExp(
+	`(?:^|[\\s"'\`/\\\\])(${AUTHORITY_SUPPORT_SCRIPTS.map((name) => name.replace(".", "\\.")).join("|")})(?=$|["'\`\\s])`,
+	"i",
+);
+
+export function callsTeamSupportScript(command: string): boolean {
+	if (typeof command !== "string" || command.trim() === "") return false;
+	// Require an actual invocation, not a bare mention in prose or an echo.
+	if (!/\bnode(?:\.exe)?\b/i.test(command)) return false;
+	return SUPPORT_SCRIPT_RE.test(command);
+}
+
+/** Reason a Peer may not run a pack support script from bash. */
+export function supportScriptBlockReason(
+	role: TeamRole,
+	command: string,
+): string | null {
+	if (role !== "peer") return null;
+	if (!callsTeamSupportScript(command)) return null;
+	return "Peer cannot run this Paseo team support script from bash — it would grant coordination or remote-host authority the Peer role does not have. Use peer_ask_lead to raise a DEPENDENCY_REQUEST instead.";
+}
+
+/**
  * Lead/Supervisor bash guard: redirect the chat CLI to the typed tool.
  *
  * Deliberately narrow -- a chat-only redirect, not a new CLI ban. Every other
@@ -329,6 +370,23 @@ export function coordinationCliBlockReason(
 	if (role !== "lead" && role !== "supervisor") return null;
 	if (!callsPaseoChatCli(command)) return null;
 	return `Use the team_chat tool instead of the Paseo chat CLI. The typed tool enforces the TEAM_MESSAGE_V1 envelope, the room allowlist, the ${TEAM_CHAT_MAX_BODY_BYTES}-byte payload ceiling and hop/TTL loop protection - none of which exist when the command is typed by hand.`;
+}
+
+/**
+ * One sentence the runtime adapters put in the team_chat tool description.
+ * Deliberately does NOT claim the chat surface is sealed: the bash rules are
+ * heuristics, rooms are unrestricted unless PASEO_TEAM_ROOMS is set, and chat
+ * rooms have no ACL of their own.
+ */
+export function teamChatToolDescription(): string {
+	return (
+		"Coordinate with other Leads and Supervisors through a Paseo chat room. " +
+		"`post` delivers a TEAM_MESSAGE_V1 envelope and wakes each recipient by mention; " +
+		"`read` returns the room with envelopes parsed; `rooms` lists rooms. " +
+		"Recipients are agent ids/short-ids, or 'domain:<name>' to reach every agent carrying that domain label. " +
+		"Use this instead of the Paseo chat CLI, which the bash guard redirects here. " +
+		"Rooms are unrestricted unless PASEO_TEAM_ROOMS is set."
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/paseo-team-policy.ts
+++ b/extensions/paseo-team-policy.ts
@@ -67,6 +67,11 @@ import {
 	teamToolBlockReason,
 	PEER_COMMUNICATION_TOOL,
 	TEAM_WATCHDOG_TOOL,
+	TEAM_CHAT_TOOL,
+	TEAM_CHAT_MAX_BODY_BYTES,
+	TEAM_MESSAGE_KIND_NAMES,
+	coordinationCliBlockReason,
+	teamChatToolBlockReason,
 	type ParsedTaskBrief,
 	type PeerMode,
 	type Policy,
@@ -137,6 +142,40 @@ function registerTeamTools(pi: ExtensionAPI, r: TeamRole): void {
 		async execute(_id, params, signal, _onUpdate, _ctx) {
 			if (r !== "lead" && r !== "supervisor") return { content: [{ type: "text", text: "team_watchdog is available only to Lead or Supervisor agents." }], details: undefined, isError: true };
 			const result = await runSupportScript("watchdog.mjs", [JSON.stringify(params ?? {})], signal, 130_000);
+			return { content: [{ type: "text", text: result.stdout || result.stderr }], details: undefined, isError: result.code !== 0 };
+		},
+	});
+	pi.registerTool({
+		name: TEAM_CHAT_TOOL,
+		label: "team_chat",
+		description:
+			"Coordinate with other Leads and Supervisors through a Paseo chat room. `post` delivers a TEAM_MESSAGE_V1 envelope and wakes each recipient by mention; `read` returns the room with envelopes parsed; `rooms` lists rooms. Recipients are agent ids/short-ids, or 'domain:<name>' to reach every agent carrying that domain label. This is the only sanctioned chat path — the Paseo chat CLI is blocked.",
+		parameters: {
+			type: "object",
+			properties: {
+				action: { type: "string", enum: ["post", "read", "rooms"] },
+				room: { type: "string", maxLength: 128 },
+				kind: { type: "string", enum: [...TEAM_MESSAGE_KIND_NAMES] },
+				topic: { type: "string", maxLength: 128 },
+				message: { type: "string", minLength: 1, maxLength: TEAM_CHAT_MAX_BODY_BYTES },
+				to: { type: "array", items: { type: "string", maxLength: 136 }, minItems: 1, maxItems: 64 },
+				correlationId: { type: "string", maxLength: 128 },
+				replyTo: { type: "string", maxLength: 128 },
+				hop: { type: "integer", minimum: 0, maximum: 7 },
+				ttl: { type: "integer", minimum: 1, maximum: 8 },
+				since: { type: "string", maxLength: 64 },
+				limit: { type: "integer", minimum: 1, maximum: 500 },
+			},
+			required: ["action"],
+			additionalProperties: false,
+		} as any,
+		async execute(_id, params, signal, _onUpdate, _ctx) {
+			const blocked = teamChatToolBlockReason(r, TEAM_CHAT_TOOL);
+			if (blocked) return { content: [{ type: "text", text: blocked }], details: undefined, isError: true };
+			const { action, ...rest } = (params ?? {}) as Record<string, unknown>;
+			const command = action === "post" ? "post" : action === "read" ? "read" : "rooms";
+			const args = command === "rooms" ? [command] : [command, JSON.stringify(rest)];
+			const result = await runSupportScript("team-chat.mjs", args, signal);
 			return { content: [{ type: "text", text: result.stdout || result.stderr }], details: undefined, isError: result.code !== 0 };
 		},
 	});
@@ -325,6 +364,12 @@ export default function (pi: ExtensionAPI) {
 			const blockReason = mcpScriptBlockReason(r, code);
 			if (blockReason) {
 				return { block: true, reason: blockReason };
+			}
+		}
+		if ((r === "lead" || r === "supervisor") && isToolCallEventType("bash", event)) {
+			const chatReason = coordinationCliBlockReason(r, event.input.command ?? "");
+			if (chatReason) {
+				return { block: true, reason: chatReason };
 			}
 		}
 		if (r === "peer" && isToolCallEventType("bash", event)) {

--- a/extensions/paseo-team-policy.ts
+++ b/extensions/paseo-team-policy.ts
@@ -71,7 +71,9 @@ import {
 	TEAM_CHAT_MAX_BODY_BYTES,
 	TEAM_MESSAGE_KIND_NAMES,
 	coordinationCliBlockReason,
+	supportScriptBlockReason,
 	teamChatToolBlockReason,
+	teamChatToolDescription,
 	type ParsedTaskBrief,
 	type PeerMode,
 	type Policy,
@@ -148,8 +150,7 @@ function registerTeamTools(pi: ExtensionAPI, r: TeamRole): void {
 	pi.registerTool({
 		name: TEAM_CHAT_TOOL,
 		label: "team_chat",
-		description:
-			"Coordinate with other Leads and Supervisors through a Paseo chat room. `post` delivers a TEAM_MESSAGE_V1 envelope and wakes each recipient by mention; `read` returns the room with envelopes parsed; `rooms` lists rooms. Recipients are agent ids/short-ids, or 'domain:<name>' to reach every agent carrying that domain label. This is the only sanctioned chat path — the Paseo chat CLI is blocked.",
+		description: teamChatToolDescription(),
 		parameters: {
 			type: "object",
 			properties: {
@@ -387,6 +388,10 @@ export default function (pi: ExtensionAPI) {
 					reason:
 						"Peer cannot run agent-browser CLI through bash; BROWSER_MCP_AUTHORITY only permits the typed agent-browser MCP surface.",
 				};
+			}
+			const supportScriptReason = supportScriptBlockReason(r, command);
+			if (supportScriptReason) {
+				return { block: true, reason: supportScriptReason };
 			}
 			const gitBlockReason = gitAuthorityBlockReason(
 				command,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paseo-pi-team",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Paseo multi-agent role pack — one rule core, two runtimes (pi extension + Claude Code hooks), role prompts, support scripts.",
   "type": "module",

--- a/scripts/claude-team-mcp.mjs
+++ b/scripts/claude-team-mcp.mjs
@@ -72,8 +72,13 @@ export const TEAM_TOOLS = [
 	},
 	{
 		name: "team_chat",
+		// Mirrors policy-core's teamChatToolDescription(). This file is plain .mjs
+		// and cannot import the TypeScript core, so the text is duplicated and
+		// claude-team-mcp.test.mjs asserts the two never drift. Deliberately does
+		// NOT claim the chat surface is sealed: the bash rules are heuristics and
+		// rooms are unrestricted unless PASEO_TEAM_ROOMS is set.
 		description:
-			"Coordinate with other Leads and Supervisors through a Paseo chat room. `post` delivers a TEAM_MESSAGE_V1 envelope and wakes each recipient by mention; `read` returns the room with envelopes parsed; `rooms` lists rooms. Recipients are agent ids/short-ids, or 'domain:<name>' to reach every agent carrying that domain label. This is the only sanctioned chat path — the Paseo chat CLI is blocked on both runtimes.",
+			"Coordinate with other Leads and Supervisors through a Paseo chat room. `post` delivers a TEAM_MESSAGE_V1 envelope and wakes each recipient by mention; `read` returns the room with envelopes parsed; `rooms` lists rooms. Recipients are agent ids/short-ids, or 'domain:<name>' to reach every agent carrying that domain label. Use this instead of the Paseo chat CLI, which the bash guard redirects here. Rooms are unrestricted unless PASEO_TEAM_ROOMS is set.",
 		roles: ["lead", "supervisor"],
 		script: "team-chat.mjs",
 		timeoutMs: 30_000,

--- a/scripts/claude-team-mcp.mjs
+++ b/scripts/claude-team-mcp.mjs
@@ -1,11 +1,11 @@
-// claude-team-mcp.mjs — stdio MCP server exposing the pack's two team tools
+// claude-team-mcp.mjs — stdio MCP server exposing the pack's team tools
 // to Claude Code, which has no extension API to register tools directly.
 //
-// Pi gets `peer_ask_lead` and `team_watchdog` from the policy extension
-// (registerTeamTools). Claude gets the SAME two tools from this server, with
+// Pi gets `peer_ask_lead`, `team_watchdog` and `team_chat` from the policy
+// extension (registerTeamTools). Claude gets the SAME tools from this server, with
 // the same role gate and the same underlying support scripts, so a Peer talks
 // to its Lead identically on both runtimes. Claude sees them as
-// `mcp__paseo-team__peer_ask_lead` / `mcp__paseo-team__team_watchdog`.
+// `mcp__paseo-team__peer_ask_lead` / `__team_watchdog` / `__team_chat`.
 //
 // Zero dependencies on purpose (the pack ships no runtime deps): this speaks
 // the MCP stdio framing — one JSON-RPC message per line — directly.
@@ -67,6 +67,43 @@ export const TEAM_TOOLS = [
 				globalDeadlineMs: { type: "integer", minimum: 1000, maximum: 120000 },
 				commandTimeoutMs: { type: "integer", minimum: 250, maximum: 30000 },
 			},
+			additionalProperties: false,
+		},
+	},
+	{
+		name: "team_chat",
+		description:
+			"Coordinate with other Leads and Supervisors through a Paseo chat room. `post` delivers a TEAM_MESSAGE_V1 envelope and wakes each recipient by mention; `read` returns the room with envelopes parsed; `rooms` lists rooms. Recipients are agent ids/short-ids, or 'domain:<name>' to reach every agent carrying that domain label. This is the only sanctioned chat path — the Paseo chat CLI is blocked on both runtimes.",
+		roles: ["lead", "supervisor"],
+		script: "team-chat.mjs",
+		timeoutMs: 30_000,
+		// `rooms` takes no payload; post/read carry theirs as one JSON argument,
+		// matching how the Pi extension invokes the same script.
+		buildArgs: (params) => {
+			const { action, ...rest } = params ?? {};
+			const command = action === "post" ? "post" : action === "read" ? "read" : "rooms";
+			return command === "rooms" ? [command] : [command, JSON.stringify(rest)];
+		},
+		inputSchema: {
+			type: "object",
+			properties: {
+				action: { type: "string", enum: ["post", "read", "rooms"] },
+				room: { type: "string", maxLength: 128 },
+				kind: {
+					type: "string",
+					enum: ["handoff", "dependency", "claim", "release", "question", "decision", "progress"],
+				},
+				topic: { type: "string", maxLength: 128 },
+				message: { type: "string", minLength: 1, maxLength: 8192 },
+				to: { type: "array", items: { type: "string", maxLength: 136 }, minItems: 1, maxItems: 64 },
+				correlationId: { type: "string", maxLength: 128 },
+				replyTo: { type: "string", maxLength: 128 },
+				hop: { type: "integer", minimum: 0, maximum: 7 },
+				ttl: { type: "integer", minimum: 1, maximum: 8 },
+				since: { type: "string", maxLength: 64 },
+				limit: { type: "integer", minimum: 1, maximum: 500 },
+			},
+			required: ["action"],
 			additionalProperties: false,
 		},
 	},

--- a/scripts/claude-team-mcp.mjs
+++ b/scripts/claude-team-mcp.mjs
@@ -22,6 +22,13 @@ import { fileURLToPath } from "node:url";
 import { isEntrypoint } from "./lib-common.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+/**
+ * The advertised payload ceiling. team-chat.mjs enforces the real one, so drift
+ * here would only desynchronize what the schema promises from what the tool
+ * accepts — fail-closed, but confusing. The parity test keeps them equal.
+ */
+export const TEAM_CHAT_MAX_BODY_BYTES = 8192;
+
 export const SERVER_NAME = "paseo-team";
 export const SERVER_VERSION = "1.0.0";
 const DEFAULT_PROTOCOL_VERSION = "2025-06-18";
@@ -99,7 +106,9 @@ export const TEAM_TOOLS = [
 					enum: ["handoff", "dependency", "claim", "release", "question", "decision", "progress"],
 				},
 				topic: { type: "string", maxLength: 128 },
-				message: { type: "string", minLength: 1, maxLength: 8192 },
+				// Mirrors MAX_BODY_BYTES in team-chat.mjs (and TEAM_CHAT_MAX_BODY_BYTES
+				// in policy-core). claude-team-mcp.test.mjs pins the three together.
+				message: { type: "string", minLength: 1, maxLength: TEAM_CHAT_MAX_BODY_BYTES },
 				to: { type: "array", items: { type: "string", maxLength: 136 }, minItems: 1, maxItems: 64 },
 				correlationId: { type: "string", maxLength: 128 },
 				replyTo: { type: "string", maxLength: 128 },

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -38,6 +38,7 @@ $teamSupportFiles = @(
   "reliability.mjs",
   "watchdog.mjs",
   "team-communication.mjs",
+  "team-chat.mjs",
   "ocr-review.mjs",
   "remote-paseo.mjs",
   "model-routing.mjs",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,6 +54,7 @@ TEAM_SUPPORT_FILES=(
   reliability.mjs
   watchdog.mjs
   team-communication.mjs
+  team-chat.mjs
   ocr-review.mjs
   remote-paseo.mjs
   model-routing.mjs

--- a/scripts/team-chat.mjs
+++ b/scripts/team-chat.mjs
@@ -59,13 +59,23 @@ export const TEAM_MESSAGE_KINDS = Object.freeze([
 
 export const TEAM_CHAT_ROLES = Object.freeze(["lead", "supervisor"]);
 
-/** Portable payload ceiling (see the header note on argv limits). */
+/** Portable payload ceiling for the message text (see the argv note above). */
 export const MAX_BODY_BYTES = 8192;
+/**
+ * Ceiling for the WHOLE posted body. argv is what the platform bounds, and the
+ * mention head grows with the recipient count, so a wide `domain:` fan-out can
+ * push a legal message past the budget. Kept well under the ~32K Windows limit
+ * so the room stays postable from any host.
+ */
+export const MAX_ENVELOPE_BYTES = 16_384;
 /** A message may be relayed at most this many times. */
 export const MAX_HOP = 8;
 export const DEFAULT_TTL = 8;
 
 const TOKEN = /^[A-Za-z0-9._:-]{1,128}$/;
+/** A mention is interpolated into the body, so its charset is what keeps the
+ *  envelope from being forgeable — a newline here would inject header lines. */
+const MENTION_TOKEN = /^[A-Za-z0-9-]{4,64}$/;
 const AGENT_REF = /^[0-9a-fA-F][0-9a-fA-F-]{5,63}$/;
 const DOMAIN_PREFIX = "domain:";
 const ALLOWED_FIELDS = new Set(["room", "kind", "topic", "message", "to", "correlationId", "hop", "ttl", "replyTo"]);
@@ -165,6 +175,12 @@ export async function expandRecipients(to, options = {}) {
 	const add = (id, shortId) => {
 		if (self && (id === self || (shortId && self.startsWith(shortId)))) return;
 		const mention = shortId ?? String(id).slice(0, 7);
+		// Explicit recipients are AGENT_REF-checked above; rows from `paseo ls` are
+		// not, and they end up inside the message body. Fail closed rather than
+		// embed whatever the daemon happened to return.
+		if (!MENTION_TOKEN.test(mention)) {
+			throw bad("RECIPIENT_INVALID", `refusing to embed mention ${JSON.stringify(mention)}: not a plain token`);
+		}
 		if (seen.has(mention)) return;
 		seen.add(mention);
 		mentions.push(mention);
@@ -308,6 +324,13 @@ export async function postTeamMessage(input, options = {}) {
 		fromDomain: ctx.domain,
 		mentions,
 	});
+	const envelopeBytes = Buffer.byteLength(body, "utf8");
+	if (envelopeBytes > MAX_ENVELOPE_BYTES) {
+		throw bad(
+			"MESSAGE_TOO_LARGE",
+			`the envelope is ${envelopeBytes} bytes with ${mentions.length} mention(s), too large (max ${MAX_ENVELOPE_BYTES}). Narrow the recipients or send the detail by pointer.`,
+		);
+	}
 	const args = ["chat", "post", message.room, body];
 	if (message.replyTo) args.push("--reply-to", message.replyTo);
 	// One shot. `post` is a mutation with delivery ambiguity: a retry would
@@ -321,7 +344,7 @@ export async function postTeamMessage(input, options = {}) {
 		correlationId: message.correlationId,
 		recipients: agentIds,
 		mentions,
-		bytes: Buffer.byteLength(body, "utf8"),
+		bytes: envelopeBytes,
 		response,
 	};
 }

--- a/scripts/team-chat.mjs
+++ b/scripts/team-chat.mjs
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+/**
+ * team-chat.mjs — Lead ↔ Lead and Supervisor ↔ Lead coordination.
+ *
+ * Peers talk to their own Lead through team-communication.mjs (parent-scoped,
+ * one-way). This file is the other channel: a many-to-many bus for the seats
+ * that coordinate rather than execute.
+ *
+ * Why chat rooms and not `paseo send`, measured 2026-08-27:
+ *
+ *   - `send` is fire-and-forget and NOT queryable, so a graph can only guess
+ *     at it. `paseo chat read --json` returns the real author agent id, which
+ *     makes every edge `confirmed` instead of `suspected`.
+ *   - An `@<shortId>` mention WAKES an idle agent (34ms in the measurement)
+ *     and QUEUES for a busy one. So the room is both the ledger and the
+ *     doorbell; there is no need to post and then ring separately.
+ *   - Mentions are delivered by agent id only. `mentionLabels` is populated by
+ *     Paseo's tokenizer but does not fan out, so a domain broadcast has to be
+ *     expanded here, by us, into one mention per agent.
+ *
+ * Three bounds exist because the transport forces them, not for taste:
+ *
+ *   - MAX_BODY_BYTES: `paseo chat post` takes the message as ARGV and has no
+ *     --message-file. Windows caps a command line near 32K (measured: 32000
+ *     chars OK, 100000 -> ENAMETOOLONG). The protocol takes the lowest
+ *     platform's budget so a room stays readable from any host.
+ *   - MAX_HOP / TTL: Lead↔Lead is symmetric, unlike Peer→Lead, so a relay
+ *     without a bound ping-pongs forever. Note what this is NOT: a relaying
+ *     agent supplies its own `hop`, so the bound is cooperative — it stops an
+ *     agent that plays by the rules from looping, and gives a reader a
+ *     ping-pong it can SEE, but it cannot stop an agent that always sends
+ *     hop:0. Hard loop-breaking would need a daemon-side hop count.
+ *   - Room allowlist: chat rooms have no membership or ACL of their own, so
+ *     confinement has to come from this side.
+ *
+ * `paseo chat` is NOT in Paseo's published CLI documentation (checked
+ * 2026-08-28) — see docs/multi-supervisor-topology.md §1.13. Treat the shape
+ * as unverified upstream and keep test/paseo-contract.test.mjs honest about it.
+ */
+
+import { execFileSync } from "node:child_process";
+import { isEntrypoint, resolvePaseoExec } from "./lib-common.mjs";
+
+export const TEAM_MESSAGE_HEADER = "TEAM_MESSAGE_V1";
+
+/**
+ * `claim`/`release` exist for the scope lease (PR-C): the lease ledger is a
+ * room, so its verbs are message kinds rather than a second transport.
+ */
+export const TEAM_MESSAGE_KINDS = Object.freeze([
+	"handoff",
+	"dependency",
+	"claim",
+	"release",
+	"question",
+	"decision",
+	"progress",
+]);
+
+export const TEAM_CHAT_ROLES = Object.freeze(["lead", "supervisor"]);
+
+/** Portable payload ceiling (see the header note on argv limits). */
+export const MAX_BODY_BYTES = 8192;
+/** A message may be relayed at most this many times. */
+export const MAX_HOP = 8;
+export const DEFAULT_TTL = 8;
+
+const TOKEN = /^[A-Za-z0-9._:-]{1,128}$/;
+const AGENT_REF = /^[0-9a-fA-F][0-9a-fA-F-]{5,63}$/;
+const DOMAIN_PREFIX = "domain:";
+const ALLOWED_FIELDS = new Set(["room", "kind", "topic", "message", "to", "correlationId", "hop", "ttl", "replyTo"]);
+
+function bad(code, message) {
+	return Object.assign(new Error(message), { code });
+}
+
+function token(name, value) {
+	if (typeof value !== "string" || !TOKEN.test(value)) {
+		throw bad("FIELD_INVALID", `${name} must be a single token matching [A-Za-z0-9._:-] (max 128 chars)`);
+	}
+	return value;
+}
+
+/**
+ * Room confinement. Unset PASEO_TEAM_ROOMS keeps the surface as open as it is
+ * today (opt-in tightening, like PASEO_TEAM_LEAD_WRITE); once set it is a
+ * strict allowlist, and an empty value grants nothing rather than everything.
+ */
+export function roomAllowed(room, allowlist) {
+	if (allowlist === undefined || allowlist === null) return true;
+	const allowed = String(allowlist)
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+	return allowed.includes(room);
+}
+
+export function validateTeamMessage(input) {
+	if (!input || typeof input !== "object" || Array.isArray(input)) {
+		throw bad("MESSAGE_INVALID", "message must be an object");
+	}
+	for (const key of Object.keys(input)) {
+		if (!ALLOWED_FIELDS.has(key)) throw bad("MESSAGE_INVALID", `unknown field '${key}'`);
+	}
+	const { kind, message, room, topic, to } = input;
+	if (!TEAM_MESSAGE_KINDS.includes(kind)) {
+		throw bad("KIND_INVALID", `kind must be one of: ${TEAM_MESSAGE_KINDS.join(", ")}`);
+	}
+	if (typeof message !== "string" || message.trim() === "") {
+		throw bad("MESSAGE_INVALID", "message must be a non-empty string");
+	}
+	// Refuse to embed the marker: a body that carries it would let a relayed
+	// message look like a second envelope to anything reading the room.
+	if (message.includes(TEAM_MESSAGE_HEADER)) {
+		throw bad("MESSAGE_INVALID", `message must not contain the ${TEAM_MESSAGE_HEADER} marker`);
+	}
+	const bytes = Buffer.byteLength(message, "utf8");
+	if (bytes > MAX_BODY_BYTES) {
+		throw bad(
+			"MESSAGE_TOO_LARGE",
+			`message is ${bytes} bytes, too large (max ${MAX_BODY_BYTES}). Send large evidence by pointer — a path, a SHA, or an agent ref — not inline.`,
+		);
+	}
+	token("room", room);
+	token("topic", topic);
+	if (!Array.isArray(to) || to.length === 0) {
+		throw bad("RECIPIENTS_MISSING", "to must be a non-empty array of agent refs or 'domain:<name>' entries");
+	}
+	const hop = input.hop === undefined ? 0 : input.hop;
+	if (!Number.isInteger(hop) || hop < 0 || hop >= MAX_HOP) {
+		throw bad("HOP_EXCEEDED", `hop must be an integer in [0, ${MAX_HOP}) — a relay past that is a loop`);
+	}
+	const ttl = input.ttl === undefined ? DEFAULT_TTL : input.ttl;
+	if (!Number.isInteger(ttl) || ttl <= 0 || ttl > DEFAULT_TTL) {
+		throw bad("TTL_INVALID", `ttl must be an integer in (0, ${DEFAULT_TTL}]`);
+	}
+	return {
+		room,
+		kind,
+		topic,
+		message: message.trim(),
+		to: [...to],
+		hop,
+		ttl,
+		replyTo: input.replyTo === undefined ? null : token("replyTo", input.replyTo),
+		correlationId:
+			input.correlationId === undefined
+				? `team-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+				: token("correlationId", input.correlationId),
+	};
+}
+
+/**
+ * Turn `to` entries into mention tokens. `domain:<name>` is expanded here
+ * because Paseo delivers mentions by agent id only (measured) — a label
+ * mention parses but never reaches anyone.
+ */
+export async function expandRecipients(to, options = {}) {
+	const run = options.runPaseo ?? runPaseo;
+	const self = options.selfAgentId ?? null;
+	const mentions = [];
+	const agentIds = [];
+	const seen = new Set();
+
+	const add = (id, shortId) => {
+		if (self && (id === self || (shortId && self.startsWith(shortId)))) return;
+		const mention = shortId ?? String(id).slice(0, 7);
+		if (seen.has(mention)) return;
+		seen.add(mention);
+		mentions.push(mention);
+		if (id) agentIds.push(id);
+	};
+
+	for (const entry of to) {
+		if (typeof entry !== "string") throw bad("RECIPIENT_INVALID", `invalid recipient ${JSON.stringify(entry)}`);
+		if (entry.startsWith(DOMAIN_PREFIX)) {
+			const domain = token("domain", entry.slice(DOMAIN_PREFIX.length));
+			let rows;
+			try {
+				rows = await run(["ls", "-g", "--label", `team.domain=${domain}`]);
+			} catch (error) {
+				// Never post to a guessed audience: an unresolvable broadcast is a
+				// failure, not a smaller broadcast.
+				throw bad("RECIPIENT_EXPANSION_FAILED", `RECIPIENT_EXPANSION_FAILED: could not resolve domain '${domain}': ${String(error?.message ?? error)}`);
+			}
+			const list = Array.isArray(rows) ? rows : [];
+			for (const row of list) add(row?.id, typeof row?.shortId === "string" ? row.shortId : undefined);
+			if (list.length === 0 || list.every((row) => row?.id === self)) {
+				throw bad("NO_RECIPIENTS", `no recipient carries team.domain=${domain}`);
+			}
+			continue;
+		}
+		if (!AGENT_REF.test(entry)) throw bad("RECIPIENT_INVALID", `invalid recipient '${entry}'`);
+		add(entry, entry.slice(0, 7));
+	}
+	if (mentions.length === 0) throw bad("NO_RECIPIENTS", "no recipient resolved");
+	return { mentions, agentIds };
+}
+
+/**
+ * The wire format. Mentions come FIRST because Paseo parses delivery targets
+ * out of the message body; the envelope follows so a reader (and the graph)
+ * gets a stable, parseable header.
+ */
+export function buildEnvelope(message, { fromAgentId, fromRole, fromDomain, mentions = [] }) {
+	const head = mentions.map((m) => `@${m}`).join(" ");
+	const block = [
+		TEAM_MESSAGE_HEADER,
+		`KIND: ${message.kind}`,
+		`CORRELATION_ID: ${message.correlationId}`,
+		`TOPIC: ${message.topic}`,
+		`FROM_AGENT_ID: ${fromAgentId}`,
+		`FROM_ROLE: ${fromRole}`,
+		`FROM_DOMAIN: ${fromDomain || "-"}`,
+		`HOP: ${message.hop}`,
+		`TTL: ${message.ttl}`,
+		"",
+		message.message,
+	].join("\n");
+	return head ? `${head}\n${block}` : block;
+}
+
+const HEADER_LINE = /^([A-Z_]+):\s*(.+)$/;
+
+/**
+ * Parse the FIRST envelope out of a room message. Fail-closed: a block missing
+ * any field, or carrying a kind outside the set, yields null rather than a
+ * half-populated edge — the same rule parsePeerMessage follows.
+ */
+export function parseTeamMessage(text) {
+	if (typeof text !== "string") return null;
+	const start = text.indexOf(TEAM_MESSAGE_HEADER);
+	if (start < 0) return null;
+	const lines = text.slice(start).split(/\r?\n/).slice(1);
+	const fields = {};
+	for (const line of lines) {
+		if (line.trim() === "") break;
+		const match = HEADER_LINE.exec(line.trim());
+		if (!match) break;
+		fields[match[1]] = match[2].trim();
+	}
+	const kind = fields.KIND;
+	if (!TEAM_MESSAGE_KINDS.includes(kind)) return null;
+	for (const required of ["CORRELATION_ID", "TOPIC", "FROM_AGENT_ID", "FROM_ROLE", "HOP", "TTL"]) {
+		if (!fields[required]) return null;
+	}
+	const hop = Number.parseInt(fields.HOP, 10);
+	const ttl = Number.parseInt(fields.TTL, 10);
+	if (!Number.isInteger(hop) || !Number.isInteger(ttl)) return null;
+	return {
+		kind,
+		correlationId: fields.CORRELATION_ID,
+		topic: fields.TOPIC,
+		fromAgentId: fields.FROM_AGENT_ID,
+		fromRole: fields.FROM_ROLE,
+		fromDomain: fields.FROM_DOMAIN && fields.FROM_DOMAIN !== "-" ? fields.FROM_DOMAIN : null,
+		hop,
+		ttl,
+	};
+}
+
+export function runPaseo(args, timeoutMs = 20_000) {
+	const [bin, ...prefix] = resolvePaseoExec((reason) => {
+		throw bad("PASEO_EXEC_INVALID", `PASEO_TEAM_PASEO_EXEC ${reason}`);
+	});
+	try {
+		return JSON.parse(
+			execFileSync(bin, [...prefix, ...args, "--json"], {
+				encoding: "utf8",
+				timeout: timeoutMs,
+				stdio: ["ignore", "pipe", "pipe"],
+				env: process.env,
+				windowsHide: true,
+			}),
+		);
+	} catch (error) {
+		const text = `${error?.stderr ?? ""}\n${error?.stdout ?? ""}\n${error?.message ?? error}`;
+		throw bad("CLI_ERROR", text.split("\n").find((line) => line.trim()) ?? "paseo chat failed");
+	}
+}
+
+function selfContext(options) {
+	const role = (options.role ?? process.env.PASEO_PI_ROLE ?? "").trim().toLowerCase();
+	if (!TEAM_CHAT_ROLES.includes(role)) {
+		throw bad("ROLE_NOT_ALLOWED", `ROLE_NOT_ALLOWED: team_chat is for ${TEAM_CHAT_ROLES.join(" and ")} only (a Peer uses peer_ask_lead)`);
+	}
+	const selfAgentId = (options.selfAgentId ?? process.env.PASEO_AGENT_ID ?? "").trim();
+	if (!selfAgentId) throw bad("AGENT_ID_MISSING", "PASEO_AGENT_ID is missing");
+	return {
+		role,
+		selfAgentId,
+		domain: (options.domain ?? process.env.PASEO_TEAM_DOMAIN ?? "").trim() || null,
+		rooms: options.rooms ?? process.env.PASEO_TEAM_ROOMS,
+	};
+}
+
+export async function postTeamMessage(input, options = {}) {
+	const ctx = selfContext(options);
+	const message = validateTeamMessage(input);
+	if (!roomAllowed(message.room, ctx.rooms)) {
+		throw bad("ROOM_NOT_ALLOWED", `ROOM_NOT_ALLOWED: '${message.room}' is outside this agent's room allowlist`);
+	}
+	const run = options.runPaseo ?? runPaseo;
+	const { mentions, agentIds } = await expandRecipients(message.to, { runPaseo: run, selfAgentId: ctx.selfAgentId });
+	const body = buildEnvelope(message, {
+		fromAgentId: ctx.selfAgentId,
+		fromRole: ctx.role,
+		fromDomain: ctx.domain,
+		mentions,
+	});
+	const args = ["chat", "post", message.room, body];
+	if (message.replyTo) args.push("--reply-to", message.replyTo);
+	// One shot. `post` is a mutation with delivery ambiguity: a retry would
+	// double-deliver, and correlationId is for reader-side dedup, not transport.
+	const response = await run(args);
+	return {
+		ok: true,
+		room: message.room,
+		kind: message.kind,
+		topic: message.topic,
+		correlationId: message.correlationId,
+		recipients: agentIds,
+		mentions,
+		bytes: Buffer.byteLength(body, "utf8"),
+		response,
+	};
+}
+
+export async function readRoom(input, options = {}) {
+	const ctx = selfContext(options);
+	const room = token("room", input?.room);
+	if (!roomAllowed(room, ctx.rooms)) {
+		throw bad("ROOM_NOT_ALLOWED", `ROOM_NOT_ALLOWED: '${room}' is outside this agent's room allowlist`);
+	}
+	const run = options.runPaseo ?? runPaseo;
+	const args = ["chat", "read", room];
+	if (input?.since !== undefined) args.push("--since", token("since", String(input.since)));
+	if (input?.limit !== undefined) {
+		if (!Number.isInteger(input.limit) || input.limit < 1 || input.limit > 500) {
+			throw bad("FIELD_INVALID", "limit must be an integer in [1, 500]");
+		}
+		args.push("--limit", String(input.limit));
+	}
+	const rows = await run(args);
+	const messages = (Array.isArray(rows) ? rows : []).map((row) => ({
+		id: row?.id ?? null,
+		author: row?.author ?? null,
+		createdAt: row?.createdAt ?? null,
+		body: row?.body ?? "",
+		envelope: parseTeamMessage(row?.body),
+	}));
+	return { ok: true, room, count: messages.length, messages };
+}
+
+export async function listRooms(options = {}) {
+	selfContext(options);
+	const run = options.runPaseo ?? runPaseo;
+	const rows = await run(["chat", "ls"]);
+	return { ok: true, rooms: Array.isArray(rows) ? rows : [] };
+}
+
+async function main() {
+	const command = process.argv[2];
+	let input = {};
+	if (process.argv[3] !== undefined) {
+		try {
+			input = JSON.parse(process.argv[3]);
+		} catch (error) {
+			throw bad("INPUT_INVALID", `invalid JSON input: ${String(error?.message ?? error)}`);
+		}
+	}
+	if (command === "post") return console.log(JSON.stringify(await postTeamMessage(input), null, 2));
+	if (command === "read") return console.log(JSON.stringify(await readRoom(input), null, 2));
+	if (command === "rooms") return console.log(JSON.stringify(await listRooms(), null, 2));
+	throw bad("USAGE", "usage: team-chat.mjs post|read '<json>' | rooms");
+}
+
+export function isMainModule(entry = process.argv[1], moduleUrl = import.meta.url) {
+	return isEntrypoint(moduleUrl, entry);
+}
+
+if (isMainModule()) {
+	main().catch((error) => {
+		console.error(JSON.stringify({ ok: false, code: error.code ?? "TEAM_CHAT_FAILED", message: error.message }));
+		process.exit(2);
+	});
+}

--- a/test/agent-state.test.mjs
+++ b/test/agent-state.test.mjs
@@ -94,9 +94,23 @@ writeFileSync(join(agentsRoot, "C-Users-x-other", "notes.txt"), "ignore me", "ut
 
 // A6 — the root is an argument, so a throwaway PASEO_HOME works in tests and
 // a non-default PASEO_HOME works in production.
+//
+// A machine where Paseo has never written agent state has no root at all. That
+// is an ABSENT enrichment, not a fault: reporting it would put a line in
+// degraded[] on every snapshot taken on a fresh host and teach the operator to
+// ignore the list. Only a root that exists and resists reading is a fault.
 {
 	const { index, degraded } = buildStateIndex(join(root, "does-not-exist"));
 	assert.deepEqual(index, {}, "a missing agents root is empty, not a throw");
+	assert.deepEqual(degraded, [], "and absent is not degraded");
+}
+{
+	// A file where the directory should be: the data is unreachable for a reason
+	// the operator can act on, so say so.
+	const notADir = join(root, "agents-is-a-file");
+	writeFileSync(notADir, "not a directory", "utf8");
+	const { index, degraded } = buildStateIndex(notADir);
+	assert.deepEqual(index, {});
 	assert.equal(degraded.length, 1);
 	assert.equal(degraded[0].reason, "AGENT_STATE_ROOT_UNREADABLE");
 }

--- a/test/agent-state.test.mjs
+++ b/test/agent-state.test.mjs
@@ -1,0 +1,194 @@
+/**
+ * agent-state.test.mjs — Paseo writes everything the team graph needs into
+ * `$PASEO_HOME/agents/<cwd-slug>/<agent-id>.json`: labels (including the parent
+ * link), the resolved model, and the provider session id + file. Reading that
+ * is a filesystem operation, so it is fixture-testable end to end — unlike the
+ * `paseo inspect` fan-out it replaces, which costs ~3s per agent.
+ *
+ * The whole point of this module is that a missing or malformed state file is
+ * DATA, not a crash: the graph must still render and say what it could not read.
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	AGENT_DOMAIN_LABEL,
+	AGENT_PARENT_LABEL,
+	buildStateIndex,
+	normalizeAgentState,
+	readAgentStates,
+} from "../cli/lib/agent-state.mjs";
+
+const root = mkdtempSync(join(tmpdir(), "pst-agent-state-"));
+const agentsRoot = join(root, "agents");
+
+function writeState(slug, id, body) {
+	const dir = join(agentsRoot, slug);
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, `${id}.json`), typeof body === "string" ? body : JSON.stringify(body), "utf8");
+}
+
+const FULL = "11111111-1111-4111-8111-111111111111";
+const NO_RUNTIME = "22222222-2222-4222-8222-222222222222";
+const CORRUPT = "33333333-3333-4333-8333-333333333333";
+const BARE = "44444444-4444-4444-8444-444444444444";
+const DRIFT = "55555555-5555-4555-8555-555555555555";
+const MISSING = "66666666-6666-4666-8666-666666666666";
+
+writeState("C-Users-x-project", FULL, {
+	id: FULL,
+	provider: "pi-lead",
+	cwd: "C:\\Users\\x\\project",
+	workspaceId: "wks_abc",
+	title: "lead one",
+	labels: { "team.domain": "payments", [AGENT_PARENT_LABEL]: "99999999-9999-4999-8999-999999999999" },
+	config: { model: "Minnyat/glm-5.2" },
+	runtimeInfo: { provider: "pi-lead", sessionId: "01a04613-e0d1-7a62-b524-ef4fa9027fe6", model: "Minnyat/glm-5.2", thinkingOptionId: "off" },
+	persistence: {
+		sessionId: "01a04613-e0d1-7a62-b524-ef4fa9027fe6",
+		nativeHandle: "C:\\Users\\x\\.pi\\agent\\sessions\\--C--Users-x-project--\\2026-01-01T00-00-00-000Z_01a04613-e0d1-7a62-b524-ef4fa9027fe6.jsonl",
+		// Stale by design: Paseo does not rewrite this after update_agent, so it
+		// must never be used as a model source (measured 2026-08-28).
+		metadata: { model: "Minnyat/claude-opus-5" },
+	},
+});
+
+// A4 — an agent that was created but has not started yet has no runtimeInfo.
+writeState("C-Users-x-project", NO_RUNTIME, {
+	id: NO_RUNTIME,
+	provider: "pi-peer",
+	cwd: "C:\\Users\\x\\project",
+	labels: { "team.domain": "payments" },
+	config: { model: "Minnyat/deepseek-v4-flash" },
+});
+
+writeState("C-Users-x-project", CORRUPT, "{ not json");
+
+// A5 — no labels at all.
+writeState("C-Users-x-other", BARE, { id: BARE, provider: "pi-supervisor", cwd: "C:\\Users\\x\\other" });
+
+// A8 — runtimeInfo and config disagree (a model change that has not been
+// picked up, or picked up only at runtime).
+writeState("C-Users-x-other", DRIFT, {
+	id: DRIFT,
+	provider: "pi-lead",
+	cwd: "C:\\Users\\x\\other",
+	config: { model: "Minnyat/claude-opus-5" },
+	runtimeInfo: { model: "Minnyat/glm-5.2", thinkingOptionId: "high", sessionId: "s-drift" },
+});
+
+// Non-JSON files and nested junk must not enter the index.
+mkdirSync(join(agentsRoot, "C-Users-x-other", "nested"), { recursive: true });
+writeFileSync(join(agentsRoot, "C-Users-x-other", "notes.txt"), "ignore me", "utf8");
+
+// --- index -----------------------------------------------------------------
+{
+	const { index, degraded } = buildStateIndex(agentsRoot);
+	assert.equal(degraded.length, 0, "a healthy tree reports no faults");
+	assert.ok(index[FULL], "an agent is indexed by id, regardless of its cwd slug");
+	assert.ok(index[BARE], "agents under a different cwd slug are indexed too");
+	assert.equal(index["notes"], undefined, "non-JSON files never enter the index");
+	assert.equal(Object.keys(index).length, 5, "one entry per state file, no duplicates");
+}
+
+// A6 — the root is an argument, so a throwaway PASEO_HOME works in tests and
+// a non-default PASEO_HOME works in production.
+{
+	const { index, degraded } = buildStateIndex(join(root, "does-not-exist"));
+	assert.deepEqual(index, {}, "a missing agents root is empty, not a throw");
+	assert.equal(degraded.length, 1);
+	assert.equal(degraded[0].reason, "AGENT_STATE_ROOT_UNREADABLE");
+}
+
+// --- normalization ---------------------------------------------------------
+// A1 — the full shape.
+{
+	const { states } = readAgentStates([FULL], { root: agentsRoot });
+	const s = states[FULL];
+	assert.equal(s.agentId, FULL);
+	assert.equal(s.domain, "payments");
+	assert.equal(s.parentAgentId, "99999999-9999-4999-8999-999999999999", "the parent link comes from a label, not from `paseo inspect`");
+	assert.equal(s.model, "Minnyat/glm-5.2");
+	assert.equal(s.modelSource, "runtime");
+	assert.equal(s.modelDrift, false);
+	assert.equal(s.thinking, "off");
+	assert.equal(s.sessionId, "01a04613-e0d1-7a62-b524-ef4fa9027fe6");
+	assert.match(s.sessionFile, /\.jsonl$/, "the session file is the pi JSONL path");
+	assert.equal(s.workspaceId, "wks_abc");
+	assert.equal(s.title, "lead one");
+}
+
+// A9 — persistence.metadata.model is stale and must never win.
+{
+	const { states } = readAgentStates([FULL], { root: agentsRoot });
+	assert.notEqual(states[FULL].model, "Minnyat/claude-opus-5", "persistence.metadata.model is a creation-time snapshot, not the live model");
+}
+
+// A8 — runtimeInfo wins over config, and the disagreement is reported.
+{
+	const { states } = readAgentStates([DRIFT], { root: agentsRoot });
+	assert.equal(states[DRIFT].model, "Minnyat/glm-5.2", "runtimeInfo is what the agent actually runs");
+	assert.equal(states[DRIFT].modelSource, "runtime");
+	assert.equal(states[DRIFT].modelDrift, true, "a config/runtime mismatch is surfaced, not hidden");
+}
+
+// A4 — no runtimeInfo yet: fall back to config, and do not call it an error.
+{
+	const { states, degraded } = readAgentStates([NO_RUNTIME], { root: agentsRoot });
+	const s = states[NO_RUNTIME];
+	assert.equal(s.sessionId, null, "an agent that never started has no session");
+	assert.equal(s.sessionFile, null);
+	assert.equal(s.model, "Minnyat/deepseek-v4-flash");
+	assert.equal(s.modelSource, "config");
+	assert.equal(s.modelDrift, false);
+	assert.equal(degraded.length, 0, "a not-yet-started agent is normal, not a fault");
+}
+
+// A5 — no labels: the node still renders.
+{
+	const { states } = readAgentStates([BARE], { root: agentsRoot });
+	assert.equal(states[BARE].domain, null);
+	assert.equal(states[BARE].parentAgentId, null);
+	assert.deepEqual(states[BARE].labels, {});
+	assert.equal(states[BARE].model, null);
+	assert.equal(states[BARE].modelSource, null);
+}
+
+// A3 — corrupt JSON is a fault about ONE agent, not about the snapshot.
+{
+	const { states, degraded } = readAgentStates([CORRUPT, FULL], { root: agentsRoot });
+	assert.equal(states[CORRUPT], undefined);
+	assert.ok(states[FULL], "one bad file must not take the healthy ones down with it");
+	assert.equal(degraded.length, 1);
+	assert.equal(degraded[0].agentId, CORRUPT);
+	assert.equal(degraded[0].reason, "AGENT_STATE_UNREADABLE");
+}
+
+// A2 — an id with no state file at all.
+{
+	const { states, degraded } = readAgentStates([MISSING], { root: agentsRoot });
+	assert.equal(states[MISSING], undefined);
+	assert.equal(degraded.length, 1);
+	assert.equal(degraded[0].agentId, MISSING);
+	assert.equal(degraded[0].reason, "AGENT_STATE_MISSING");
+}
+
+// A7 — a hostile id must not reach outside the agents root.
+{
+	for (const bad of ["../../etc/passwd", "a/b", "..", "", null, 42]) {
+		const { states, degraded } = readAgentStates([bad], { root: agentsRoot });
+		assert.equal(Object.keys(states).length, 0, `'${bad}' must resolve to nothing`);
+		assert.equal(degraded[0]?.reason, "AGENT_STATE_ID_INVALID", `'${bad}' is rejected before any path is built`);
+	}
+}
+
+// normalizeAgentState is pure and must survive junk without throwing.
+assert.equal(normalizeAgentState(null, "x"), null);
+assert.equal(normalizeAgentState("nope", "x"), null);
+assert.equal(normalizeAgentState({ labels: "not-an-object" }, FULL).labels && Object.keys(normalizeAgentState({ labels: "not-an-object" }, FULL).labels).length, 0);
+assert.equal(AGENT_DOMAIN_LABEL, "team.domain");
+assert.equal(AGENT_PARENT_LABEL, "paseo.parent-agent-id");
+
+rmSync(root, { recursive: true, force: true });
+console.log("agent-state.test.mjs OK");

--- a/test/claude-policy.test.mjs
+++ b/test/claude-policy.test.mjs
@@ -350,4 +350,16 @@ assert.match(describeClaudePolicy("lead", null), /paseoMcp=\[/);
 	);
 }
 
+// --- OCR-001 parity: the support-script side door is shut on Claude too ----
+{
+	const bash = (role, command) =>
+		claudeToolBlockReason({ role, toolName: "Bash", toolInput: { command }, brief: null });
+
+	assert.match(String(bash("peer", "node /x/paseo-team-scripts/team-chat.mjs post {}")), /support script/i);
+	assert.match(String(bash("peer", "node /x/paseo-team-scripts/remote-paseo.mjs run")), /support script/i);
+	// The Reviewer Peer runs this one by design.
+	assert.equal(bash("peer", "node /x/paseo-team-scripts/ocr-review.mjs --repo r"), null);
+	assert.equal(bash("peer", "node /x/paseo-team-scripts/team-communication.mjs ask-lead {}"), null);
+}
+
 console.log("claude policy tests passed");

--- a/test/claude-policy.test.mjs
+++ b/test/claude-policy.test.mjs
@@ -317,4 +317,37 @@ assert.match(described, /edit=true/);
 assert.match(describeClaudePolicy("peer", null), /brief=none/);
 assert.match(describeClaudePolicy("lead", null), /paseoMcp=\[/);
 
+// --- chat CLI guard: runtime parity ------------------------------------------
+// The coordination channel is a typed tool on BOTH runtimes. If the redirect
+// lived only in the Pi adapter, picking a `claude-lead` provider would be a
+// one-line bypass of the envelope, the room allowlist and the size ceiling —
+// which is exactly the failure mode policy-core exists to prevent.
+{
+	const bash = (role, command) =>
+		claudeToolBlockReason({ role, toolName: "Bash", toolInput: { command }, brief: null });
+
+	assert.match(String(bash("lead", "paseo chat ls")), /team_chat/);
+	assert.match(String(bash("lead", "paseo chat post coord hi")), /team_chat/);
+	assert.match(String(bash("lead", "paseo.cmd chat read coord")), /team_chat/);
+	assert.match(String(bash("lead", "echo hi && paseo chat post r x")), /team_chat/);
+
+	// Narrow on purpose: this is a chat redirect, not a new CLI ban.
+	assert.equal(bash("lead", "paseo ls -g"), null);
+	assert.equal(bash("lead", "node scripts/remote-paseo.mjs health --host-id mac"), null);
+	assert.equal(bash("lead", "git status"), null);
+
+	// A Peer never had chat and still does not — via the blanket Paseo CLI block.
+	assert.match(String(bash("peer", "paseo chat ls")), /Paseo CLI from bash/);
+
+	// And the tool itself is Lead/Supervisor only on this runtime too.
+	assert.equal(
+		claudeToolBlockReason({ role: "peer", toolName: "mcp__paseo-team__team_chat", toolInput: {}, brief: null }),
+		"team_chat is restricted to Lead and Supervisor agents.",
+	);
+	assert.equal(
+		claudeToolBlockReason({ role: "lead", toolName: "mcp__paseo-team__team_chat", toolInput: {}, brief: null }),
+		null,
+	);
+}
+
 console.log("claude policy tests passed");

--- a/test/claude-team-mcp.test.mjs
+++ b/test/claude-team-mcp.test.mjs
@@ -104,4 +104,22 @@ assert.deepEqual(
 	assert.equal(messages[3].result.tools.length, TEAM_TOOLS.length);
 }
 
+// The Pi extension takes this text from policy-core's teamChatToolDescription();
+// this file is plain .mjs and cannot import the .ts core, so the string is
+// mirrored — and drift between the two runtimes is exactly what this pack's
+// parity tests exist to catch.
+{
+	const { teamChatToolDescription } = await import("../extensions/paseo-team-core/policy-core.ts");
+	const chat = TEAM_TOOLS.find((tool) => tool.name === "team_chat");
+	assert.equal(
+		chat.description,
+		teamChatToolDescription(),
+		"the Claude tool description must not drift from the shared one",
+	);
+	assert.ok(
+		!/only sanctioned/i.test(chat.description),
+		"and must not overstate closure: the bash rules are heuristics, not a boundary",
+	);
+}
+
 console.log("claude team mcp tests passed");

--- a/test/claude-team-mcp.test.mjs
+++ b/test/claude-team-mcp.test.mjs
@@ -120,6 +120,15 @@ assert.deepEqual(
 		!/only sanctioned/i.test(chat.description),
 		"and must not overstate closure: the bash rules are heuristics, not a boundary",
 	);
+
+	// The payload ceiling exists in three unlinked copies for the same reason the
+	// description does: this file cannot import the .ts core, and team-chat.mjs is
+	// a separate process. Only team-chat.mjs ENFORCES it — the other two advertise
+	// it — so drift would leave a schema promising more than the tool accepts.
+	const { TEAM_CHAT_MAX_BODY_BYTES: coreCeiling } = await import("../extensions/paseo-team-core/policy-core.ts");
+	const { MAX_BODY_BYTES: enforcedCeiling } = await import("../scripts/team-chat.mjs");
+	assert.equal(chat.inputSchema.properties.message.maxLength, enforcedCeiling, "the Claude schema advertises what team-chat.mjs enforces");
+	assert.equal(coreCeiling, enforcedCeiling, "and so does the shared core");
 }
 
 console.log("claude team mcp tests passed");

--- a/test/claude-team-mcp.test.mjs
+++ b/test/claude-team-mcp.test.mjs
@@ -32,9 +32,11 @@ const serverPath = join(root, "scripts", "claude-team-mcp.mjs");
 	assert.equal(await handleMessage({ jsonrpc: "2.0", method: "notifications/initialized" }), null);
 
 	const listed = await handleMessage({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+	// Parity with the Pi extension's registerTeamTools: a tool that exists on one
+	// runtime and not the other is a capability the other runtime silently lacks.
 	assert.deepEqual(
 		listed.result.tools.map((tool) => tool.name).sort(),
-		["peer_ask_lead", "team_watchdog"],
+		["peer_ask_lead", "team_chat", "team_watchdog"],
 	);
 	for (const tool of listed.result.tools) {
 		assert.equal(tool.inputSchema.type, "object");
@@ -76,6 +78,7 @@ assert.deepEqual(
 	TEAM_TOOLS.map((tool) => [tool.name, tool.roles]).sort(),
 	[
 		["peer_ask_lead", ["peer"]],
+		["team_chat", ["lead", "supervisor"]],
 		["team_watchdog", ["lead", "supervisor"]],
 	],
 );
@@ -98,7 +101,7 @@ assert.deepEqual(
 	const messages = stdout.trim().split(/\r?\n/).map((line) => JSON.parse(line));
 	assert.deepEqual(messages.map((message) => message.id), [1, 2, null, 3]);
 	assert.equal(messages[2].error.code, -32700, "a malformed line is answered, not fatal");
-	assert.equal(messages[3].result.tools.length, 2);
+	assert.equal(messages[3].result.tools.length, TEAM_TOOLS.length);
 }
 
 console.log("claude team mcp tests passed");

--- a/test/cli-contract.test.mjs
+++ b/test/cli-contract.test.mjs
@@ -20,6 +20,10 @@ function run(args, extraEnv = {}) {
 			...process.env,
 			PASEO_TEAM_PASEO_EXEC: `node "${FAKE}"`,
 			PI_HOME: join(sandbox, "pi"),
+			// Paseo's own home, so the graph never reads the developer's real
+			// agent state — that difference is what let a bug reach CI green here
+			// and red on every runner.
+			PASEO_HOME: join(sandbox, "paseo"),
 			PST_TEAM_CONFIG_DIR: join(sandbox, "team"),
 			PASEO_CONFIG_JSON: join(sandbox, "paseo-config.json"),
 			// The Claude half of the pack lives in two more user-owned files;

--- a/test/graph.test.mjs
+++ b/test/graph.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildGraph, collectGraph, inferFamily, inferRole, inferRoleProvider, normalizePermits, parsePeerMessage } from "../cli/lib/graph.mjs";
+import { buildGraph, chatEdges, collectGraph, inferFamily, inferRole, inferRoleProvider, normalizePermits, parsePeerMessage } from "../cli/lib/graph.mjs";
 import * as cache from "../cli/lib/graph-cache.mjs";
 
 // --- role inference --------------------------------------------------------
@@ -254,6 +254,199 @@ function fakeRunner(overrides = {}) {
 	assert.equal(result.ok, true);
 	assert.equal(result.counts.agents, 4);
 	assert.ok(result.degraded.some((fault) => fault.reason === "CLI_ERROR"));
+}
+
+// --- agent state: domain, model, and free spawn edges ----------------------
+// Paseo's own per-agent state files carry the parent link and the resolved
+// model, so the graph can stop paying ~3s per `paseo inspect` for a tree it
+// can read off disk. See cli/lib/agent-state.mjs.
+{
+	const graph = buildGraph({
+		agents: AGENTS,
+		// No inspect-derived parents at all: everything comes from state.
+		parents: {},
+		states: {
+			sup: { agentId: "sup", domain: "security", parentAgentId: null, model: "o/m", modelDrift: false, sessionId: "s-sup" },
+			lead: { agentId: "lead", domain: "payments", parentAgentId: "sup", model: "o/m", modelDrift: false, sessionId: "s-lead" },
+			peer: { agentId: "peer", domain: "payments", parentAgentId: "lead", model: "o/other", modelDrift: true, sessionId: "s-peer" },
+		},
+		now: 0,
+	});
+	const by = Object.fromEntries(graph.nodes.map((n) => [n.id, n]));
+	assert.equal(by.lead.parentId, "sup", "the spawn edge comes from the state file");
+	assert.equal(by.lead.parentSource, "state");
+	assert.equal(by.lead.domain, "payments");
+	assert.equal(by.peer.modelDrift, true, "a config/runtime model disagreement stays visible");
+	assert.equal(by.peer.sessionId, "s-peer", "the pi session id rides along for fork/handoff");
+	assert.equal(by.lost.parentId, null, "an agent with no state and no inspect has an unknown parent");
+	assert.equal(by.lost.parentKnown, false);
+	assert.equal(by.lost.domain, null);
+	assert.equal(graph.edges.filter((e) => e.type === "spawn").length, 2);
+
+	// A11 — two seats in different domains must not collapse into one bucket.
+	assert.equal(graph.counts.byDomain.payments, 2);
+	assert.equal(graph.counts.byDomain.security, 1);
+	assert.equal(graph.counts.byDomain.unknown, 1, "an agent with no domain is counted as unknown, never silently dropped");
+}
+
+{
+	// `paseo inspect` stays authoritative where we paid for it: a state file
+	// that disagrees must not silently override a fresh inspect.
+	const graph = buildGraph({
+		agents: AGENTS,
+		parents: { peer: "lead" },
+		states: { peer: { agentId: "peer", parentAgentId: "sup", domain: "x" } },
+		now: 0,
+	});
+	const peer = graph.nodes.find((n) => n.id === "peer");
+	assert.equal(peer.parentId, "lead");
+	assert.equal(peer.parentSource, "inspect");
+	assert.equal(peer.domain, "x", "non-parent fields still come from state");
+}
+
+{
+	// collectGraph must spend inspect calls ONLY on agents that have no state
+	// file — that is the whole cost saving.
+	const seen = [];
+	const result = await collectGraph({
+		runPaseoJson: async (args) => {
+			seen.push(args.join(" "));
+			if (args[0] === "ls") return AGENTS;
+			if (args[0] === "permit") return [];
+			return { Id: args[1], ParentAgentId: null };
+		},
+		readStates: () => ({
+			states: {
+				sup: { agentId: "sup", parentAgentId: null, domain: "security" },
+				lead: { agentId: "lead", parentAgentId: "sup", domain: "security" },
+				peer: { agentId: "peer", parentAgentId: "lead", domain: "security" },
+			},
+			degraded: [],
+		}),
+		cache: { version: cache.CACHE_VERSION, parents: {} },
+		persistCache: false,
+		maxInspect: 10,
+		now: 0,
+	});
+	assert.equal(result.ok, true);
+	const inspects = seen.filter((c) => c.startsWith("inspect"));
+	assert.equal(inspects.length, 1, "only the one agent without a state file costs an inspect");
+	assert.ok(inspects[0].includes("lost"));
+	assert.equal(result.edges.filter((e) => e.type === "spawn").length, 2);
+}
+
+{
+	// A degraded state read is reported, and the graph still renders.
+	const result = await collectGraph({
+		runPaseoJson: async (args) => (args[0] === "ls" ? AGENTS : args[0] === "permit" ? [] : { Id: args[1], ParentAgentId: null }),
+		readStates: () => ({ states: {}, degraded: [{ reason: "AGENT_STATE_ROOT_UNREADABLE", detail: "no such dir" }] }),
+		cache: { version: cache.CACHE_VERSION, parents: {} },
+		persistCache: false,
+		maxInspect: 0,
+		now: 0,
+	});
+	assert.equal(result.ok, true);
+	assert.equal(result.counts.agents, 4);
+	assert.ok(result.degraded.some((f) => f.reason === "AGENT_STATE_ROOT_UNREADABLE"));
+}
+
+// --- chat rooms as confirmed message edges --------------------------------
+// `paseo chat read --json` reports the real author agent id, so unlike the
+// log-scraped Lead→Peer guesses these edges are facts, not suspicions.
+{
+	const LEAD_A = "aaaaaaaa-1111-4111-8111-111111111111";
+	const LEAD_B = "bbbbbbbb-2222-4222-8222-222222222222";
+	const roster = [
+		{ id: LEAD_A, shortId: "aaaaaaa" },
+		{ id: LEAD_B, shortId: "bbbbbbb" },
+	];
+	const envelope = (from, corr) =>
+		[
+			"@bbbbbbb",
+			"TEAM_MESSAGE_V1",
+			"KIND: dependency",
+			`CORRELATION_ID: ${corr}`,
+			"TOPIC: T-7",
+			`FROM_AGENT_ID: ${from}`,
+			"FROM_ROLE: lead",
+			"FROM_DOMAIN: payments",
+			"HOP: 0",
+			"TTL: 8",
+			"",
+			"who owns the migration?",
+		].join("\n");
+
+	// B17 — a real author id yields a confirmed edge.
+	{
+		const edges = chatEdges([{ id: "m1", author: LEAD_A, createdAt: "t0", body: envelope(LEAD_A, "c1") }], roster, "coord");
+		assert.equal(edges.length, 1);
+		assert.equal(edges[0].type, "message");
+		assert.equal(edges[0].from, LEAD_A);
+		assert.equal(edges[0].to, LEAD_B, "the mention resolves from short id to the full agent id");
+		assert.equal(edges[0].confidence, "confirmed");
+		assert.equal(edges[0].kind, "dependency");
+		assert.equal(edges[0].taskId, "T-7");
+		assert.equal(edges[0].room, "coord");
+		assert.equal(edges[0].origin, "agent");
+	}
+
+	// B18 — a human posting in the room is not an agent edge.
+	{
+		const edges = chatEdges([{ id: "m2", author: "manual", createdAt: "t1", body: envelope(LEAD_A, "c2") }], roster, "coord");
+		assert.equal(edges[0].origin, "human", "author 'manual' is a person at a terminal, not an agent");
+		assert.equal(edges[0].from, "human");
+	}
+
+	// B19 — the same correlation id seen twice draws once.
+	{
+		const messages = [
+			{ id: "m3", author: LEAD_A, createdAt: "t2", body: envelope(LEAD_A, "c3") },
+			{ id: "m4", author: LEAD_A, createdAt: "t3", body: envelope(LEAD_A, "c3") },
+		];
+		const graph = buildGraph({
+			agents: [
+				{ id: LEAD_A, shortId: "aaaaaaa", provider: "pi-lead/o/m", status: "idle" },
+				{ id: LEAD_B, shortId: "bbbbbbb", provider: "pi-lead/o/m", status: "idle" },
+			],
+			messages: chatEdges(messages, roster, "coord"),
+			now: 0,
+		});
+		assert.equal(graph.edges.filter((e) => e.type === "message").length, 1, "dedup is by correlation id");
+	}
+
+	// A message with no envelope is room chatter, not a protocol edge.
+	assert.deepEqual(chatEdges([{ id: "m5", author: LEAD_A, body: "just talking" }], roster, "coord"), []);
+
+	// B21 — a mention nobody in the listing answers to is kept and flagged,
+	// never silently dropped.
+	{
+		const edges = chatEdges([{ id: "m6", author: LEAD_A, body: envelope(LEAD_A, "c6").replace("@bbbbbbb", "@zzzzzzz") }], roster, "coord");
+		assert.equal(edges.length, 1);
+		assert.equal(edges[0].to, "zzzzzzz");
+		assert.equal(edges[0].unresolvedRecipient, true);
+	}
+}
+
+{
+	// B20 — a room that cannot be read degrades that room only.
+	const result = await collectGraph({
+		runPaseoJson: async (args) => {
+			if (args[0] === "ls") return AGENTS;
+			if (args[0] === "permit") return [];
+			if (args[0] === "chat" && args[2] === "broken") throw Object.assign(new Error("no such room"), { code: "CLI_ERROR" });
+			if (args[0] === "chat") return [];
+			return { Id: args[1], ParentAgentId: null };
+		},
+		readStates: () => ({ states: {}, degraded: [] }),
+		chatRooms: ["coord", "broken"],
+		cache: { version: cache.CACHE_VERSION, parents: {} },
+		persistCache: false,
+		maxInspect: 0,
+		now: 0,
+	});
+	assert.equal(result.ok, true);
+	assert.equal(result.counts.agents, 4, "the graph still renders");
+	assert.ok(result.degraded.some((f) => f.reason === "CHAT_READ_FAILED" && f.detail.includes("broken")));
 }
 
 console.log("graph tests passed");

--- a/test/graph.test.mjs
+++ b/test/graph.test.mjs
@@ -449,4 +449,45 @@ function fakeRunner(overrides = {}) {
 	assert.ok(result.degraded.some((f) => f.reason === "CHAT_READ_FAILED" && f.detail.includes("broken")));
 }
 
+// --- OCR-005: dedup must not let one message erase another -----------------
+// correlationId is chosen by the sender, so it is not a unique key. Two
+// distinct messages sharing one must both draw, or a crafted (or merely
+// careless) collision silently deletes a real edge from the graph.
+{
+	const A = "aaaaaaaa-1111-4111-8111-111111111111";
+	const Bq = "bbbbbbbb-2222-4222-8222-222222222222";
+	const graph = buildGraph({
+		agents: [
+			{ id: A, shortId: "aaaaaaa", provider: "pi-lead/o/m", status: "idle" },
+			{ id: Bq, shortId: "bbbbbbb", provider: "pi-lead/o/m", status: "idle" },
+		],
+		messages: [
+			{ from: A, to: Bq, kind: "question", correlationId: "same", room: "coord", confidence: "confirmed" },
+			{ from: Bq, to: A, kind: "decision", correlationId: "same", room: "coord", confidence: "confirmed" },
+			{ from: A, to: Bq, kind: "question", correlationId: "same", room: "leases", confidence: "confirmed" },
+			// A true duplicate (same room, same author, same correlation) still draws once.
+			{ from: A, to: Bq, kind: "question", correlationId: "same", room: "coord", confidence: "confirmed" },
+		],
+		now: 0,
+	});
+	const messages = graph.edges.filter((e) => e.type === "message");
+	assert.equal(messages.length, 3, "distinct author/room pairs survive; the exact repeat is deduped");
+}
+
+// --- OCR-004: a parent disagreement is reported, not silently resolved ------
+{
+	const graph = buildGraph({
+		agents: AGENTS,
+		parents: { peer: "lead" },
+		states: { peer: { agentId: "peer", parentAgentId: "sup" } },
+		now: 0,
+	});
+	const peer = graph.nodes.find((n) => n.id === "peer");
+	assert.equal(peer.parentId, "lead", "the paid-for inspect answer still wins");
+	assert.ok(
+		graph.degraded.some((f) => f.reason === "PARENT_SOURCE_DISAGREEMENT" && f.agentId === "peer"),
+		"but the operator is told the two sources disagree",
+	);
+}
+
 console.log("graph tests passed");

--- a/test/installer-contract.test.mjs
+++ b/test/installer-contract.test.mjs
@@ -188,7 +188,7 @@ for (const installer of ["install.sh", "install.ps1"]) {
     },
   );
   const tools = JSON.parse(handshake).result.tools.map((tool) => tool.name);
-  assert.deepEqual(tools.sort(), ["peer_ask_lead", "team_watchdog"]);
+  assert.deepEqual(tools.sort(), ["peer_ask_lead", "team_chat", "team_watchdog"]);
 }
 
 console.log("installer contract tests passed");

--- a/test/installer-contract.test.mjs
+++ b/test/installer-contract.test.mjs
@@ -11,6 +11,7 @@ import { isMainModule as isRoutingMain } from "../scripts/model-routing.mjs";
 import { isMainModule as isOcrMain } from "../scripts/ocr-setup.mjs";
 import { isMainModule as isOcrReviewMain } from "../scripts/ocr-review.mjs";
 import { isMainModule as isCommunicationMain } from "../scripts/team-communication.mjs";
+import { isMainModule as isChatMain } from "../scripts/team-chat.mjs";
 import { isMainModule as isWatchdogMain } from "../scripts/watchdog.mjs";
 import { isMainModule as isPathMain } from "../scripts/team-scripts-path.mjs";
 import { defaultTeamScriptsDir, resolveTeamScriptsDir } from "../scripts/team-scripts-path.mjs";
@@ -18,7 +19,7 @@ const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const source = join(root, "scripts");
 const installed = mkdtempSync(join(tmpdir(), "paseo-installed-support-"));
 const unrelatedCwd = mkdtempSync(join(tmpdir(), "paseo-unrelated-cwd-"));
-for (const file of ["lib-common.mjs", "remote-paseo.mjs", "model-routing.mjs", "reliability.mjs", "team-communication.mjs", "watchdog.mjs", "ocr-review.mjs", "ocr-setup.mjs", "team-scripts-path.mjs"]) {
+for (const file of ["lib-common.mjs", "remote-paseo.mjs", "model-routing.mjs", "reliability.mjs", "team-communication.mjs", "team-chat.mjs", "watchdog.mjs", "ocr-review.mjs", "ocr-setup.mjs", "team-scripts-path.mjs"]) {
   cpSync(join(source, file), join(installed, file));
 }
 
@@ -67,6 +68,7 @@ const symlinkCases = [
   [join(installed, "ocr-setup.mjs"), isOcrMain],
   [join(installed, "ocr-review.mjs"), isOcrReviewMain],
   [join(installed, "team-communication.mjs"), isCommunicationMain],
+  [join(installed, "team-chat.mjs"), isChatMain],
   [join(installed, "watchdog.mjs"), isWatchdogMain],
   [join(installed, "team-scripts-path.mjs"), isPathMain],
 ];

--- a/test/paseo-contract.test.mjs
+++ b/test/paseo-contract.test.mjs
@@ -52,4 +52,54 @@ assert.equal(typeof detail.UpdatedAt, "string");
 assert.ok(Array.isArray(detail.PendingPermissions));
 assert.ok(detail.ParentAgentId === null || typeof detail.ParentAgentId === "string");
 
+// --- chat room contract ------------------------------------------------------
+// `paseo chat` carries the Lead/Supervisor coordination bus (scripts/team-chat.mjs)
+// and is ABSENT from Paseo's published CLI docs, so nothing upstream promises
+// this shape. Every unit test mocks the CLI; this is the one place the real
+// argv is exercised, including the trailing `--json` that team-chat.mjs appends
+// to every command — a post that silently rejected it would fail only in
+// production. Runs a full create -> post -> read -> delete cycle in a
+// throwaway room so it leaves no residue on the daemon.
+{
+  const room = `pteam-contract-${process.pid}-${Date.now().toString(36)}`;
+  const marker = `PTEAM_CONTRACT_${process.pid}`;
+  let created = false;
+  try {
+    const createdRoom = paseoJson(["chat", "create", room, "--purpose", "paseo-pi-team contract test"]);
+    created = true;
+    assert.equal(typeof createdRoom.id, "string", "chat create must return a room id");
+    assert.equal(createdRoom.name, room);
+
+    // The body goes through argv exactly as team-chat.mjs sends it.
+    const posted = paseoJson(["chat", "post", room, `${marker} @${required.slice(0, 7)} body`]);
+    for (const field of ["id", "author", "createdAt", "body", "mentionAgentIds"]) {
+      assert.ok(Object.hasOwn(posted, field), `chat post contract must expose ${field}`);
+    }
+    assert.ok(posted.body.includes(marker), "the posted body must round-trip verbatim");
+    // The graph's confirmed message edges depend on this: the author is stamped
+    // by the daemon, never taken from the envelope.
+    assert.equal(typeof posted.author, "string");
+    assert.ok(Array.isArray(posted.mentionAgentIds), "mentions must parse out of the body");
+    assert.ok(
+      posted.mentionAgentIds.includes(required.slice(0, 7)),
+      "an @short-id in the body must be recognized as a mention — delivery depends on it",
+    );
+
+    const read = paseoJson(["chat", "read", room]);
+    assert.ok(Array.isArray(read), "chat read --json must return an array");
+    const found = read.find((message) => message.id === posted.id);
+    assert.ok(found, "a posted message must come back from chat read");
+    assert.equal(found.author, posted.author, "author must be stable between post and read");
+    assert.equal(found.body, posted.body);
+  } finally {
+    if (created) {
+      try {
+        paseoJson(["chat", "delete", room]);
+      } catch (error) {
+        console.error(`[warn] could not delete contract room ${room}: ${String(error?.message ?? error)}`);
+      }
+    }
+  }
+}
+
 console.log(`paseo contract test passed: ${required}`);

--- a/test/policy.test.mts
+++ b/test/policy.test.mts
@@ -8,6 +8,8 @@ import {
 	browserMcpAllowed,
 	callsAgentBrowserCli,
 	callsPaseoCli,
+	coordinationCliBlockReason,
+	teamChatToolBlockReason,
 	classifyMcpInput,
 	denyReason,
 	gitAuthorityBlockReason,
@@ -1430,6 +1432,38 @@ for (const file of readdirSync(examplesDir).filter((f) => f.endsWith(".md"))) {
 		[],
 		`${file}: brief must be clean, got: ${brief.malformed.join("; ")}`,
 	);
+}
+
+// --- team_chat: the coordination channel is typed, not a raw CLI ----------
+// Chat is absent from Paseo's MCP catalog (60 tools, measured), so Lead and
+// Supervisor could only reach it through bash — a surface the policy cannot
+// inspect: no room gate, no envelope, no audit. The typed tool replaces it,
+// and the raw CLI is closed for every role.
+{
+	// B10 — a Peer never had chat and still does not: no MCP, and the Paseo
+	// CLI (which includes `chat`) is already blocked from bash.
+	assert.equal(callsPaseoCli("paseo chat post coord hello"), true);
+	assert.equal(callsPaseoCli("paseo chat read coord"), true);
+	assert.equal(teamChatToolBlockReason("peer"), "team_chat is restricted to Lead and Supervisor agents.");
+	assert.equal(teamChatToolBlockReason("lead"), null);
+	assert.equal(teamChatToolBlockReason("supervisor"), null);
+
+	// B11/B12 — Lead and Supervisor must go through team_chat too, so the
+	// envelope, the size ceiling and the room allowlist cannot be bypassed by
+	// typing the command by hand.
+	for (const role of ["lead", "supervisor"] as const) {
+		const reason = coordinationCliBlockReason(role, "paseo chat post coord hello");
+		assert.match(String(reason), /team_chat/, `${role} is redirected to the typed tool`);
+	}
+	// Everything else a Lead does with the Paseo CLI is untouched: this is a
+	// chat-only redirect, not a new CLI ban.
+	assert.equal(coordinationCliBlockReason("lead", "paseo ls -g"), null);
+	assert.equal(coordinationCliBlockReason("lead", "paseo inspect abc"), null);
+	assert.equal(coordinationCliBlockReason("supervisor", "paseo status"), null);
+	assert.equal(coordinationCliBlockReason("peer", "paseo chat ls"), null, "the peer path stays where it is");
+	// Wrappers and alternate spellings must not reopen it.
+	assert.match(String(coordinationCliBlockReason("lead", "paseo.cmd chat ls")), /team_chat/);
+	assert.match(String(coordinationCliBlockReason("lead", "echo hi && paseo chat post r x")), /team_chat/);
 }
 
 console.log("[paseo-team] policy tests passed");

--- a/test/policy.test.mts
+++ b/test/policy.test.mts
@@ -1513,4 +1513,34 @@ for (const file of readdirSync(examplesDir).filter((f) => f.endsWith(".md"))) {
 	else process.env.PASEO_PI_ROLE = prevRole;
 }
 
+// The peer branch is a SEPARATE leg of the same handler, and
+// supportScriptBlockReason returns null for a Lead by construction — so the
+// block above cannot reach it. Without this, deleting the peer wiring in the
+// extension leaves the whole suite green.
+{
+	const { piStub, handlers } = makePiStub(["read", "bash"]);
+	const prevRole = process.env.PASEO_PI_ROLE;
+	process.env.PASEO_PI_ROLE = "peer";
+	const createExtension = await loadFreshExtension("lifecycle=support-script");
+	createExtension(piStub);
+
+	const toolCall = requireHandler(handlers, "tool_call");
+	const bash = async (command: string) =>
+		(await toolCall({ toolName: "bash", input: { command } })) as
+			| { block?: boolean; reason?: string }
+			| undefined;
+
+	const blocked = await bash("node /x/paseo-team-scripts/team-chat.mjs post {}");
+	assert.equal(blocked?.block, true, "the peer support-script guard is wired into the Pi extension");
+	assert.match(String(blocked?.reason), /support script/i);
+	assert.equal(
+		(await bash("node /x/paseo-team-scripts/ocr-review.mjs --repo r"))?.block,
+		undefined,
+		"the Reviewer skill's own wrapper stays runnable",
+	);
+
+	if (prevRole === undefined) delete process.env.PASEO_PI_ROLE;
+	else process.env.PASEO_PI_ROLE = prevRole;
+}
+
 console.log("[paseo-team] policy tests passed");

--- a/test/policy.test.mts
+++ b/test/policy.test.mts
@@ -8,6 +8,7 @@ import {
 	browserMcpAllowed,
 	callsAgentBrowserCli,
 	callsPaseoCli,
+	callsTeamSupportScript,
 	coordinationCliBlockReason,
 	teamChatToolBlockReason,
 	classifyMcpInput,
@@ -1464,6 +1465,52 @@ for (const file of readdirSync(examplesDir).filter((f) => f.endsWith(".md"))) {
 	// Wrappers and alternate spellings must not reopen it.
 	assert.match(String(coordinationCliBlockReason("lead", "paseo.cmd chat ls")), /team_chat/);
 	assert.match(String(coordinationCliBlockReason("lead", "echo hi && paseo chat post r x")), /team_chat/);
+}
+
+// --- OCR-001: the support script is not a side door ------------------------
+// Blocking `paseo chat` while leaving `node .../team-chat.mjs` open would move
+// the bypass one word to the left. The bar is the same for both spellings —
+// and, like every bash rule here, it is a heuristic, not an authorization
+// boundary: the script's own gate reads env the caller owns.
+{
+	assert.equal(callsTeamSupportScript("node /x/paseo-team-scripts/team-chat.mjs post {}"), true);
+	assert.equal(callsTeamSupportScript("node ~/.pi/agent/extensions/paseo-team-scripts/remote-paseo.mjs run"), true);
+	assert.equal(callsTeamSupportScript("node team-chat.mjs rooms"), true);
+	assert.equal(callsTeamSupportScript('node "C:\\x y\\team-chat.mjs" post {}'), true);
+
+	// The Reviewer skill runs this one directly, by design — it must stay open.
+	assert.equal(callsTeamSupportScript("node /x/paseo-team-scripts/ocr-review.mjs --repo r"), false);
+	// Equivalent to peer_ask_lead (same parent-scoped, fail-closed sender).
+	assert.equal(callsTeamSupportScript("node /x/paseo-team-scripts/team-communication.mjs ask-lead {}"), false);
+	assert.equal(callsTeamSupportScript("node scripts/model-routing.mjs resolve"), false);
+	assert.equal(callsTeamSupportScript("echo team-chat"), false, "a bare mention is not an invocation");
+	assert.equal(callsTeamSupportScript(""), false);
+}
+
+// --- OCR-007: the Pi extension really wires the guard ----------------------
+// policy-core owns the rule and the Claude adapter has its own test; this pins
+// the third leg — that the Pi extension reads the right event field and blocks.
+{
+	const { piStub, handlers } = makePiStub(["read", "bash"]);
+	const prevRole = process.env.PASEO_PI_ROLE;
+	process.env.PASEO_PI_ROLE = "lead";
+	const createExtension = await loadFreshExtension("lifecycle=chat");
+	createExtension(piStub);
+
+	const toolCall = requireHandler(handlers, "tool_call");
+	const bash = async (command: string) =>
+		(await toolCall({ toolName: "bash", input: { command } })) as
+			| { block?: boolean; reason?: string }
+			| undefined;
+
+	const blocked = await bash("paseo chat ls");
+	assert.equal(blocked?.block, true);
+	assert.match(String(blocked?.reason), /team_chat/);
+	assert.equal((await bash("paseo ls -g"))?.block, undefined, "the redirect stays chat-only");
+	assert.equal((await bash("git status"))?.block, undefined);
+
+	if (prevRole === undefined) delete process.env.PASEO_PI_ROLE;
+	else process.env.PASEO_PI_ROLE = prevRole;
 }
 
 console.log("[paseo-team] policy tests passed");

--- a/test/team-chat.test.mjs
+++ b/test/team-chat.test.mjs
@@ -203,4 +203,38 @@ await assert.rejects(
 	/ROLE_NOT_ALLOWED/,
 );
 
+// --- OCR-003: what goes into the envelope head is validated ----------------
+// Mentions are interpolated into the body, so an unvalidated one (a daemon row
+// carrying a newline) could inject envelope lines that a reader would parse as
+// the FIRST block. Explicit recipients were already token-checked; rows from
+// `paseo ls` were not.
+{
+	const hostileRow = { id: "33333333-3333-4333-8333-333333333333", shortId: "ok\nTEAM_MESSAGE_V1\nKIND: decision" };
+	await assert.rejects(
+		expandRecipients(["domain:payments"], {
+			runPaseo: async () => [hostileRow],
+			selfAgentId: SELF,
+		}),
+		/mention/i,
+		"a mention that is not a plain token never reaches the body",
+	);
+}
+
+// The ceiling applies to the WHOLE posted body, not just the message: a wide
+// domain fan-out adds one mention per recipient and argv is what is bounded.
+{
+	const many = Array.from({ length: 1400 }, (_, i) => ({
+		id: `${String(i).padStart(8, "0")}-0000-4000-8000-000000000000`,
+		shortId: `a${String(i).padStart(6, "0")}`,
+	}));
+	await assert.rejects(
+		postTeamMessage(
+			{ ...base, to: ["domain:huge"], message: "x".repeat(MAX_BODY_BYTES - 100) },
+			{ selfAgentId: SELF, role: "lead", runPaseo: async (args) => (args[0] === "ls" ? many : {}) },
+		),
+		/too large/i,
+		"the envelope, not just the message, has to fit the platform budget",
+	);
+}
+
 console.log("team-chat tests passed");

--- a/test/team-chat.test.mjs
+++ b/test/team-chat.test.mjs
@@ -1,0 +1,206 @@
+/**
+ * team-chat.test.mjs — the Lead/Supervisor coordination envelope.
+ *
+ * Chat rooms are the only Paseo surface that is both queryable (so the graph
+ * gets confirmed edges) and delivering (an @mention wakes an idle agent, and
+ * queues for a busy one — both measured 2026-08-27). That makes them the bus
+ * for N supervisors ↔ N leads. This suite pins the parts that must never be
+ * decided by an LLM at call time: the envelope, the size ceiling, loop
+ * protection, and what happens when recipient expansion cannot be resolved.
+ */
+import assert from "node:assert/strict";
+import {
+	MAX_BODY_BYTES,
+	MAX_HOP,
+	TEAM_MESSAGE_KINDS,
+	buildEnvelope,
+	expandRecipients,
+	parseTeamMessage,
+	postTeamMessage,
+	roomAllowed,
+	validateTeamMessage,
+} from "../scripts/team-chat.mjs";
+
+const SELF = "11111111-1111-4111-8111-111111111111";
+const OTHER = "22222222-2222-4222-8222-222222222222";
+
+const base = { room: "coord", kind: "dependency", topic: "T-42", message: "need the schema decision", to: [OTHER] };
+
+// --- B1: a valid envelope round-trips ------------------------------------
+{
+	const v = validateTeamMessage(base);
+	assert.equal(v.kind, "dependency");
+	assert.equal(v.topic, "T-42");
+	assert.equal(v.hop, 0);
+	assert.ok(v.correlationId, "a correlation id is minted when the caller omits one");
+
+	const body = buildEnvelope(v, { fromAgentId: SELF, fromRole: "lead", fromDomain: "payments", mentions: ["2222222"] });
+	assert.ok(body.startsWith("@2222222"), "mentions lead the body — that is what Paseo parses for delivery");
+	const parsed = parseTeamMessage(body);
+	assert.equal(parsed.kind, "dependency");
+	assert.equal(parsed.fromAgentId, SELF);
+	assert.equal(parsed.fromRole, "lead");
+	assert.equal(parsed.fromDomain, "payments");
+	assert.equal(parsed.topic, "T-42");
+	assert.equal(parsed.hop, 0);
+	assert.equal(parsed.correlationId, v.correlationId);
+}
+
+// --- B2/B3/B4: fail closed on shape --------------------------------------
+for (const [label, patch] of [
+	["missing kind", { kind: undefined }],
+	["missing message", { message: "" }],
+	["missing room", { room: undefined }],
+	["missing topic", { topic: undefined }],
+	["missing recipients", { to: [] }],
+	["kind outside the set", { kind: "gossip" }],
+	["topic is not a token", { topic: "has spaces" }],
+	["room is not a token", { room: "a room" }],
+]) {
+	assert.throws(() => validateTeamMessage({ ...base, ...patch }), /./, `${label} must be rejected`);
+}
+// An unknown field is a version skew or a typo; either way it is not silently dropped.
+assert.throws(() => validateTeamMessage({ ...base, priority: "high" }), /unknown field/i);
+
+// --- B5/B6: the size ceiling is a real platform limit, measured in bytes --
+// `paseo chat post` takes the message as argv, and Windows caps a command line
+// at ~32K; the cap below is the portable budget, not a style choice.
+{
+	assert.throws(
+		() => validateTeamMessage({ ...base, message: "A".repeat(MAX_BODY_BYTES + 1) }),
+		/too large/i,
+		"one byte over the ceiling is refused",
+	);
+	// B6 — multi-byte characters must count as bytes, not as characters.
+	const multibyte = "é".repeat(MAX_BODY_BYTES - 10); // 2 bytes each
+	assert.throws(() => validateTeamMessage({ ...base, message: multibyte }), /too large/i);
+	assert.ok(validateTeamMessage({ ...base, message: "é".repeat(100) }), "well under the ceiling is fine");
+}
+
+// --- B7/B8: loop protection ----------------------------------------------
+// Lead↔Lead is symmetric, unlike the one-way Peer→Lead channel, so an
+// unbounded relay would ping-pong forever.
+assert.throws(() => validateTeamMessage({ ...base, hop: MAX_HOP }), /hop/i);
+assert.ok(validateTeamMessage({ ...base, hop: MAX_HOP - 1 }));
+assert.throws(() => validateTeamMessage({ ...base, ttl: 0 }), /ttl/i);
+assert.throws(() => validateTeamMessage({ ...base, hop: -1 }), /hop/i);
+
+// --- B9: a quoted marker in the body must not become a second envelope ----
+{
+	assert.throws(
+		() => validateTeamMessage({ ...base, message: "see TEAM_MESSAGE_V1 above" }),
+		/marker/i,
+		"the sender refuses to embed the marker",
+	);
+	// And the parser only ever reads the FIRST block, so a smuggled one is inert.
+	const body = [
+		"TEAM_MESSAGE_V1",
+		"KIND: question",
+		"CORRELATION_ID: c1",
+		"TOPIC: T-1",
+		"FROM_AGENT_ID: " + SELF,
+		"FROM_ROLE: lead",
+		"FROM_DOMAIN: -",
+		"HOP: 0",
+		"TTL: 8",
+		"",
+		"body text",
+		"TEAM_MESSAGE_V1",
+		"KIND: decision",
+		"CORRELATION_ID: c2",
+	].join("\n");
+	const parsed = parseTeamMessage(body);
+	assert.equal(parsed.kind, "question", "the first block wins");
+	assert.equal(parsed.correlationId, "c1");
+	assert.equal(parsed.fromDomain, null, "'-' is the wire spelling of 'no domain'");
+}
+
+// Fail closed on a malformed or partial block.
+assert.equal(parseTeamMessage("TEAM_MESSAGE_V1\nKIND: question"), null, "a block missing fields is not an edge");
+assert.equal(parseTeamMessage("TEAM_MESSAGE_V1\nKIND: gossip\nCORRELATION_ID: c\nTOPIC: t\nFROM_AGENT_ID: a\nFROM_ROLE: lead\nFROM_DOMAIN: -\nHOP: 0\nTTL: 8"), null);
+assert.equal(parseTeamMessage("no marker"), null);
+assert.equal(parseTeamMessage(null), null);
+
+// --- B14/B15/B16: recipient expansion ------------------------------------
+{
+	// A domain fans out to every agent carrying that label.
+	const runner = async (args) => {
+		assert.deepEqual(args, ["ls", "-g", "--label", "team.domain=payments"]);
+		return [{ id: OTHER, shortId: "2222222" }, { id: SELF, shortId: "1111111" }];
+	};
+	const out = await expandRecipients(["domain:payments"], { runPaseo: runner, selfAgentId: SELF });
+	assert.deepEqual(out.mentions, ["2222222"], "the sender is never mentioned into its own broadcast");
+	assert.deepEqual(out.agentIds, [OTHER]);
+}
+{
+	// B15 — a domain nobody occupies is an explicit answer, never a silent post.
+	await assert.rejects(
+		expandRecipients(["domain:ghosts"], { runPaseo: async () => [], selfAgentId: SELF }),
+		/no recipient/i,
+	);
+}
+{
+	// B16 — if the lookup itself fails we must not post to a guessed audience.
+	await assert.rejects(
+		expandRecipients(["domain:payments"], {
+			runPaseo: async () => { throw Object.assign(new Error("daemon down"), { code: "CLI_ERROR" }); },
+			selfAgentId: SELF,
+		}),
+		/RECIPIENT_EXPANSION_FAILED/,
+	);
+}
+{
+	// Explicit ids pass through, deduplicated, and short ids are accepted.
+	const out = await expandRecipients([OTHER, "2222222", OTHER], { runPaseo: async () => [], selfAgentId: SELF });
+	assert.equal(out.mentions.length, 1, "the same agent is mentioned once");
+}
+await assert.rejects(expandRecipients(["not a ref"], { runPaseo: async () => [], selfAgentId: SELF }), /invalid recipient/i);
+
+// --- posting: one shot, never retried ------------------------------------
+{
+	const calls = [];
+	const result = await postTeamMessage(base, {
+		selfAgentId: SELF,
+		role: "lead",
+		domain: "payments",
+		runPaseo: async (args) => {
+			calls.push(args);
+			if (args[0] === "ls") return [{ id: OTHER, shortId: "2222222" }];
+			return { id: "msg-1", author: SELF };
+		},
+	});
+	assert.equal(result.ok, true);
+	assert.equal(result.room, "coord");
+	assert.ok(result.correlationId);
+	const post = calls.find((c) => c[0] === "chat" && c[1] === "post");
+	assert.ok(post, "the message went out through `paseo chat post`");
+	assert.equal(post[2], "coord");
+	assert.ok(post[3].includes("TEAM_MESSAGE_V1"));
+	assert.ok(Buffer.byteLength(post[3], "utf8") < 32000, "the whole argv payload stays under the platform ceiling");
+}
+
+// --- B13: room allowlist --------------------------------------------------
+{
+	// Unset PASEO_TEAM_ROOMS keeps today's behaviour (any well-formed room).
+	assert.equal(roomAllowed("anything", undefined), true);
+	// Set, and it is a strict allowlist — the substitute for the ACL that chat
+	// rooms do not have.
+	assert.equal(roomAllowed("coord", "coord,leases"), true);
+	assert.equal(roomAllowed("leases", "coord,leases"), true);
+	assert.equal(roomAllowed("secret", "coord,leases"), false);
+	assert.equal(roomAllowed("coord", ""), false, "an empty allowlist grants nothing");
+}
+{
+	await assert.rejects(
+		postTeamMessage(base, { selfAgentId: SELF, role: "lead", rooms: "leases", runPaseo: async () => [{ id: OTHER, shortId: "2222222" }] }),
+		/ROOM_NOT_ALLOWED/,
+	);
+}
+
+// Only Lead and Supervisor hold this channel; a Peer has peer_ask_lead.
+await assert.rejects(
+	postTeamMessage(base, { selfAgentId: SELF, role: "peer", runPaseo: async () => [] }),
+	/ROLE_NOT_ALLOWED/,
+);
+
+console.log("team-chat tests passed");


### PR DESCRIPTION
First two steps of the N-supervisor / N-lead topology plan in
`docs/multi-supervisor-topology.md`. Every design decision in that document is
anchored to a measurement against a live daemon (Paseo 0.3.0, Pi 0.84.2), not
to assumptions about what the CLI can do.

## PR-A — identity from what Paseo already persists

Paseo writes one state file per agent at
`$PASEO_HOME/agents/<cwd-slug>/<id>.json`, and it already carries what the team
graph was buying with `paseo inspect`: the parent link (as a label), the
resolved model, and the pi session id and file. `cli/lib/agent-state.mjs` reads
it; `collectGraph` now spends inspect calls only on agents that have no state
file.

Measured on the dev daemon with 30 agents: a cold `pteam graph --refresh` goes
from ~12s across several polls (max 6 inspects each) to **3.66s with
`inspectSpent: 0`**, and picks up 9 spawn edges instead of 7 because it no
longer has to ration lookups.

Two rules are pinned by tests because getting them wrong reports a model the
agent is not running: `runtimeInfo.model` wins over `config.model`, and
`persistence.metadata.model` is never a model source — Paseo does not rewrite
it after `update_agent`.

Nodes gain `domain`, `model`, `modelDrift`, `sessionId` and `parentSource`;
counts gain `byDomain`; `pteam agents` gains `--domain`.

## PR-B — `team_chat`, and closing PR-4 along the way

Chat rooms are the only Paseo surface that is both queryable and delivering:
`chat read --json` reports the real author agent id, and an `@mention` wakes an
idle agent (34ms, measured) and queues for a busy one. That makes them the bus
for N supervisors ↔ N leads — and it means the team graph finally gets
**confirmed** message edges instead of guesses scraped from `paseo logs`, which
closes PR-4 in `docs/webui-architecture.md` by a route that doesn't depend on
`logs` at all.

Chat is also the one Paseo surface with **no MCP tool behind it** (60 tools,
none of them chat), so Lead and Supervisor could previously only reach it
through bash — a channel the policy cannot inspect. `scripts/team-chat.mjs` +
the typed `team_chat` tool replace that, enforcing:

- the `TEAM_MESSAGE_V1` envelope,
- a room allowlist (opt-in via `PASEO_TEAM_ROOMS`; rooms have no ACL of their own),
- an 8 KB payload / 16 KB envelope ceiling in **UTF-8 bytes** — `paseo chat post`
  takes the message as argv and Windows caps a command line near 32K (measured:
  32000 chars OK, 100000 → `ENAMETOOLONG`),
- cooperative hop/TTL loop protection, since Lead↔Lead is symmetric unlike the
  one-way Peer→Lead channel.

Recipients may be agent ids or `domain:<name>`, expanded here into one mention
per agent because Paseo delivers mentions by agent id only — `mentionLabels`
parses but never fans out.

## Runtime parity

The rules live in `extensions/paseo-team-core/policy-core.ts`, which states the
invariant this branch had to learn twice: *a rule that lives in only one adapter
is a rule the other runtime silently lacks*. The first cut put the chat guard in
the Pi adapter, which would have made `claude-lead` a one-provider bypass. Both
adapters now bind the same core, and `claude-team-mcp.mjs` exposes `team_chat`
as the third team tool.

## Review

Three independent review rounds, each in a detached worktree at the exact
candidate SHA, driving the deterministic OCR wrapper (`linked_worktree: true`,
clean entry and exit, 100% manifest coverage).

- **Round 1** → `CHANGES_REQUIRED`, findings OCR-001..007.
- **Round 2** → five closed, two only *partially* closed: the shared tool
  description had replaced the overstated wording on Pi only, and the harness
  test meant to pin the new Pi wiring ran as `role=lead` and so never reached
  the peer branch it claimed to cover.
- **Round 3** → running against this head.

Both partial findings are fixed and now have tests that fail without them. The
`paseo chat` CLI shape — undocumented upstream — is exercised end to end by a
create → post → read → delete cycle added to `test/paseo-contract.test.mjs`.

## Known, deliberately not changed

The support scripts gate on `PASEO_PI_ROLE` / `PASEO_AGENT_ID`, which the
calling process owns, so the bash rules raise the bar rather than seal the
surface — the pack documents them as heuristics, not an authorization boundary.
`pteam chat post` reaches the same rooms without a role gate because the pack
CLI is an operator tool; that path predates this branch. Both are recorded in
the plan document.

## Verification

- 26/26 suites green, `tsc` clean, on `origin/main` as of #20.
- Guard verified live on **both** runtimes: a real Pi Lead running `paseo chat
  ls` is redirected to `team_chat`, and the Claude adapter blocks the same set
  while leaving `paseo ls`, `remote-paseo.mjs` and `git` alone.
- `pteam graph --with-chat` verified against a real room: one `message` edge,
  `confidence: "confirmed"`, `inspectSpent: 0`, `degraded: 0`.
- Version 1.3.0 → 1.4.0 (new CLI surface = MINOR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
