### PR TITLE
test(claude-hook): stop the suite inheriting the developer's Paseo role

### DIFF
--- a/test/claude-hook.test.mjs
+++ b/test/claude-hook.test.mjs
@@ -40,11 +40,29 @@ const V3_WRITE = [
 
 const peerEnv = { ...baseEnv, PASEO_PI_ROLE: "peer" };
 
+/**
+ * The hook resolves its whole policy from the environment, so the child must
+ * see EXACTLY the variables a case declares — never the ones the developer
+ * happens to be running under.
+ *
+ * This matters more here than in most suites: the audience for this pack works
+ * inside Paseo agents, and every one of them carries PASEO_PI_ROLE. Inheriting
+ * it turned the "passive without a role" case below into a false failure for
+ * anyone running the suite from an agent session, which is exactly who runs it.
+ */
+function childEnv(env) {
+	const inherited = { ...process.env };
+	for (const key of Object.keys(inherited)) {
+		if (key.startsWith("PASEO_")) delete inherited[key];
+	}
+	return { ...inherited, ...env };
+}
+
 function runHook(event, payload, env = peerEnv) {
 	const stdout = execFileSync(process.execPath, [hookPath, event], {
 		encoding: "utf8",
 		input: JSON.stringify(payload),
-		env: { ...process.env, ...env },
+		env: childEnv(env),
 	});
 	return stdout.trim() ? JSON.parse(stdout) : null;
 }
@@ -57,6 +75,28 @@ assert.equal(
 	"no PASEO_PI_ROLE → no policy at all (safe to install globally)",
 );
 assert.equal(runHook("pre-tool-use", { session_id: "s0", tool_name: "Write" }, baseEnv), null);
+
+// The scrub is the thing under test here: an ambient role must not survive into
+// the child, while the case's own variables must.
+{
+	const ambient = "PASEO_PI_ROLE";
+	const previous = process.env[ambient];
+	process.env[ambient] = "lead";
+	try {
+		const built = childEnv(baseEnv);
+		assert.equal(built[ambient], undefined, "an ambient role never reaches the hook");
+		assert.equal(built.PASEO_TEAM_HOME, home, "the case's own variables do reach it");
+		assert.ok(built.PATH !== undefined || process.platform === "win32", "unrelated environment is preserved");
+		assert.equal(
+			runHook("pre-tool-use", { session_id: "s0b", tool_name: "Write" }, baseEnv),
+			null,
+			"and the passive case stays passive even when the suite runs inside a Paseo agent",
+		);
+	} finally {
+		if (previous === undefined) delete process.env[ambient];
+		else process.env[ambient] = previous;
+	}
+}
 
 // --- the brief is recomputed per prompt, never inherited -----------------------
 


### PR DESCRIPTION
`test/claude-hook.test.mjs` spawned the hook with `{ ...process.env, ...env }`,
so a `PASEO_PI_ROLE` already present in the shell survived into the child and
overrode what the case declared. The "no role → no policy at all" assertion then
failed, because the child *did* have a role — the one belonging to whoever ran
the tests.

That is a false red aimed squarely at this pack's own audience: everyone working
inside a Paseo agent carries `PASEO_PI_ROLE`, so the suite failed for exactly the
people most likely to run it.

It is not hypothetical. Reviewing #21 took three independent review rounds, each
one a Paseo peer agent, and two of them reported this as a suspected pre-existing
regression — one round spent effort on it, and the finding then had to be
disproved by hand. It was reproducible all along; the reproduction just required
the variable that only agents have set.

## The fix

The child now receives an environment scrubbed of every `PASEO_` variable before
the case's own values are applied. A new case asserts the scrub directly rather
than trusting it: an ambient role does not reach the hook, the case's own
variables do, unrelated environment is preserved, and the passive path stays
passive with a role set in the parent.

## Verification

`npm test` green under all three conditions — `PASEO_PI_ROLE` unset, `peer`, and
`lead` — 24/24 each time. Before the fix, `PASEO_PI_ROLE=peer npm test` was 23/24
on this same base (`8410658`), which is how the branch scope was confirmed: the
bug predates #21 and is untouched by it.

Test-only change; no runtime file is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
