### PR TITLE
feat(topology): scope leases — one writer per moving scope, enforced (PR-C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ When the `claude` CLI is present, the installers also run
 skips that step; it is not an error.
 
 The support scripts are `lib-common`, `reliability`, `watchdog`,
-`team-communication`, `team-chat`, `ocr-review`, `remote-paseo`,
+`team-communication`, `team-chat`, `team-lease`, `ocr-review`, `remote-paseo`,
 `model-routing`, `team-scripts-path`, `claude-hook` and `claude-team-mcp`.
 They are copied **flat**, so every import between them
 must stay `./<name>.mjs`. `installer-contract.test.mjs` guards that: every

--- a/docs/multi-supervisor-topology.md
+++ b/docs/multi-supervisor-topology.md
@@ -368,7 +368,7 @@ state file của Paseo (§1.4) đã có đủ, nên module chỉ đọc. Phần 
 kiến: label `paseo.parent-agent-id` cho luôn cây spawn (177/259 agent có), nên
 `inspect` gần như không còn cần.
 
-### PR-C — Scope lease (bắt buộc trước khi bật multi-lead)
+### PR-C — Scope lease (bắt buộc trước khi bật multi-lead) — ✅ ĐÃ LÀM
 
 **Vấn đề.** Invariant "một writer cho một moving scope" hiện được giữ *tình cờ*
 vì chỉ có 1 Lead. N Lead + fork phá thẳng nó.
@@ -395,6 +395,32 @@ mọi guard khác của pack, và một Lead không tạo được writer là s�
 **DoD.** 2 Lead cùng claim 1 scope → chỉ 1 tạo được writer, cái kia nhận
 `BLOCKED: SCOPE_LEASE_HELD`; lease hết hạn thì giải phóng; `chat read` lỗi →
 `BLOCKED: LEASE_UNVERIFIABLE`; test bằng fixture, không cần daemon.
+
+#### Đã giao
+
+| Thành phần | Nơi |
+|---|---|
+| Logic thuần: normalize, conflict-by-containment, fold ledger, guard | `extensions/paseo-team-core/policy-core.ts` |
+| I/O: claim / renew / release / status / ledger trên room `leases` | `scripts/team-lease.mjs` |
+| Enforcement `create_agent` (Pi) | `extensions/paseo-team-policy.ts` |
+| Enforcement `create_agent` (Claude) | `extensions/paseo-team-core/claude-policy.ts` + `scripts/claude-hook.mjs` |
+| Tool `team_lease` cho cả hai runtime | Pi extension + `scripts/claude-team-mcp.mjs` |
+| `notify: false` — bản ghi không đánh thức ai | `scripts/team-chat.mjs` |
+| Hướng dẫn cho Lead | `prompts/lead.md` §5, `skills/paseo-team-lead/SKILL.md` bước 0 |
+
+Test: `test/scope-lease.test.mts` (logic thuần), `test/team-lease.test.mjs`
+(I/O), cộng wiring test trong `policy.test.mts` và `claude-policy.test.mjs` —
+bài học OCR-007: luật mà adapter không gọi thì là luật không tồn tại.
+
+**Lỗi do chạy thật mới lộ ra.** Fold khoá lease theo **chuỗi scope chính xác**,
+nên một claim THUA (`src/auth/login` dưới `src/auth` đang sống) vẫn được ghi
+dưới key riêng, chỉ bị che lúc đọc — rồi nổi lên thành lease thật ngay khi
+`src/auth` được release, trao cho Lead đó phần đất nó chưa từng giành được.
+Unit test trượt vì case "sau release thì claim tiếp theo thắng" dùng cùng một
+chuỗi scope. Conflict phải được xét lúc **ghi**, không chỉ lúc **đọc**.
+
+**Còn thiếu:** watchdog báo lease quá hạn của Lead đã chết (báo cáo, không tự
+thu hồi).
 
 ---
 

--- a/extensions/paseo-team-core/claude-policy.ts
+++ b/extensions/paseo-team-core/claude-policy.ts
@@ -30,6 +30,7 @@ import {
 	callsPaseoCli,
 	coordinationCliBlockReason,
 	leaseBlockReason,
+	teamLeaseToolBlockReason,
 	type LeaseHolder,
 	supportScriptBlockReason,
 	writerScopeFromCreateAgent,
@@ -215,7 +216,18 @@ export function claudeToolBlockReason(
 	const peerMode = resolvePeerMode(brief);
 
 	if (classified.kind === "team") {
-		return teamToolBlockReason(role, teamToolName(toolName), brief);
+		const named = teamToolName(toolName);
+		const coarse = teamToolBlockReason(role, named, brief);
+		if (coarse) return coarse;
+		// The per-action gate needs the arguments, which the coarse name-only
+		// check never sees. Without this a Claude Supervisor could claim and
+		// release scopes that a Pi Supervisor is refused — an authority
+		// asymmetry, which is the one thing the shared core exists to prevent.
+		return teamLeaseToolBlockReason(
+			role,
+			(input.toolInput as Record<string, unknown> | undefined)?.action,
+			named,
+		);
 	}
 
 	// Same scope-lease rule the Pi extension applies. The ledger cannot be read
@@ -225,7 +237,8 @@ export function claudeToolBlockReason(
 	if (
 		role === "lead" &&
 		classified.kind === "paseo-mcp" &&
-		matchesPaseoToolName(classified.target ?? "", ["create_agent"]) &&
+		// Both calls can deliver the brief that arms a writer.
+		matchesPaseoToolName(classified.target ?? "", ["create_agent", "send_agent_prompt"]) &&
 		writerScopeFromCreateAgent(input.toolInput)
 	) {
 		const leaseReason = leaseBlockReason({

--- a/extensions/paseo-team-core/claude-policy.ts
+++ b/extensions/paseo-team-core/claude-policy.ts
@@ -29,7 +29,10 @@ import {
 	callsAgentBrowserCli,
 	callsPaseoCli,
 	coordinationCliBlockReason,
+	leaseBlockReason,
+	type LeaseHolder,
 	supportScriptBlockReason,
+	writerScopeFromCreateAgent,
 	extraTools,
 	gitAuthorityBlockReason,
 	isAgentBrowserMcpTarget,
@@ -184,6 +187,11 @@ export interface ClaudeToolDecisionInput {
 	toolName: string;
 	toolInput?: unknown;
 	brief: ParsedTaskBrief | null;
+	/** Live scope leases, resolved by policy-core. Required only when the call
+	 *  staffs a writer; null means the ledger could not be read (fail-closed). */
+	leases?: Map<string, LeaseHolder> | null;
+	/** This agent's own Paseo id, to match against the lease holder. */
+	selfAgentId?: string | null;
 }
 
 function bashCommand(toolInput: unknown): string {
@@ -208,6 +216,25 @@ export function claudeToolBlockReason(
 
 	if (classified.kind === "team") {
 		return teamToolBlockReason(role, teamToolName(toolName), brief);
+	}
+
+	// Same scope-lease rule the Pi extension applies. The ledger cannot be read
+	// from a synchronous guard, so the hook fetches it and hands it in; an
+	// absent `leases` when one is actually needed is treated as unreadable,
+	// which is fail-closed rather than a silent allow.
+	if (
+		role === "lead" &&
+		classified.kind === "paseo-mcp" &&
+		matchesPaseoToolName(classified.target ?? "", ["create_agent"]) &&
+		writerScopeFromCreateAgent(input.toolInput)
+	) {
+		const leaseReason = leaseBlockReason({
+			role,
+			args: input.toolInput,
+			leases: input.leases ?? null,
+			selfAgentId: input.selfAgentId ?? null,
+		});
+		if (leaseReason) return leaseReason;
 	}
 
 	if (classified.kind === "paseo-mcp") {

--- a/extensions/paseo-team-core/policy-core.ts
+++ b/extensions/paseo-team-core/policy-core.ts
@@ -93,6 +93,7 @@ export const MCP_TOOLS = ["mcp", "mcp_script"];
 export const PEER_COMMUNICATION_TOOL = "peer_ask_lead";
 export const TEAM_WATCHDOG_TOOL = "team_watchdog";
 export const TEAM_CHAT_TOOL = "team_chat";
+export const TEAM_LEASE_TOOL = "team_lease";
 /** Payload ceiling, kept in sync with scripts/team-chat.mjs MAX_BODY_BYTES. */
 export const TEAM_CHAT_MAX_BODY_BYTES = 8192;
 /** Mirror of TEAM_MESSAGE_KINDS in scripts/team-chat.mjs (shapes tool schemas). */
@@ -203,6 +204,7 @@ export function policyFor(role: TeamRole, peerMode: PeerMode): Policy {
 					),
 					TEAM_WATCHDOG_TOOL,
 					TEAM_CHAT_TOOL,
+					TEAM_LEASE_TOOL,
 					...LEAD_ALLOWED_MCP_TARGETS,
 					...MCP_TOOLS,
 				],
@@ -210,7 +212,7 @@ export function policyFor(role: TeamRole, peerMode: PeerMode): Policy {
 			};
 		case "supervisor":
 			return {
-				allow: ["read", "mcp", TEAM_WATCHDOG_TOOL, TEAM_CHAT_TOOL, ...PASEO_TOOLS.monitoring, "send_agent_prompt"],
+				allow: ["read", "mcp", TEAM_WATCHDOG_TOOL, TEAM_CHAT_TOOL, TEAM_LEASE_TOOL, ...PASEO_TOOLS.monitoring, "send_agent_prompt"],
 				deny: ["write", "edit", "mcp_script", ...ALL_PASEO_TOOLS],
 			};
 		case "peer":
@@ -342,6 +344,257 @@ export function callsTeamSupportScript(command: string): boolean {
 	return SUPPORT_SCRIPT_RE.test(command);
 }
 
+// ---------------------------------------------------------------------------
+// Scope leases
+//
+// "One writer per moving scope" used to hold by accident: there was exactly one
+// Lead, so nobody could contend. With several Leads nothing structural stops two
+// of them staffing writers on the same files, and that failure shows up as a
+// corrupted working tree rather than an error.
+//
+// The ledger is a chat room. That buys a total order by server timestamp
+// (measured: four concurrent posts, four distinct timestamps, none lost) but no
+// compare-and-swap — every CLAIM succeeds. Arbitration therefore happens on
+// READ, here, and this module stays pure: it is handed the ledger as data so a
+// lease decision never depends on a daemon being reachable, and so the same
+// rules run identically on both runtimes.
+// ---------------------------------------------------------------------------
+
+export const LEASE_HEADER = "LEASE_V1";
+export const LEASE_ACTIONS = ["claim", "renew", "release"] as const;
+export type LeaseAction = (typeof LEASE_ACTIONS)[number];
+
+/** Repo-relative path, or "." for the whole tree. No traversal, bounded. */
+const SCOPE_CHARS = /^[A-Za-z0-9._\-/]{1,256}$/;
+
+/**
+ * Canonical spelling of a scope, so who wins never depends on how it was typed.
+ * A Windows Lead writing `src\auth` and a POSIX Lead writing `./src/auth/` are
+ * claiming the same thing and must collide.
+ */
+export function normalizeScope(scope: unknown): string | null {
+	if (typeof scope !== "string") return null;
+	const collapsed = scope.trim().replace(/\\/g, "/").replace(/\/+/g, "/");
+	if (collapsed === "" || collapsed === "/") return null;
+	const trimmed = collapsed.replace(/^\.\//, "").replace(/\/$/, "");
+	if (trimmed === "" || trimmed === ".") return ".";
+	if (!SCOPE_CHARS.test(trimmed)) return null;
+	// A scope names something inside the repo. `..` is either a mistake or an
+	// attempt to claim outside it; neither should become a lease.
+	if (trimmed.split("/").some((segment) => segment === "..")) return null;
+	return trimmed;
+}
+
+/**
+ * Whether two scopes cannot both have a writer.
+ *
+ * Containment, not equality: a claim on `src/auth` has to exclude a writer on
+ * `src/auth/login`, or the invariant is only enforced for Leads that happen to
+ * spell the scope the same way. Segment-wise so `src/auth` does not swallow
+ * `src/authz`.
+ */
+export function scopeConflicts(a: unknown, b: unknown): boolean {
+	const left = normalizeScope(a);
+	const right = normalizeScope(b);
+	if (!left || !right) return false;
+	if (left === "." || right === ".") return true;
+	if (left === right) return true;
+	const l = left.split("/");
+	const r = right.split("/");
+	const shared = Math.min(l.length, r.length);
+	for (let i = 0; i < shared; i += 1) if (l[i] !== r[i]) return false;
+	return true;
+}
+
+export interface LeaseRecord {
+	action: LeaseAction;
+	scope: string;
+	ttlMs: number | null;
+}
+
+const LEASE_LINE = /^([A-Z_]+):\s*(.+)$/;
+
+/**
+ * Parse a LEASE_V1 block out of a room message body.
+ *
+ * Fail-closed both ways, and the two directions fail for different reasons: a
+ * half-record read as a CLAIM would hold a scope hostage, and one read as a
+ * RELEASE would hand the scope to a second writer. Neither is acceptable, so an
+ * unparseable record is simply not a lease event at all.
+ */
+export function parseLeaseRecord(text: unknown): LeaseRecord | null {
+	if (typeof text !== "string") return null;
+	const start = text.indexOf(LEASE_HEADER);
+	if (start < 0) return null;
+	const fields: Record<string, string> = {};
+	for (const line of text.slice(start).split(/\r?\n/).slice(1)) {
+		if (line.trim() === "") break;
+		const match = LEASE_LINE.exec(line.trim());
+		const key = match?.[1];
+		const value = match?.[2];
+		if (key === undefined || value === undefined) break;
+		fields[key] = value.trim();
+	}
+	const action = fields.ACTION as LeaseAction;
+	if (!LEASE_ACTIONS.includes(action)) return null;
+	const scope = normalizeScope(fields.SCOPE);
+	if (!scope) return null;
+	if (action === "release") return { action, scope, ttlMs: null };
+	const ttlMs = Number.parseInt(fields.TTL_MS ?? "", 10);
+	if (!Number.isInteger(ttlMs) || ttlMs <= 0) return null;
+	return { action, scope, ttlMs };
+}
+
+export interface LeaseHolder {
+	agentId: string;
+	scope: string;
+	claimedAt: number;
+	expiresAt: number;
+}
+
+/**
+ * Fold a room's messages into the set of live leases.
+ *
+ * The holder is the message AUTHOR — stamped by the daemon — never a field in
+ * the body, which the sender writes. That is the same rule the message graph
+ * follows, and for the same reason: an id the claimant supplies proves nothing.
+ *
+ * @param entries rows from `paseo chat read --json` (author, createdAt, body)
+ */
+export function resolveLeases(
+	entries: unknown,
+	{ now }: { now: number },
+): Map<string, LeaseHolder> {
+	const rows = Array.isArray(entries) ? entries : [];
+	const ordered = rows
+		.map((row: any) => ({
+			author: typeof row?.author === "string" ? row.author : null,
+			at: Date.parse(row?.createdAt ?? ""),
+			record: parseLeaseRecord(row?.body),
+		}))
+		.filter((row) => row.author && row.record && Number.isFinite(row.at))
+		.sort((a, b) => a.at - b.at);
+
+	const live = new Map<string, LeaseHolder>();
+	/** Any live lease that would collide with `scope` as of `at`. */
+	const conflictAt = (scope: string, at: number): LeaseHolder | null => {
+		for (const holder of live.values()) {
+			if (holder.expiresAt <= at) continue;
+			if (scopeConflicts(holder.scope, scope)) return holder;
+		}
+		return null;
+	};
+
+	for (const row of ordered) {
+		const record = row.record as LeaseRecord;
+		const own = live.get(record.scope);
+		const holdsOwn = own && own.expiresAt > row.at && own.agentId === row.author;
+
+		if (record.action === "release") {
+			// Only the holder may release its OWN lease. Otherwise any Lead could
+			// evict another and the lease would be advice rather than a rule.
+			if (holdsOwn) live.delete(record.scope);
+			continue;
+		}
+		if (record.action === "renew") {
+			if (holdsOwn) {
+				live.set(record.scope, { ...own!, expiresAt: row.at + (record.ttlMs as number) });
+			}
+			continue;
+		}
+		// claim — rejected if ANY live lease collides, not merely one filed under
+		// the same spelling. Recording a losing claim under its own key would let
+		// it surface later as a lease nobody ever granted: exactly what happened
+		// when a Lead claimed `src/auth/login` under a live `src/auth` and then
+		// inherited the ground the moment `src/auth` was released.
+		if (conflictAt(record.scope, row.at)) continue;
+		live.set(record.scope, {
+			agentId: row.author as string,
+			scope: record.scope,
+			claimedAt: row.at,
+			expiresAt: row.at + (record.ttlMs as number),
+		});
+	}
+
+	for (const [scope, holder] of [...live]) {
+		if (holder.expiresAt <= now) live.delete(scope);
+	}
+	return live;
+}
+
+/** The live lease that would conflict with `scope`, if any. */
+export function leaseHolderFor(
+	leases: Map<string, LeaseHolder> | null | undefined,
+	scope: unknown,
+): LeaseHolder | null {
+	if (!leases) return null;
+	for (const holder of leases.values()) {
+		if (scopeConflicts(holder.scope, scope)) return holder;
+	}
+	return null;
+}
+
+/**
+ * The scope a `create_agent` call is about to put a WRITER on, or null when the
+ * call staffs nobody who writes.
+ *
+ * Read-only researchers, scouts and reviewers share a tree by design; gating
+ * them would turn the lease into a bottleneck instead of a safety rule. The
+ * authority comes from the same V3 brief the Peer will be held to, so the gate
+ * and the grant cannot disagree.
+ */
+export function writerScopeFromCreateAgent(args: unknown): string | null {
+	if (!args || typeof args !== "object") return null;
+	const prompt = (args as Record<string, unknown>).initialPrompt;
+	if (typeof prompt !== "string") return null;
+	const brief = parseTaskBrief(prompt);
+	if (!brief || brief.version !== 3 || brief.malformed.length > 0) return null;
+	if (brief.mode !== "write") return null;
+	if (brief.fields.get("EDIT_AUTHORITY") !== "allowed") return null;
+	// A write brief with no OWNED_SCOPE is the dangerous one: it writes
+	// somewhere and says nothing about where. Treat it as the whole repo rather
+	// than as exempt.
+	return normalizeScope(brief.fields.get("OWNED_SCOPE")) ?? ".";
+}
+
+/**
+ * Whether this `create_agent` may proceed under the lease rule.
+ *
+ * Pure: the caller fetches the ledger and passes it in. `leases: null` means the
+ * ledger could not be read, and that is deliberately fatal — a Lead that cannot
+ * staff a writer is a visible incident with an error message, while two writers
+ * on one scope is a silent one discovered later in the git history.
+ */
+export function leaseBlockReason({
+	role,
+	args,
+	leases,
+	selfAgentId,
+}: {
+	role: TeamRole;
+	args: unknown;
+	leases: Map<string, LeaseHolder> | null;
+	selfAgentId: string | null | undefined;
+}): string | null {
+	if (role !== "lead") return null;
+	const scope = writerScopeFromCreateAgent(args);
+	if (!scope) return null;
+	if (!leases) {
+		return "BLOCKED: LEASE_UNVERIFIABLE — the scope-lease ledger could not be read, so this writer cannot be shown to be the only one on its scope. Fix the ledger read and retry; do not create the writer meanwhile.";
+	}
+	if (!selfAgentId) {
+		return "BLOCKED: LEASE_UNVERIFIABLE — this agent's own id is unknown, so it cannot be matched against the lease holder.";
+	}
+	const holder = leaseHolderFor(leases, scope);
+	if (!holder) {
+		return `BLOCKED: SCOPE_LEASE_MISSING — no live lease covers "${scope}". Claim it first (team_lease claim), then create the writer.`;
+	}
+	if (holder.agentId !== selfAgentId) {
+		return `BLOCKED: SCOPE_LEASE_HELD — "${holder.scope}" is held by ${holder.agentId} until ${new Date(holder.expiresAt).toISOString()}, and it covers "${scope}". Coordinate with that Lead through the leases room instead of starting a second writer.`;
+	}
+	return null;
+}
+
 /** Reason a Peer may not run a pack support script from bash. */
 export function supportScriptBlockReason(
 	role: TeamRole,
@@ -378,6 +631,16 @@ export function coordinationCliBlockReason(
  * heuristics, rooms are unrestricted unless PASEO_TEAM_ROOMS is set, and chat
  * rooms have no ACL of their own.
  */
+export function teamLeaseToolDescription(): string {
+	return (
+		"Take, extend, release or inspect a scope lease — the record of which Lead may put a WRITER on which files. " +
+		"`claim` before creating an engineer; `release` when the work is done; `renew` for long work; `status` to see the board. " +
+		"Scopes are repo-relative paths and nest: holding `src` also holds `src/auth`. " +
+		"A claim can lose — read `granted` in the result, not merely `ok`. " +
+		"Creating a write-mode Peer without a covering lease is refused."
+	);
+}
+
 export function teamChatToolDescription(): string {
 	return (
 		"Coordinate with other Leads and Supervisors through a Paseo chat room. " +
@@ -1277,7 +1540,37 @@ export function teamToolBlockReason(
 	}
 	const chatReason = teamChatToolBlockReason(role, toolName);
 	if (chatReason) return chatReason;
+	// The lease tool's action is not visible here (teamToolBlockReason takes a
+	// name, not arguments), so this is the coarse gate; the adapters apply the
+	// per-action one with the arguments in hand.
+	if (toolName === TEAM_LEASE_TOOL && role !== "lead" && role !== "supervisor") {
+		return "team_lease is restricted to Lead agents (Supervisor may read status).";
+	}
 	return null;
+}
+
+/**
+ * Who may work the scope-lease ledger.
+ *
+ * Claiming is a Lead act: it decides who staffs a writer, which is the Lead's
+ * job and nobody else's. The Supervisor may READ the board, because "two Leads
+ * are contending for one scope" is exactly the workflow observation it exists
+ * to make — but it does not get to take or free a scope, the same way it does
+ * not get to accept a candidate.
+ */
+export function teamLeaseToolBlockReason(
+	role: TeamRole,
+	action: unknown,
+	toolName: string = TEAM_LEASE_TOOL,
+): string | null {
+	if (toolName !== TEAM_LEASE_TOOL) return null;
+	if (role === "lead") return null;
+	if (role === "supervisor") {
+		return action === "status"
+			? null
+			: "Supervisor may read the lease board but not claim, renew or release a scope — staffing a writer is the Lead's decision. Send an observation instead.";
+	}
+	return "team_lease is restricted to Lead agents (Supervisor may read status).";
 }
 
 /**

--- a/extensions/paseo-team-core/policy-core.ts
+++ b/extensions/paseo-team-core/policy-core.ts
@@ -170,6 +170,17 @@ export const SUPERVISOR_ALLOWED_MCP_TARGETS: string[] = [
 const SUPERVISOR_MCP_SCRIPT_TARGETS: string[] = SUPERVISOR_MONITORING_TARGETS;
 
 /**
+ * The Lead's mcp_script surface, for the same reason the Supervisor has one:
+ * a script's ARGUMENTS cannot be statically verified, and both create_agent and
+ * send_agent_prompt carry the brief that arms a writer. Allowing them here would
+ * leave a first-class path that the scope-lease gate — which inspects arguments
+ * — never sees.
+ */
+const LEAD_MCP_SCRIPT_TARGETS: string[] = LEAD_ALLOWED_MCP_TARGETS.filter(
+	(tool) => tool !== "create_agent" && tool !== "send_agent_prompt",
+);
+
+/**
  * Match a possibly-prefixed proxy tool name against known Paseo tool names.
  * Handles "paseo_list_providers" and "server:list_providers" forms without
  * mangling bare names like "list_providers" (whose first segment is part of
@@ -362,6 +373,14 @@ export function callsTeamSupportScript(command: string): boolean {
 
 export const LEASE_HEADER = "LEASE_V1";
 export const LEASE_ACTIONS = ["claim", "renew", "release"] as const;
+/**
+ * Hard ceiling on how long any single lease can hold ground, applied in the
+ * FOLD rather than only in the tool that posts. The tool's cap binds callers
+ * that go through it; arbitration reads whatever is in the room, and one
+ * smuggled `TTL_MS: 999999999999` on the repo root would otherwise lock every
+ * writer out until someone edited the room by hand.
+ */
+export const LEASE_MAX_TTL_MS = 12 * 3_600_000;
 export type LeaseAction = (typeof LEASE_ACTIONS)[number];
 
 /** Repo-relative path, or "." for the whole tree. No traversal, bounded. */
@@ -381,8 +400,15 @@ export function normalizeScope(scope: unknown): string | null {
 	if (!SCOPE_CHARS.test(trimmed)) return null;
 	// A scope names something inside the repo. `..` is either a mistake or an
 	// attempt to claim outside it; neither should become a lease.
-	if (trimmed.split("/").some((segment) => segment === "..")) return null;
-	return trimmed;
+	//
+	// Interior `.` segments are dropped for the same reason `..` is rejected:
+	// `src/./auth` and `src/auth` are the same directory on every filesystem, and
+	// leaving them distinct would let two Leads hold identical files by spelling
+	// the path two ways.
+	const segments = trimmed.split("/").filter((segment) => segment !== ".");
+	if (segments.some((segment) => segment === "..")) return null;
+	if (segments.length === 0) return ".";
+	return segments.join("/");
 }
 
 /**
@@ -398,9 +424,15 @@ export function scopeConflicts(a: unknown, b: unknown): boolean {
 	const right = normalizeScope(b);
 	if (!left || !right) return false;
 	if (left === "." || right === ".") return true;
-	if (left === right) return true;
-	const l = left.split("/");
-	const r = right.split("/");
+	// Compared case-insensitively even though the stored scope keeps its case.
+	// `src/auth` and `SRC/Auth` are the same files on Windows and on default
+	// macOS, which is where this pack runs; on a case-sensitive filesystem this
+	// can only produce a FALSE conflict, and erring toward "these two Leads
+	// collide" is the safe direction — the other way round puts two writers on
+	// one directory.
+	const l = left.toLowerCase().split("/");
+	const r = right.toLowerCase().split("/");
+	if (left.toLowerCase() === right.toLowerCase()) return true;
 	const shared = Math.min(l.length, r.length);
 	for (let i = 0; i < shared; i += 1) if (l[i] !== r[i]) return false;
 	return true;
@@ -442,7 +474,7 @@ export function parseLeaseRecord(text: unknown): LeaseRecord | null {
 	if (action === "release") return { action, scope, ttlMs: null };
 	const ttlMs = Number.parseInt(fields.TTL_MS ?? "", 10);
 	if (!Number.isInteger(ttlMs) || ttlMs <= 0) return null;
-	return { action, scope, ttlMs };
+	return { action, scope, ttlMs: Math.min(ttlMs, LEASE_MAX_TTL_MS) };
 }
 
 export interface LeaseHolder {
@@ -545,12 +577,26 @@ export function leaseHolderFor(
  */
 export function writerScopeFromCreateAgent(args: unknown): string | null {
 	if (!args || typeof args !== "object") return null;
-	const prompt = (args as Record<string, unknown>).initialPrompt;
+	const record = args as Record<string, unknown>;
+	// A brief arms a Peer whether it arrives at creation (`initialPrompt`) or in
+	// a later turn (`prompt` via send_agent_prompt) — authority is recomputed
+	// from whatever prompt starts the turn, never inherited. Gating only the
+	// first would leave the two-step open: create something benign, then send
+	// the write brief to the same agent.
+	const prompt = typeof record.initialPrompt === "string" ? record.initialPrompt : record.prompt;
 	if (typeof prompt !== "string") return null;
 	const brief = parseTaskBrief(prompt);
 	if (!brief || brief.version !== 3 || brief.malformed.length > 0) return null;
-	if (brief.mode !== "write") return null;
-	if (brief.fields.get("EDIT_AUTHORITY") !== "allowed") return null;
+	// Ask the SAME function that grants the authority, not a second reading of
+	// the same fields. They diverged once already: the gate required a literal
+	// `EDIT_AUTHORITY: allowed`, while the grant defaults edit to true when the
+	// field is absent under `MODE: write` — so a brief the parser happily
+	// accepts produced a writer the lease never saw.
+	// This mirrors policyWithAuthority exactly: write/edit tools are granted only
+	// when the mode is write AND the authority allows edit. Reading either half
+	// alone is how the gate and the grant drifted apart the first time.
+	if (resolvePeerMode(brief) !== "write") return null;
+	if (!peerAuthority(brief).edit) return null;
 	// A write brief with no OWNED_SCOPE is the dangerous one: it writes
 	// somewhere and says nothing about where. Treat it as the whole repo rather
 	// than as exempt.
@@ -1007,7 +1053,9 @@ export function mcpScriptBlockReason(
 	const allowed =
 		role === "supervisor"
 			? SUPERVISOR_MCP_SCRIPT_TARGETS
-			: mcpAllowedTargets(role);
+			: role === "lead"
+				? LEAD_MCP_SCRIPT_TARGETS
+				: mcpAllowedTargets(role);
 	for (const _match of code.matchAll(MCP_SCRIPT_DYNAMIC_CALL_RE)) {
 		return `mcp_script invokes an MCP tool through a non-literal target (variable, expression or computed key) — the ${role} allowlist cannot verify it, so the call is blocked fail-closed. Use a literal tool name: tools.call("<allowed_tool>", ...) or tools.<allowed_tool>().`;
 	}

--- a/extensions/paseo-team-policy.ts
+++ b/extensions/paseo-team-policy.ts
@@ -68,12 +68,20 @@ import {
 	PEER_COMMUNICATION_TOOL,
 	TEAM_WATCHDOG_TOOL,
 	TEAM_CHAT_TOOL,
+	TEAM_LEASE_TOOL,
+	teamLeaseToolBlockReason,
+	teamLeaseToolDescription,
 	TEAM_CHAT_MAX_BODY_BYTES,
 	TEAM_MESSAGE_KIND_NAMES,
+	classifyMcpInput,
 	coordinationCliBlockReason,
+	leaseBlockReason,
+	matchesPaseoToolName,
+	resolveLeases,
 	supportScriptBlockReason,
 	teamChatToolBlockReason,
 	teamChatToolDescription,
+	writerScopeFromCreateAgent,
 	type ParsedTaskBrief,
 	type PeerMode,
 	type Policy,
@@ -111,6 +119,60 @@ function runSupportScript(name: string, args: string[], signal?: AbortSignal, ti
 			},
 		);
 	});
+}
+
+/**
+ * The scope-lease gate for a Lead's create_agent.
+ *
+ * It lives OUTSIDE mcpBlockReason on purpose: that function is pure and both
+ * runtimes depend on it staying that way, while this needs to read the ledger
+ * room — a ~3s round trip. create_agent is rare enough to afford it, and the
+ * alternative is a rule that only the Leads who feel like claiming obey.
+ *
+ * Everything about the decision is still pure: the ledger is fetched here and
+ * arbitrated by policy-core, so the Pi and Claude adapters cannot disagree
+ * about who holds a scope.
+ */
+async function leadCreateAgentLeaseReason(input: unknown): Promise<string | null> {
+	const classified = classifyMcpInput(input);
+	if (classified.kind !== "target") return null;
+	if (!matchesPaseoToolName(classified.target ?? "", ["create_agent"])) return null;
+
+	const args = extractCreateAgentArgs(input);
+	// Nothing to gate unless this call staffs a writer; the core decides that
+	// from the same V3 brief the Peer will be held to.
+	if (!writerScopeFromCreateAgent(args)) return null;
+
+	let entries: unknown = null;
+	try {
+		const result = await runSupportScript("team-lease.mjs", ["ledger", "{}"]);
+		const parsed = JSON.parse(result.stdout || "{}");
+		entries = parsed?.ok ? parsed.entries : null;
+	} catch {
+		// Leave entries null — the guard is fail-closed by design, and the reason
+		// it returns says so in words the Lead can act on.
+		entries = null;
+	}
+
+	return leaseBlockReason({
+		role: "lead",
+		args,
+		leases: entries ? resolveLeases(entries, { now: Date.now() }) : null,
+		selfAgentId: process.env.PASEO_AGENT_ID?.trim() || null,
+	});
+}
+
+function extractCreateAgentArgs(input: unknown): unknown {
+	if (!input || typeof input !== "object") return null;
+	const args = (input as Record<string, unknown>).args;
+	if (typeof args === "string") {
+		try {
+			return JSON.parse(args);
+		} catch {
+			return null;
+		}
+	}
+	return args ?? null;
 }
 
 function registerTeamTools(pi: ExtensionAPI, r: TeamRole): void {
@@ -177,6 +239,30 @@ function registerTeamTools(pi: ExtensionAPI, r: TeamRole): void {
 			const command = action === "post" ? "post" : action === "read" ? "read" : "rooms";
 			const args = command === "rooms" ? [command] : [command, JSON.stringify(rest)];
 			const result = await runSupportScript("team-chat.mjs", args, signal);
+			return { content: [{ type: "text", text: result.stdout || result.stderr }], details: undefined, isError: result.code !== 0 };
+		},
+	});
+	pi.registerTool({
+		name: TEAM_LEASE_TOOL,
+		label: "team_lease",
+		description: teamLeaseToolDescription(),
+		parameters: {
+			type: "object",
+			properties: {
+				action: { type: "string", enum: ["claim", "renew", "release", "status"] },
+				scope: { type: "string", maxLength: 256 },
+				ttlMs: { type: "integer", minimum: 1, maximum: 43_200_000 },
+				taskId: { type: "string", maxLength: 128 },
+			},
+			required: ["action"],
+			additionalProperties: false,
+		} as any,
+		async execute(_id, params, signal, _onUpdate, _ctx) {
+			const { action, ...rest } = (params ?? {}) as Record<string, unknown>;
+			const blocked = teamLeaseToolBlockReason(r, action);
+			if (blocked) return { content: [{ type: "text", text: blocked }], details: undefined, isError: true };
+			const command = typeof action === "string" ? action : "status";
+			const result = await runSupportScript("team-lease.mjs", [command, JSON.stringify(rest)], signal);
 			return { content: [{ type: "text", text: result.stdout || result.stderr }], details: undefined, isError: result.code !== 0 };
 		},
 	});
@@ -354,6 +440,12 @@ export default function (pi: ExtensionAPI) {
 				const blockReason = mcpBlockReason(r, event.input);
 				if (blockReason) {
 					return { block: true, reason: blockReason };
+				}
+			}
+			if (r === "lead") {
+				const leaseReason = await leadCreateAgentLeaseReason(event.input);
+				if (leaseReason) {
+					return { block: true, reason: leaseReason };
 				}
 			}
 		}

--- a/extensions/paseo-team-policy.ts
+++ b/extensions/paseo-team-policy.ts
@@ -133,10 +133,13 @@ function runSupportScript(name: string, args: string[], signal?: AbortSignal, ti
  * arbitrated by policy-core, so the Pi and Claude adapters cannot disagree
  * about who holds a scope.
  */
-async function leadCreateAgentLeaseReason(input: unknown): Promise<string | null> {
+async function leadWriterLeaseReason(input: unknown): Promise<string | null> {
 	const classified = classifyMcpInput(input);
 	if (classified.kind !== "target") return null;
-	if (!matchesPaseoToolName(classified.target ?? "", ["create_agent"])) return null;
+	// Both calls can deliver the brief that arms a writer.
+	if (!matchesPaseoToolName(classified.target ?? "", ["create_agent", "send_agent_prompt"])) {
+		return null;
+	}
 
 	const args = extractCreateAgentArgs(input);
 	// Nothing to gate unless this call staffs a writer; the core decides that
@@ -443,7 +446,7 @@ export default function (pi: ExtensionAPI) {
 				}
 			}
 			if (r === "lead") {
-				const leaseReason = await leadCreateAgentLeaseReason(event.input);
+				const leaseReason = await leadWriterLeaseReason(event.input);
 				if (leaseReason) {
 					return { block: true, reason: leaseReason };
 				}

--- a/prompts/lead.md
+++ b/prompts/lead.md
@@ -75,7 +75,22 @@ implementation still goes to an Engineer Peer.
    correction returns to the SAME Engineer, as a new commit — no amend, no
    force-push, and the new SHA goes through review again.
 5. **One writer per moving scope**, worktree isolation when running in
-   parallel.
+   parallel. With more than one Lead this is no longer something you can hold
+   by being careful — another Lead cannot see your intentions. **Claim the
+   scope before you create a writer** (`team_lease claim`), and release it when
+   the work is accepted. A `create_agent` in write mode without a covering
+   lease is refused by the policy on both runtimes.
+   - A claim can LOSE: the ledger has no locking, so read `granted` in the
+     result, not merely `ok`. If another Lead holds it, talk to that Lead
+     through the leases room — do not wait for the lease to expire and do not
+     start a second writer.
+   - Scopes nest: holding `src` also holds `src/auth`. Claim the narrowest
+     scope your writer actually needs, or you will block Leads you did not
+     mean to.
+   - Read-only Peers (scouts, researchers, reviewers) need no lease and are
+     never gated; they share a tree by design.
+   - If the ledger cannot be read the answer is `BLOCKED: LEASE_UNVERIFIABLE`,
+     not "proceed". Fix the ledger, do not route around it.
 6. **Acceptance is the Lead's decision; merge/deploy is the Human's.**
 7. **Browser authority is explicit and narrow**: only grant
    `BROWSER_MCP_AUTHORITY: allowed` when the Peer needs browser automation;

--- a/scripts/claude-hook.mjs
+++ b/scripts/claude-hook.mjs
@@ -218,6 +218,31 @@ function authorityBlock(describe, role, brief) {
  * "say nothing"), never throws for policy reasons — the caller turns an
  * unexpected throw into a fail-closed deny.
  */
+/**
+ * The live scope leases, but only when the decision actually needs them.
+ *
+ * Returns undefined when the call staffs no writer — the core then never looks
+ * at it — and null when the ledger could not be read, which the core treats as
+ * fatal. Those two must stay distinct: collapsing them would either block every
+ * tool call or, far worse, let an unreadable ledger read as an empty one.
+ */
+async function leasesForDecision({ core, claude }, role, toolName, toolInput, env, now) {
+	if (role !== "lead") return undefined;
+	const classified = claude.classifyClaudeTool?.(toolName) ?? null;
+	if (classified?.kind !== "paseo-mcp") return undefined;
+	if (!core.matchesPaseoToolName(classified.target ?? "", ["create_agent", "send_agent_prompt"])) {
+		return undefined;
+	}
+	if (!core.writerScopeFromCreateAgent(toolInput)) return undefined;
+	try {
+		const { leaseLedger } = await import("./team-lease.mjs");
+		const result = await leaseLedger({}, { role, selfAgentId: env.PASEO_AGENT_ID, now });
+		return result.ok ? core.resolveLeases(result.entries, { now }) : null;
+	} catch {
+		return null;
+	}
+}
+
 export async function handleEvent(event, payload, env = process.env, now = Date.now()) {
 	const { core, claude } = await loadPolicy(env);
 	const role = core.detectRole(env);
@@ -285,11 +310,18 @@ export async function handleEvent(event, payload, env = process.env, now = Date.
 
 	if (event === "pre-tool-use") {
 		const brief = await currentBrief(payload, env, now);
+		const toolName = String(payload?.tool_name ?? "");
 		const reason = claude.claudeToolBlockReason({
 			role,
-			toolName: String(payload?.tool_name ?? ""),
+			toolName,
 			toolInput: payload?.tool_input,
 			brief,
+			// Only fetched when the call would staff a writer: the ledger read is
+			// a round trip, and every other tool call must stay cheap. A fetch
+			// that fails hands over null, which the core treats as
+			// LEASE_UNVERIFIABLE rather than as an empty board.
+			leases: await leasesForDecision({ core, claude }, role, toolName, payload?.tool_input, env, now),
+			selfAgentId: env.PASEO_AGENT_ID?.trim() || null,
 		});
 		if (!reason) return null; // allow: say nothing, let normal permissions apply
 		return {

--- a/scripts/claude-team-mcp.mjs
+++ b/scripts/claude-team-mcp.mjs
@@ -121,6 +121,32 @@ export const TEAM_TOOLS = [
 			additionalProperties: false,
 		},
 	},
+	{
+		name: "team_lease",
+		// Mirrors policy-core's teamLeaseToolDescription(); the parity test pins them.
+		description:
+			"Take, extend, release or inspect a scope lease — the record of which Lead may put a WRITER on which files. `claim` before creating an engineer; `release` when the work is done; `renew` for long work; `status` to see the board. Scopes are repo-relative paths and nest: holding `src` also holds `src/auth`. A claim can lose — read `granted` in the result, not merely `ok`. Creating a write-mode Peer without a covering lease is refused.",
+		// Supervisor is included so it can read the board; the per-action gate in
+		// policy-core refuses it claim/renew/release.
+		roles: ["lead", "supervisor"],
+		script: "team-lease.mjs",
+		timeoutMs: 30_000,
+		buildArgs: (params) => {
+			const { action, ...rest } = params ?? {};
+			return [typeof action === "string" ? action : "status", JSON.stringify(rest)];
+		},
+		inputSchema: {
+			type: "object",
+			properties: {
+				action: { type: "string", enum: ["claim", "renew", "release", "status"] },
+				scope: { type: "string", maxLength: 256 },
+				ttlMs: { type: "integer", minimum: 1, maximum: 43200000 },
+				taskId: { type: "string", maxLength: 128 },
+			},
+			required: ["action"],
+			additionalProperties: false,
+		},
+	},
 ];
 
 /** Same two-candidate resolution the Pi extension uses for support scripts. */

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -39,6 +39,7 @@ $teamSupportFiles = @(
   "watchdog.mjs",
   "team-communication.mjs",
   "team-chat.mjs",
+  "team-lease.mjs",
   "ocr-review.mjs",
   "remote-paseo.mjs",
   "model-routing.mjs",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,6 +55,7 @@ TEAM_SUPPORT_FILES=(
   watchdog.mjs
   team-communication.mjs
   team-chat.mjs
+  team-lease.mjs
   ocr-review.mjs
   remote-paseo.mjs
   model-routing.mjs

--- a/scripts/team-chat.mjs
+++ b/scripts/team-chat.mjs
@@ -286,6 +286,35 @@ export function parseTeamMessage(text) {
 	};
 }
 
+/**
+ * Turn a failed CLI invocation into something a Lead can act on.
+ *
+ * Taking "the first non-empty line" seemed reasonable until Paseo answered with
+ * a pretty-printed JSON error and the Lead was told the operation failed with
+ * the message `{`. Prefer the structured message when the output is JSON, and
+ * otherwise fall back to the first line that carries actual words.
+ */
+export function cliErrorMessage(text) {
+	const raw = String(text ?? "").trim();
+	if (raw === "") return "paseo chat failed";
+	const start = raw.indexOf("{");
+	if (start >= 0) {
+		try {
+			const parsed = JSON.parse(raw.slice(start));
+			const message =
+				parsed?.error?.message ?? parsed?.message ?? parsed?.error ?? null;
+			if (typeof message === "string" && message.trim() !== "") return message.trim();
+		} catch {
+			// Not JSON after all — fall through to the line scan.
+		}
+	}
+	const informative = raw
+		.split("\n")
+		.map((line) => line.trim())
+		.find((line) => /[A-Za-z0-9]/.test(line));
+	return informative ?? raw.slice(0, 400);
+}
+
 export function runPaseo(args, timeoutMs = 20_000) {
 	const [bin, ...prefix] = resolvePaseoExec((reason) => {
 		throw bad("PASEO_EXEC_INVALID", `PASEO_TEAM_PASEO_EXEC ${reason}`);
@@ -302,7 +331,7 @@ export function runPaseo(args, timeoutMs = 20_000) {
 		);
 	} catch (error) {
 		const text = `${error?.stderr ?? ""}\n${error?.stdout ?? ""}\n${error?.message ?? error}`;
-		throw bad("CLI_ERROR", text.split("\n").find((line) => line.trim()) ?? "paseo chat failed");
+		throw bad("CLI_ERROR", cliErrorMessage(text));
 	}
 }
 

--- a/scripts/team-chat.mjs
+++ b/scripts/team-chat.mjs
@@ -402,8 +402,12 @@ export async function readRoom(input, options = {}) {
 	const args = ["chat", "read", room];
 	if (input?.since !== undefined) args.push("--since", token("since", String(input.since)));
 	if (input?.limit !== undefined) {
-		if (!Number.isInteger(input.limit) || input.limit < 1 || input.limit > 500) {
-			throw bad("FIELD_INVALID", "limit must be an integer in [1, 500]");
+		// The ceiling is high because the scope-lease ledger reads a whole time
+		// window rather than a page: a live lease that falls outside the read is
+		// invisible, and invisible reads as free. A human reading a room still
+		// wants a small limit, so the DEFAULT stays whatever the caller asks for.
+		if (!Number.isInteger(input.limit) || input.limit < 1 || input.limit > 5000) {
+			throw bad("FIELD_INVALID", "limit must be an integer in [1, 5000]");
 		}
 		args.push("--limit", String(input.limit));
 	}

--- a/scripts/team-chat.mjs
+++ b/scripts/team-chat.mjs
@@ -78,7 +78,7 @@ const TOKEN = /^[A-Za-z0-9._:-]{1,128}$/;
 const MENTION_TOKEN = /^[A-Za-z0-9-]{4,64}$/;
 const AGENT_REF = /^[0-9a-fA-F][0-9a-fA-F-]{5,63}$/;
 const DOMAIN_PREFIX = "domain:";
-const ALLOWED_FIELDS = new Set(["room", "kind", "topic", "message", "to", "correlationId", "hop", "ttl", "replyTo"]);
+const ALLOWED_FIELDS = new Set(["room", "kind", "topic", "message", "to", "correlationId", "hop", "ttl", "replyTo", "notify"]);
 
 function bad(code, message) {
 	return Object.assign(new Error(message), { code });
@@ -133,8 +133,18 @@ export function validateTeamMessage(input) {
 	}
 	token("room", room);
 	token("topic", topic);
-	if (!Array.isArray(to) || to.length === 0) {
-		throw bad("RECIPIENTS_MISSING", "to must be a non-empty array of agent refs or 'domain:<name>' entries");
+	// `notify: false` marks a RECORD rather than a request — a ledger entry that
+	// belongs in the room's history but that nobody has to wake up for. Mentions
+	// are what wake an agent, so a record simply has none. Default is true: a
+	// message with no audience must be a deliberate choice, never an omission.
+	const notify = input.notify === undefined ? true : input.notify;
+	if (typeof notify !== "boolean") throw bad("FIELD_INVALID", "notify must be a boolean");
+	if (notify) {
+		if (!Array.isArray(to) || to.length === 0) {
+			throw bad("RECIPIENTS_MISSING", "to must be a non-empty array of agent refs or 'domain:<name>' entries");
+		}
+	} else if (Array.isArray(to) && to.length > 0) {
+		throw bad("FIELD_INVALID", "notify: false posts a record, so it cannot also carry recipients");
 	}
 	const hop = input.hop === undefined ? 0 : input.hop;
 	if (!Number.isInteger(hop) || hop < 0 || hop >= MAX_HOP) {
@@ -149,7 +159,8 @@ export function validateTeamMessage(input) {
 		kind,
 		topic,
 		message: message.trim(),
-		to: [...to],
+		to: notify ? [...to] : [],
+		notify,
 		hop,
 		ttl,
 		replyTo: input.replyTo === undefined ? null : token("replyTo", input.replyTo),
@@ -317,7 +328,10 @@ export async function postTeamMessage(input, options = {}) {
 		throw bad("ROOM_NOT_ALLOWED", `ROOM_NOT_ALLOWED: '${message.room}' is outside this agent's room allowlist`);
 	}
 	const run = options.runPaseo ?? runPaseo;
-	const { mentions, agentIds } = await expandRecipients(message.to, { runPaseo: run, selfAgentId: ctx.selfAgentId });
+	// A record resolves no recipients, so it also costs no `paseo ls` round trip.
+	const { mentions, agentIds } = message.notify
+		? await expandRecipients(message.to, { runPaseo: run, selfAgentId: ctx.selfAgentId })
+		: { mentions: [], agentIds: [] };
 	const body = buildEnvelope(message, {
 		fromAgentId: ctx.selfAgentId,
 		fromRole: ctx.role,

--- a/scripts/team-lease.mjs
+++ b/scripts/team-lease.mjs
@@ -113,7 +113,8 @@ async function postLease(action, input, options = {}) {
 	const room = input?.room ?? LEASE_ROOM;
 	const run = options.runPaseo ?? runPaseo;
 
-	const posted = await postTeamMessage(
+	const post = () =>
+		postTeamMessage(
 		{
 			room,
 			kind: action === "release" ? "release" : "claim",
@@ -124,8 +125,27 @@ async function postLease(action, input, options = {}) {
 			notify: false,
 			hop: 0,
 		},
-		{ ...options, runPaseo: run },
-	);
+			{ ...options, runPaseo: run },
+		);
+
+	let posted;
+	try {
+		posted = await post();
+	} catch (error) {
+		// First run on a fresh machine: nobody has created the ledger room yet.
+		// Making that the operator's problem means the very first claim fails
+		// with a CLI error and the Lead has no idea a setup step existed. Create
+		// it and retry once — but surface the ORIGINAL failure if that does not
+		// help, because "could not create the room" is rarely the real cause.
+		try {
+			await run(["chat", "create", room, "--purpose", "paseo-pi-team scope lease ledger"]);
+		} catch {
+			throw error;
+		}
+		posted = await post().catch(() => {
+			throw error;
+		});
+	}
 
 	const after = await fetchLeases({ ...options, room, runPaseo: run });
 	const holder = after.ok ? leaseHolderFor(after.leases, scope) : null;

--- a/scripts/team-lease.mjs
+++ b/scripts/team-lease.mjs
@@ -26,6 +26,7 @@
 
 import {
 	LEASE_ACTIONS,
+	LEASE_MAX_TTL_MS,
 	leaseHolderFor,
 	normalizeScope,
 	resolveLeases,
@@ -39,9 +40,25 @@ export const LEASE_ROOM = "leases";
  *  that dies holding one does not block the scope for a whole day. */
 export const DEFAULT_TTL_MS = 3_600_000;
 export const MAX_TTL_MS = 12 * 3_600_000;
-/** How many messages back to read. The ledger is append-only, so a claim older
- *  than this many messages has long since expired anyway. */
-export const LEDGER_DEPTH = 300;
+/**
+ * How far BACK the ledger is read, in time rather than in messages.
+ *
+ * Counting messages was wrong in the one way that matters: a live claim can be
+ * pushed out of a fixed window by ordinary traffic — or deliberately, since
+ * records are cheap to post — and a lease that falls outside the window reads as
+ * no lease at all, which is the silent two-writer outcome. Time is safe because
+ * one fact bounds it: nothing can outlive LEASE_MAX_TTL_MS, so a window that
+ * covers that cannot hide anything still live. The margin absorbs clock skew
+ * between the Lead's host and the daemon.
+ */
+export const LEDGER_WINDOW_MS = LEASE_MAX_TTL_MS + 3_600_000;
+/**
+ * Safety valve, not a window. If a read comes back at the cap the board may
+ * have been cut short, and a truncated board that reads as "free" is precisely
+ * the bug this replaced — so that answer is reported as unreadable rather than
+ * as empty.
+ */
+export const LEDGER_MAX_MESSAGES = 2000;
 
 function bad(code, message) {
 	return Object.assign(new Error(message), { code });
@@ -66,10 +83,7 @@ export async function fetchLeases(options = {}) {
 	const run = options.runPaseo ?? runPaseo;
 	const now = options.now ?? Date.now();
 	try {
-		const room = await readRoom(
-			{ room: options.room ?? LEASE_ROOM, limit: options.depth ?? LEDGER_DEPTH },
-			{ ...options, runPaseo: run },
-		);
+		const room = await readLedgerRoom(options, run, now);
 		return { ok: true, leases: resolveLeases(room.messages, { now }) };
 	} catch (error) {
 		return {
@@ -79,6 +93,29 @@ export async function fetchLeases(options = {}) {
 			message: String(error?.message ?? error),
 		};
 	}
+}
+
+/**
+ * Read the ledger over a window that cannot hide a live lease, and refuse to
+ * pretend a possibly-truncated answer is the whole board.
+ */
+async function readLedgerRoom(options, run, now) {
+	const limit = options.maxMessages ?? LEDGER_MAX_MESSAGES;
+	const room = await readRoom(
+		{
+			room: options.room ?? LEASE_ROOM,
+			since: new Date(now - (options.windowMs ?? LEDGER_WINDOW_MS)).toISOString(),
+			limit,
+		},
+		{ ...options, runPaseo: run },
+	);
+	if (room.count >= limit) {
+		throw bad(
+			"LEASE_LEDGER_TRUNCATED",
+			`the lease ledger returned ${room.count} messages, at or above the ${limit} cap — the board may be incomplete, so it cannot be treated as authoritative`,
+		);
+	}
+	return room;
 }
 
 function requireScope(scope) {
@@ -178,10 +215,7 @@ export const releaseScope = (input, options) => postLease("release", input, opti
 export async function leaseLedger(input = {}, options = {}) {
 	const run = options.runPaseo ?? runPaseo;
 	try {
-		const room = await readRoom(
-			{ room: input.room ?? LEASE_ROOM, limit: input.depth ?? LEDGER_DEPTH },
-			{ ...options, runPaseo: run },
-		);
+		const room = await readLedgerRoom({ ...options, room: input.room ?? LEASE_ROOM }, run, options.now ?? Date.now());
 		return {
 			ok: true,
 			room: room.room,

--- a/scripts/team-lease.mjs
+++ b/scripts/team-lease.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * team-lease.mjs — who is allowed to put a writer on which files.
+ *
+ * "One writer per moving scope" is the oldest invariant in this pack, and until
+ * now it held for a reason that is about to stop being true: there was exactly
+ * one Lead, so nobody could contend. With several Leads, two of them can staff
+ * engineers on the same files, and that failure does not announce itself — it
+ * shows up later as a tangled working tree or a lost commit.
+ *
+ * The ledger is a Paseo chat room, reached through team-chat.mjs so a lease
+ * message is an ordinary TEAM_MESSAGE_V1 with `KIND: claim|release` and a
+ * LEASE_V1 block in the body. That choice buys three things measured on
+ * 2026-08-27: the room is queryable, its messages carry a daemon-stamped author,
+ * and concurrent posts land in a total order with none lost.
+ *
+ * What it does NOT buy is compare-and-swap: every CLAIM succeeds, including the
+ * losing one. So the ledger is append-only evidence and arbitration happens on
+ * READ, in policy-core's resolveLeases() — which is pure, and therefore the part
+ * that is actually tested. This file only fetches and posts.
+ *
+ * The rule is enforced where it can be enforced: the adapters call the pure
+ * guard before a Lead's create_agent, so a Lead that skips the claim is stopped
+ * by its own policy rather than trusted to be polite.
+ */
+
+import {
+	LEASE_ACTIONS,
+	leaseHolderFor,
+	normalizeScope,
+	resolveLeases,
+} from "../extensions/paseo-team-core/policy-core.ts";
+import { isEntrypoint } from "./lib-common.mjs";
+import { postTeamMessage, readRoom, runPaseo } from "./team-chat.mjs";
+
+/** The room that holds the ledger. One room, so the total order is global. */
+export const LEASE_ROOM = "leases";
+/** Default lease length. Long enough for real work, short enough that a Lead
+ *  that dies holding one does not block the scope for a whole day. */
+export const DEFAULT_TTL_MS = 3_600_000;
+export const MAX_TTL_MS = 12 * 3_600_000;
+/** How many messages back to read. The ledger is append-only, so a claim older
+ *  than this many messages has long since expired anyway. */
+export const LEDGER_DEPTH = 300;
+
+function bad(code, message) {
+	return Object.assign(new Error(message), { code });
+}
+
+function leaseBody(action, scope, ttlMs) {
+	const lines = ["LEASE_V1", `ACTION: ${action}`, `SCOPE: ${scope}`];
+	if (action !== "release") lines.push(`TTL_MS: ${ttlMs}`);
+	return lines.join("\n");
+}
+
+/**
+ * Read the ledger and resolve it to the set of live leases.
+ *
+ * Returns null — never an empty map — when the room could not be read. The
+ * difference matters: an empty ledger means "nobody holds anything", while an
+ * unreadable one means "we do not know", and the guard treats those opposite
+ * ways. Collapsing them would turn a daemon hiccup into permission to start a
+ * second writer.
+ */
+export async function fetchLeases(options = {}) {
+	const run = options.runPaseo ?? runPaseo;
+	const now = options.now ?? Date.now();
+	try {
+		const room = await readRoom(
+			{ room: options.room ?? LEASE_ROOM, limit: options.depth ?? LEDGER_DEPTH },
+			{ ...options, runPaseo: run },
+		);
+		return { ok: true, leases: resolveLeases(room.messages, { now }) };
+	} catch (error) {
+		return {
+			ok: false,
+			leases: null,
+			code: error?.code ?? "LEASE_LEDGER_UNREADABLE",
+			message: String(error?.message ?? error),
+		};
+	}
+}
+
+function requireScope(scope) {
+	const normalized = normalizeScope(scope);
+	if (!normalized) {
+		throw bad("SCOPE_INVALID", `scope must be a repo-relative path (got ${JSON.stringify(scope)})`);
+	}
+	return normalized;
+}
+
+function requireTtl(ttlMs) {
+	const value = ttlMs === undefined ? DEFAULT_TTL_MS : ttlMs;
+	if (!Number.isInteger(value) || value <= 0 || value > MAX_TTL_MS) {
+		throw bad("TTL_INVALID", `ttlMs must be an integer in (0, ${MAX_TTL_MS}]`);
+	}
+	return value;
+}
+
+/**
+ * Post a lease event.
+ *
+ * A claim is deliberately NOT checked against the ledger before posting: the
+ * room has no compare-and-swap, so a pre-check would only produce a
+ * comfortable-looking race. Post the intent, then let the read side arbitrate —
+ * and report the resolved holder back so the caller learns immediately whether
+ * it won.
+ */
+async function postLease(action, input, options = {}) {
+	if (!LEASE_ACTIONS.includes(action)) throw bad("ACTION_INVALID", `unknown lease action '${action}'`);
+	const scope = requireScope(input?.scope);
+	const ttlMs = action === "release" ? null : requireTtl(input?.ttlMs);
+	const room = input?.room ?? LEASE_ROOM;
+	const run = options.runPaseo ?? runPaseo;
+
+	const posted = await postTeamMessage(
+		{
+			room,
+			kind: action === "release" ? "release" : "claim",
+			topic: input?.taskId ?? "lease",
+			message: leaseBody(action, scope, ttlMs),
+			// A lease event is a record, not a request: it belongs in the room's
+			// history, but no Lead should be pulled out of its work to read it.
+			notify: false,
+			hop: 0,
+		},
+		{ ...options, runPaseo: run },
+	);
+
+	const after = await fetchLeases({ ...options, room, runPaseo: run });
+	const holder = after.ok ? leaseHolderFor(after.leases, scope) : null;
+	const self = options.selfAgentId ?? process.env.PASEO_AGENT_ID ?? null;
+	return {
+		ok: true,
+		action,
+		scope,
+		ttlMs,
+		room,
+		correlationId: posted.correlationId,
+		ledgerReadable: after.ok,
+		holder,
+		// The only field a caller should branch on: did WE end up holding it.
+		granted: Boolean(holder && self && holder.agentId === self),
+	};
+}
+
+export const claimScope = (input, options) => postLease("claim", input, options);
+export const renewScope = (input, options) => postLease("renew", input, options);
+export const releaseScope = (input, options) => postLease("release", input, options);
+
+/**
+ * The raw ledger, for a caller that will arbitrate itself.
+ *
+ * The policy adapters use this rather than leaseStatus(): arbitration must run
+ * in ONE place (policy-core's resolveLeases) with the caller's own clock, so a
+ * guard decision can never differ from what the guard's own core would conclude.
+ */
+export async function leaseLedger(input = {}, options = {}) {
+	const run = options.runPaseo ?? runPaseo;
+	try {
+		const room = await readRoom(
+			{ room: input.room ?? LEASE_ROOM, limit: input.depth ?? LEDGER_DEPTH },
+			{ ...options, runPaseo: run },
+		);
+		return {
+			ok: true,
+			room: room.room,
+			entries: room.messages.map(({ author, createdAt, body }) => ({ author, createdAt, body })),
+		};
+	} catch (error) {
+		// Fail LOUD, not empty: the guard has to tell "nobody holds it" apart from
+		// "we could not find out", and those lead to opposite decisions.
+		return {
+			ok: false,
+			code: error?.code ?? "LEASE_LEDGER_UNREADABLE",
+			message: String(error?.message ?? error),
+			entries: null,
+		};
+	}
+}
+
+/** Everything currently held, for a Lead deciding where it can work. */
+export async function leaseStatus(input = {}, options = {}) {
+	const result = await fetchLeases({ ...options, room: input.room ?? LEASE_ROOM });
+	if (!result.ok) {
+		return { ok: false, code: result.code, message: result.message, leases: null };
+	}
+	const held = [...result.leases.values()].sort((a, b) => a.claimedAt - b.claimedAt);
+	const scope = input.scope === undefined ? null : requireScope(input.scope);
+	return {
+		ok: true,
+		room: input.room ?? LEASE_ROOM,
+		count: held.length,
+		leases: held.map((holder) => ({ ...holder, expiresAtIso: new Date(holder.expiresAt).toISOString() })),
+		...(scope ? { scope, holder: leaseHolderFor(result.leases, scope) } : {}),
+	};
+}
+
+async function main() {
+	const command = process.argv[2];
+	let input = {};
+	if (process.argv[3] !== undefined) {
+		try {
+			input = JSON.parse(process.argv[3]);
+		} catch (error) {
+			throw bad("INPUT_INVALID", `invalid JSON input: ${String(error?.message ?? error)}`);
+		}
+	}
+	const handlers = { claim: claimScope, renew: renewScope, release: releaseScope, status: leaseStatus, ledger: leaseLedger };
+	const handler = handlers[command];
+	if (!handler) throw bad("USAGE", `usage: team-lease.mjs ${Object.keys(handlers).join("|")} '<json>'`);
+	console.log(JSON.stringify(await handler(input), null, 2));
+}
+
+export function isMainModule(entry = process.argv[1], moduleUrl = import.meta.url) {
+	return isEntrypoint(moduleUrl, entry);
+}
+
+if (isMainModule()) {
+	main().catch((error) => {
+		console.error(JSON.stringify({ ok: false, code: error.code ?? "LEASE_FAILED", message: error.message }));
+		process.exit(2);
+	});
+}

--- a/scripts/watchdog.mjs
+++ b/scripts/watchdog.mjs
@@ -95,6 +95,44 @@ async function inspectOne(agent, deadline, options) {
   }
 }
 
+/**
+ * Cross the lease board with the agent list.
+ *
+ * Two situations deserve an operator's attention, and neither is something the
+ * watchdog may fix: a scope held by an agent that is no longer listed (a Lead
+ * died holding it, and it will block other Leads until the TTL runs out), and a
+ * scope whose lease has already lapsed while its holder is still alive (the
+ * Lead believes it owns ground the policy will no longer grant it).
+ *
+ * Observation only, like everything else here. Reclaiming a scope from a Lead
+ * that might still be mid-write is exactly the move that produces the second
+ * writer this whole mechanism exists to prevent.
+ */
+export function classifyLeases(leases, agents, { now }) {
+  const alive = new Set(
+    (Array.isArray(agents) ? agents : [])
+      .map((agent) => agent?.id ?? agent?.Id)
+      .filter((id) => typeof id === "string"),
+  );
+  const rows = [];
+  for (const holder of leases?.values?.() ?? []) {
+    const holderListed = alive.has(holder.agentId);
+    const expired = holder.expiresAt <= now;
+    if (holderListed && !expired) continue;
+    rows.push({
+      scope: holder.scope,
+      agentId: holder.agentId,
+      expiresAt: new Date(holder.expiresAt).toISOString(),
+      holderListed,
+      expired,
+      suspicion: !holderListed
+        ? "holder is not in the agent listing — the scope stays blocked until the lease expires"
+        : "lease has lapsed while the holder is still running — its next create_agent will be refused",
+    });
+  }
+  return rows;
+}
+
 export async function collectWatchdogSnapshot(options = {}) {
   const globalDeadlineMs = Math.max(1000, options.globalDeadlineMs ?? DEFAULT_GLOBAL_DEADLINE_MS);
   const deadline = Date.now() + globalDeadlineMs;
@@ -146,11 +184,30 @@ export async function collectWatchdogSnapshot(options = {}) {
   });
   const classified = classifyStaleAgents(complete, options);
   const partial = allRunning.length > running.length || complete.some((agent) => agent.inspectOk !== true);
+  const now = options.now ?? Date.now();
+  // The lease board is a second, cheaper source of "something is stuck": one
+  // room read, no per-agent fan-out. Its absence degrades the report rather
+  // than failing it — an unreadable ledger is already fatal where it matters,
+  // at the create_agent gate.
+  let leaseRows = [];
+  let leaseError = null;
+  if (options.leases !== false) {
+    try {
+      const { fetchLeases } = options.leaseModule ?? (await import("./team-lease.mjs"));
+      const fetched = await fetchLeases({ ...options, now });
+      if (fetched.ok) leaseRows = classifyLeases(fetched.leases, allRunning, { now });
+      else leaseError = fetched.code ?? "LEASE_LEDGER_UNREADABLE";
+    } catch (error) {
+      leaseError = String(error?.message ?? error);
+    }
+  }
   return {
-    generatedAt: new Date(options.now ?? Date.now()).toISOString(),
+    generatedAt: new Date(now).toISOString(),
     staleAfterMs: Math.max(1000, options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS),
     agents: classified,
     stale: classified.filter((agent) => agent.stale),
+    leases: leaseRows,
+    ...(leaseError ? { leaseError } : {}),
     partial,
     action: "observation-only: do not cancel/archive/spawn until status, activity and workspace state are reconciled",
   };

--- a/skills/paseo-team-lead/SKILL.md
+++ b/skills/paseo-team-lead/SKILL.md
@@ -69,6 +69,38 @@ from the project's current working directory.
 
 For EVERY `create_agent`, run this exact cycle. Do not skip steps.
 
+0. **Scope lease — writers only.** Before creating any Peer whose brief carries
+   `MODE: write` + `EDIT_AUTHORITY: allowed`, take the lease for the scope that
+   Peer will own:
+
+   ```text
+   team_lease { action: "claim", scope: "<OWNED_SCOPE>", ttlMs: <work window> }
+   ```
+
+   Check `granted` in the result — a claim is written even when it loses,
+   because the ledger room has no locking and arbitration happens on read.
+
+   - `granted: true` → continue the cycle.
+   - `granted: false` → another Lead owns ground that covers your scope; the
+     result names it. Coordinate through the leases room. Do NOT create the
+     writer, do NOT narrow the scope to sneak under the holder, and do NOT wait
+     out the TTL as a strategy.
+   - Ledger unreadable → `BLOCKED: LEASE_UNVERIFIABLE`. This is a real blocker,
+     not a warning.
+
+   Renew with `action: "renew"` when work outlives the TTL, and
+   `action: "release"` once the candidate is accepted or abandoned — a scope
+   you forget to release blocks other Leads until it expires.
+
+   Read-only dispositions (repository-scout, documentation-researcher,
+   solution-architect, independent-reviewer) take no lease: they share the tree
+   by design, and gating them would turn the lease into a bottleneck rather
+   than a safety rule.
+
+   The policy enforces this on both runtimes, so a skipped claim surfaces as a
+   refused `create_agent` rather than as two engineers quietly editing the same
+   files.
+
 1. Pick `MODEL_CLASS` from task risk + disposition (classes table below).
 2. Pick `HOST_ID` from the controller-local cluster routing file
    `~/.paseo-pi-team/cluster-routing.local.json` (capability filter: writers

--- a/test/claude-hook.test.mjs
+++ b/test/claude-hook.test.mjs
@@ -299,4 +299,54 @@ assert.equal(runHook("pre-tool-use", { session_id: "s0", tool_name: "Write" }, b
 }
 
 rmSync(home, { recursive: true, force: true });
+// --- scope lease: the hook has to fetch the ledger, not just forward a deny --
+// A decision function that is never handed a ledger denies every writer. That
+// fails closed, so no test of the DECISION would notice — only a test of the
+// HOOK does.
+{
+	const LEAD = "aaaaaaaa-1111-4111-8111-111111111111";
+	const leadEnv = { ...baseEnv, PASEO_PI_ROLE: "lead", PASEO_AGENT_ID: LEAD };
+	const writerBrief = [
+		"PASEO_TEAM_TASK_V3_BEGIN",
+		"TASK_ID: T-1",
+		"DISPOSITION: engineer",
+		"MODE: write",
+		"OWNED_SCOPE: src/auth",
+		"EDIT_AUTHORITY: allowed",
+		"PASEO_TEAM_TASK_V3_END",
+	].join("\n");
+	const createWriter = {
+		session_id: "lease-1",
+		tool_name: "mcp__paseo__create_agent",
+		tool_input: { initialPrompt: writerBrief },
+	};
+
+	// No daemon here, so the ledger read fails — and the hook must turn that into
+	// LEASE_UNVERIFIABLE rather than into silence.
+	const blocked = await handleEvent("pre-tool-use", createWriter, leadEnv);
+	assert.match(
+		String(blocked?.hookSpecificOutput?.permissionDecisionReason),
+		/LEASE_UNVERIFIABLE|SCOPE_LEASE/,
+		"a Lead staffing a writer is lease-checked on the Claude runtime",
+	);
+
+	// A read-only Peer is not gated, so it must pass even with no ledger at all —
+	// this is what proves the gate is scoped to writers rather than to every call.
+	assert.equal(
+		await handleEvent(
+			"pre-tool-use",
+			{ ...createWriter, tool_input: { initialPrompt: writerBrief.replace("MODE: write", "MODE: read-only") } },
+			leadEnv,
+		),
+		null,
+		"read-only creation is never lease-gated",
+	);
+
+	// And an ordinary call is untouched: no ledger read, no denial.
+	assert.equal(
+		await handleEvent("pre-tool-use", { session_id: "lease-2", tool_name: "Read", tool_input: { file_path: "a" } }, leadEnv),
+		null,
+	);
+}
+
 console.log("claude hook tests passed");

--- a/test/claude-policy.test.mjs
+++ b/test/claude-policy.test.mjs
@@ -416,6 +416,40 @@ assert.match(describeClaudePolicy("lead", null), /paseoMcp=\[/);
 	assert.match(String(createAgent(null, LEAD_A)), /LEASE_UNVERIFIABLE/);
 	assert.match(String(createAgent(undefined, LEAD_A)), /LEASE_UNVERIFIABLE/, "a caller that forgot to fetch is not a free pass");
 
+	// OCR-002: the brief arms a Peer whether it arrives at creation or in a later
+	// turn, so send_agent_prompt is gated exactly like create_agent. Otherwise the
+	// two-step — create something benign, then send the write brief — walks past
+	// the lease untouched.
+	assert.match(
+		String(
+			claudeToolBlockReason({
+				role: "lead",
+				toolName: "mcp__paseo__send_agent_prompt",
+				toolInput: { agentId: "x", prompt: writerBrief },
+				brief: null,
+				leases: resolveLeases([claim(LEAD_B, "src/auth")], { now }),
+				selfAgentId: LEAD_A,
+			}),
+			/SCOPE_LEASE_HELD/,
+		),
+		/SCOPE_LEASE_HELD/,
+	);
+
+	// OCR-007: the Supervisor may read the lease board but not move it, on this
+	// runtime as well — an authority that exists on one adapter only is the exact
+	// asymmetry the shared core exists to prevent.
+	const leaseTool = (role, action) =>
+		claudeToolBlockReason({
+			role,
+			toolName: "mcp__paseo-team__team_lease",
+			toolInput: { action, scope: "src/auth" },
+			brief: null,
+		});
+	assert.equal(leaseTool("supervisor", "status"), null, "reading the board is governance");
+	assert.match(String(leaseTool("supervisor", "claim")), /not claim, renew or release/);
+	assert.match(String(leaseTool("supervisor", "release")), /not claim, renew or release/);
+	assert.equal(leaseTool("lead", "claim"), null);
+
 	// A read-only peer shares the tree by design and is never gated.
 	assert.equal(
 		createAgent(resolveLeases([claim(LEAD_B, "src/auth")], { now }), LEAD_A, writerBrief.replace("MODE: write", "MODE: read-only")),

--- a/test/claude-policy.test.mjs
+++ b/test/claude-policy.test.mjs
@@ -362,4 +362,65 @@ assert.match(describeClaudePolicy("lead", null), /paseoMcp=\[/);
 	assert.equal(bash("peer", "node /x/paseo-team-scripts/team-communication.mjs ask-lead {}"), null);
 }
 
+// --- scope lease: the same rule reaches the Claude runtime -------------------
+// The rule itself is pinned in scope-lease.test.mts. What is pinned HERE is that
+// the Claude adapter actually consults it — the leg that, for the chat guard,
+// was missing on this runtime and would have made `claude-lead` a one-provider
+// bypass.
+{
+	const { resolveLeases } = await import("../extensions/paseo-team-core/policy-core.ts");
+	const LEAD_A = "aaaaaaaa-1111-4111-8111-111111111111";
+	const LEAD_B = "bbbbbbbb-2222-4222-8222-222222222222";
+	const now = 10_000_000;
+	const claim = (author, scope) => ({
+		author,
+		createdAt: new Date(now - 1000).toISOString(),
+		body: `LEASE_V1\nACTION: claim\nSCOPE: ${scope}\nTTL_MS: 3600000`,
+	});
+	const writerBrief = [
+		"PASEO_TEAM_TASK_V3_BEGIN",
+		"TASK_ID: T-1",
+		"DISPOSITION: engineer",
+		"MODE: write",
+		"OWNED_SCOPE: src/auth",
+		"EDIT_AUTHORITY: allowed",
+		"PASEO_TEAM_TASK_V3_END",
+	].join("\n");
+	const createAgent = (leases, selfAgentId, prompt = writerBrief) =>
+		claudeToolBlockReason({
+			role: "lead",
+			toolName: "mcp__paseo__create_agent",
+			toolInput: { initialPrompt: prompt },
+			brief: null,
+			leases,
+			selfAgentId,
+		});
+
+	assert.equal(
+		createAgent(resolveLeases([claim(LEAD_A, "src/auth")], { now }), LEAD_A),
+		null,
+		"the holder may staff its own scope",
+	);
+	assert.match(
+		String(createAgent(resolveLeases([claim(LEAD_B, "src/auth")], { now }), LEAD_A)),
+		/SCOPE_LEASE_HELD/,
+		"another Lead's scope is refused on this runtime too",
+	);
+	assert.match(
+		String(createAgent(resolveLeases([], { now }), LEAD_A)),
+		/SCOPE_LEASE_MISSING/,
+		"and staffing an unclaimed scope is refused",
+	);
+	// The hook could not read the ledger. Fail closed: a Lead that cannot create
+	// a writer is a visible incident, two writers on one scope is a silent one.
+	assert.match(String(createAgent(null, LEAD_A)), /LEASE_UNVERIFIABLE/);
+	assert.match(String(createAgent(undefined, LEAD_A)), /LEASE_UNVERIFIABLE/, "a caller that forgot to fetch is not a free pass");
+
+	// A read-only peer shares the tree by design and is never gated.
+	assert.equal(
+		createAgent(resolveLeases([claim(LEAD_B, "src/auth")], { now }), LEAD_A, writerBrief.replace("MODE: write", "MODE: read-only")),
+		null,
+	);
+}
+
 console.log("claude policy tests passed");

--- a/test/claude-team-mcp.test.mjs
+++ b/test/claude-team-mcp.test.mjs
@@ -36,7 +36,7 @@ const serverPath = join(root, "scripts", "claude-team-mcp.mjs");
 	// runtime and not the other is a capability the other runtime silently lacks.
 	assert.deepEqual(
 		listed.result.tools.map((tool) => tool.name).sort(),
-		["peer_ask_lead", "team_chat", "team_watchdog"],
+		["peer_ask_lead", "team_chat", "team_lease", "team_watchdog"],
 	);
 	for (const tool of listed.result.tools) {
 		assert.equal(tool.inputSchema.type, "object");
@@ -79,6 +79,7 @@ assert.deepEqual(
 	[
 		["peer_ask_lead", ["peer"]],
 		["team_chat", ["lead", "supervisor"]],
+		["team_lease", ["lead", "supervisor"]],
 		["team_watchdog", ["lead", "supervisor"]],
 	],
 );
@@ -125,6 +126,11 @@ assert.deepEqual(
 	// description does: this file cannot import the .ts core, and team-chat.mjs is
 	// a separate process. Only team-chat.mjs ENFORCES it — the other two advertise
 	// it — so drift would leave a schema promising more than the tool accepts.
+	// Same parity rule for the lease tool: one description, two runtimes.
+	const lease = TEAM_TOOLS.find((tool) => tool.name === "team_lease");
+	const { teamLeaseToolDescription } = await import("../extensions/paseo-team-core/policy-core.ts");
+	assert.equal(lease.description, teamLeaseToolDescription(), "the lease description must not drift either");
+
 	const { TEAM_CHAT_MAX_BODY_BYTES: coreCeiling } = await import("../extensions/paseo-team-core/policy-core.ts");
 	const { MAX_BODY_BYTES: enforcedCeiling } = await import("../scripts/team-chat.mjs");
 	assert.equal(chat.inputSchema.properties.message.maxLength, enforcedCeiling, "the Claude schema advertises what team-chat.mjs enforces");

--- a/test/installer-contract.test.mjs
+++ b/test/installer-contract.test.mjs
@@ -12,6 +12,7 @@ import { isMainModule as isOcrMain } from "../scripts/ocr-setup.mjs";
 import { isMainModule as isOcrReviewMain } from "../scripts/ocr-review.mjs";
 import { isMainModule as isCommunicationMain } from "../scripts/team-communication.mjs";
 import { isMainModule as isChatMain } from "../scripts/team-chat.mjs";
+import { isMainModule as isLeaseMain } from "../scripts/team-lease.mjs";
 import { isMainModule as isWatchdogMain } from "../scripts/watchdog.mjs";
 import { isMainModule as isPathMain } from "../scripts/team-scripts-path.mjs";
 import { defaultTeamScriptsDir, resolveTeamScriptsDir } from "../scripts/team-scripts-path.mjs";
@@ -19,7 +20,7 @@ const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const source = join(root, "scripts");
 const installed = mkdtempSync(join(tmpdir(), "paseo-installed-support-"));
 const unrelatedCwd = mkdtempSync(join(tmpdir(), "paseo-unrelated-cwd-"));
-for (const file of ["lib-common.mjs", "remote-paseo.mjs", "model-routing.mjs", "reliability.mjs", "team-communication.mjs", "team-chat.mjs", "watchdog.mjs", "ocr-review.mjs", "ocr-setup.mjs", "team-scripts-path.mjs"]) {
+for (const file of ["lib-common.mjs", "remote-paseo.mjs", "model-routing.mjs", "reliability.mjs", "team-communication.mjs", "team-chat.mjs", "team-lease.mjs", "watchdog.mjs", "ocr-review.mjs", "ocr-setup.mjs", "team-scripts-path.mjs"]) {
   cpSync(join(source, file), join(installed, file));
 }
 
@@ -69,6 +70,7 @@ const symlinkCases = [
   [join(installed, "ocr-review.mjs"), isOcrReviewMain],
   [join(installed, "team-communication.mjs"), isCommunicationMain],
   [join(installed, "team-chat.mjs"), isChatMain],
+  [join(installed, "team-lease.mjs"), isLeaseMain],
   [join(installed, "watchdog.mjs"), isWatchdogMain],
   [join(installed, "team-scripts-path.mjs"), isPathMain],
 ];
@@ -188,7 +190,7 @@ for (const installer of ["install.sh", "install.ps1"]) {
     },
   );
   const tools = JSON.parse(handshake).result.tools.map((tool) => tool.name);
-  assert.deepEqual(tools.sort(), ["peer_ask_lead", "team_chat", "team_watchdog"]);
+  assert.deepEqual(tools.sort(), ["peer_ask_lead", "team_chat", "team_lease", "team_watchdog"]);
 }
 
 console.log("installer contract tests passed");

--- a/test/policy.test.mts
+++ b/test/policy.test.mts
@@ -1412,7 +1412,8 @@ function requireHandler(handlers: StubHandlers, name: string): StubHandler {
 
 // --- Examples regression: every V3 brief in examples/*.md must parse clean ---
 
-import { readdirSync, readFileSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -1541,6 +1542,75 @@ for (const file of readdirSync(examplesDir).filter((f) => f.endsWith(".md"))) {
 
 	if (prevRole === undefined) delete process.env.PASEO_PI_ROLE;
 	else process.env.PASEO_PI_ROLE = prevRole;
+}
+
+// --- scope lease: the Pi extension really consults the ledger ---------------
+// Same lesson as the support-script guard: a rule the adapter never calls is a
+// rule that does not exist. This drives the extension's own tool_call handler
+// with the support script stubbed, so deleting the gate fails here.
+{
+	const { piStub, handlers } = makePiStub(["read", "mcp"]);
+	const prevRole = process.env.PASEO_PI_ROLE;
+	const prevSelf = process.env.PASEO_AGENT_ID;
+	const prevScripts = process.env.PASEO_TEAM_SCRIPTS_DIR;
+	const LEAD_A = "aaaaaaaa-1111-4111-8111-111111111111";
+	const LEAD_B = "bbbbbbbb-2222-4222-8222-222222222222";
+
+	// A stub support-script directory whose team-lease.mjs prints a ledger in
+	// which LEAD_B holds src/auth.
+	const stubDir = mkdtempSync(join(tmpdir(), "pst-lease-stub-"));
+	const ledger = JSON.stringify({
+		ok: true,
+		entries: [
+			{
+				author: LEAD_B,
+				createdAt: new Date().toISOString(),
+				body: "LEASE_V1\nACTION: claim\nSCOPE: src/auth\nTTL_MS: 3600000",
+			},
+		],
+	});
+	writeFileSync(join(stubDir, "team-lease.mjs"), `console.log(${JSON.stringify(ledger)});\n`, "utf8");
+
+	process.env.PASEO_PI_ROLE = "lead";
+	process.env.PASEO_AGENT_ID = LEAD_A;
+	process.env.PASEO_TEAM_SCRIPTS_DIR = stubDir;
+	try {
+		const createExtension = await loadFreshExtension("lifecycle=lease");
+		createExtension(piStub);
+		const toolCall = requireHandler(handlers, "tool_call");
+		const writerBrief = [
+			"PASEO_TEAM_TASK_V3_BEGIN",
+			"TASK_ID: T-1",
+			"DISPOSITION: engineer",
+			"MODE: write",
+			"OWNED_SCOPE: src/auth/login",
+			"EDIT_AUTHORITY: allowed",
+			"PASEO_TEAM_TASK_V3_END",
+		].join("\n");
+		const create = async (prompt: string) =>
+			(await toolCall({
+				toolName: "mcp",
+				input: { tool: "create_agent", args: { initialPrompt: prompt } },
+			})) as { block?: boolean; reason?: string } | undefined;
+
+		const blocked = await create(writerBrief);
+		assert.equal(blocked?.block, true, "the Pi extension consults the lease ledger");
+		assert.match(String(blocked?.reason), /SCOPE_LEASE_HELD/);
+		assert.match(String(blocked?.reason), /bbbbbbbb/, "and names the Lead to go talk to");
+
+		// A read-only peer on the very same scope is untouched: the lease guards
+		// writers, not parallelism.
+		const readOnly = await create(writerBrief.replace("MODE: write", "MODE: read-only"));
+		assert.equal(readOnly?.block, undefined);
+	} finally {
+		rmSync(stubDir, { recursive: true, force: true });
+		if (prevRole === undefined) delete process.env.PASEO_PI_ROLE;
+		else process.env.PASEO_PI_ROLE = prevRole;
+		if (prevSelf === undefined) delete process.env.PASEO_AGENT_ID;
+		else process.env.PASEO_AGENT_ID = prevSelf;
+		if (prevScripts === undefined) delete process.env.PASEO_TEAM_SCRIPTS_DIR;
+		else process.env.PASEO_TEAM_SCRIPTS_DIR = prevScripts;
+	}
 }
 
 console.log("[paseo-team] policy tests passed");

--- a/test/policy.test.mts
+++ b/test/policy.test.mts
@@ -838,13 +838,28 @@ assert.equal(
 	mcpScriptBlockReason("lead", "const r = await tools.paseo_list_agents();"),
 	null,
 );
-assert.equal(
-	mcpScriptBlockReason(
-		"lead",
-		'await tools.call("paseo_create_agent", { provider: "pi-peer/x" });',
+// create_agent and send_agent_prompt are NOT reachable from a Lead's mcp_script,
+// for the reason the Supervisor's set already documents: a script's arguments
+// cannot be statically verified. Both calls carry the V3 brief that arms a
+// writer, and the scope-lease gate works by INSPECTING those arguments — so
+// leaving them here would keep a first-class path the gate never sees. The Lead
+// uses the direct `mcp` tool for these two.
+assert.match(
+	String(
+		mcpScriptBlockReason(
+			"lead",
+			'await tools.call("paseo_create_agent", { provider: "pi-peer/x" });',
+		),
 	),
-	null,
+	/not in the lead MCP allowlist/,
 );
+assert.match(
+	String(mcpScriptBlockReason("lead", "await tools.paseo_send_agent_prompt({});")),
+	/not in the lead MCP allowlist/,
+);
+// Everything else a Lead scripts is untouched.
+assert.equal(mcpScriptBlockReason("lead", "await tools.paseo_list_models({});"), null);
+assert.equal(mcpScriptBlockReason("lead", "await tools.paseo_get_agent_status({});"), null);
 assert.match(
 	mcpScriptBlockReason("lead", "await tools.paseo_create_terminal();") ?? "",
 	/allowlist/,
@@ -1602,6 +1617,24 @@ for (const file of readdirSync(examplesDir).filter((f) => f.endsWith(".md"))) {
 		// writers, not parallelism.
 		const readOnly = await create(writerBrief.replace("MODE: write", "MODE: read-only"));
 		assert.equal(readOnly?.block, undefined);
+
+		// The brief arms a Peer whether it arrives at creation or in a later turn,
+		// so send_agent_prompt is gated identically. Without this the two-step —
+		// create something benign, then send the write brief — walks past the
+		// lease untouched.
+		const sent = (await toolCall({
+			toolName: "mcp",
+			input: { tool: "send_agent_prompt", args: { agentId: "some-peer", prompt: writerBrief } },
+		})) as { block?: boolean; reason?: string } | undefined;
+		assert.equal(sent?.block, true, "a write brief sent after creation is lease-checked too");
+		assert.match(String(sent?.reason), /SCOPE_LEASE_HELD/);
+
+		// An ordinary follow-up carries no brief and is not gated.
+		const followUp = await toolCall({
+			toolName: "mcp",
+			input: { tool: "send_agent_prompt", args: { agentId: "some-peer", prompt: "please add a test" } },
+		});
+		assert.equal((followUp as { block?: boolean } | undefined)?.block, undefined);
 	} finally {
 		rmSync(stubDir, { recursive: true, force: true });
 		if (prevRole === undefined) delete process.env.PASEO_PI_ROLE;

--- a/test/scope-lease.test.mts
+++ b/test/scope-lease.test.mts
@@ -13,6 +13,7 @@
 
 import assert from "node:assert/strict";
 import {
+	LEASE_MAX_TTL_MS,
 	leaseBlockReason,
 	leaseHolderFor,
 	normalizeScope,
@@ -33,7 +34,14 @@ assert.equal(normalizeScope("./src/auth"), "src/auth");
 assert.equal(normalizeScope("src\\auth"), "src/auth", "a Windows Lead and a POSIX Lead claim the same thing");
 assert.equal(normalizeScope("src/auth/"), "src/auth");
 assert.equal(normalizeScope("  src//auth  "), "src/auth");
-assert.equal(normalizeScope("SRC/Auth"), "SRC/Auth", "case is preserved: paths are case-sensitive where it matters");
+assert.equal(normalizeScope("SRC/Auth"), "SRC/Auth", "the stored spelling is preserved");
+// Interior "." segments are the same directory on every filesystem. Leaving
+// them distinct would let two Leads hold identical files by spelling the path
+// two ways — the same class of hole as `..`, which is already rejected.
+assert.equal(normalizeScope("src/./auth"), "src/auth");
+assert.equal(normalizeScope("./src/./auth/."), "src/auth");
+assert.equal(normalizeScope("."), ".");
+assert.equal(normalizeScope("./"), ".");
 assert.equal(normalizeScope(""), null);
 assert.equal(normalizeScope("   "), null);
 assert.equal(normalizeScope(null), null);
@@ -50,6 +58,14 @@ assert.equal(scopeConflicts("src/auth", "src/authz"), false, "a shared prefix is
 assert.equal(scopeConflicts("src/auth", "src/billing"), false);
 assert.equal(scopeConflicts(".", "anything/at/all"), true, "the repo root covers everything");
 assert.equal(scopeConflicts("src/auth", null), false);
+assert.equal(scopeConflicts("src/auth", "src/./auth"), true, "the same directory spelled two ways is one scope");
+// Compared case-insensitively: `src/auth` and `SRC/Auth` are the same files on
+// Windows and default macOS, which is where this pack runs. On a case-sensitive
+// filesystem this can only produce a FALSE conflict, and "these two Leads
+// collide" is the safe direction to be wrong in.
+assert.equal(scopeConflicts("src/auth", "SRC/Auth"), true);
+assert.equal(scopeConflicts("src/auth", "SRC/Auth/Login"), true);
+assert.equal(scopeConflicts("src/auth", "SRC/Authz"), false, "case-folding must not turn distinct siblings into a conflict");
 
 // --- record parsing ----------------------------------------------------------
 {
@@ -179,6 +195,19 @@ function entry(author, action, scope, ts, ttlMs = HOUR) {
 	assert.equal(leaseHolderFor(leases, "src/auth")?.agentId, LEAD_A, "the narrower, earlier lease keeps the ground");
 }
 
+{
+	// The tool caps TTL, but arbitration reads whatever is in the room. One
+	// smuggled record on the repo root would otherwise hold every writer out
+	// until someone edited the room by hand.
+	const forever = entry(LEAD_B, "claim", ".", 1000, 999_999_999_999);
+	const leases = resolveLeases([forever], { now: 1000 + LEASE_MAX_TTL_MS + 1 });
+	assert.equal(leases.size, 0, "an absurd TTL is clamped at fold time, so the lock still lapses");
+
+	const stillLive = resolveLeases([forever], { now: 1000 + LEASE_MAX_TTL_MS - 1 });
+	assert.equal(stillLive.size, 1, "and it is honoured up to the ceiling");
+	assert.equal(parseLeaseRecord(forever.body)?.ttlMs, LEASE_MAX_TTL_MS);
+}
+
 // Junk in the room is not a lease and must not disturb the ones that are.
 {
 	const leases = resolveLeases(
@@ -205,6 +234,18 @@ const writeBrief = (scope: string) =>
 	].join("\n");
 
 assert.equal(writerScopeFromCreateAgent({ initialPrompt: writeBrief("src/auth") }), "src/auth");
+// The gate and the grant must be one question, not two readings of the same
+// fields. They diverged: the gate demanded a literal `EDIT_AUTHORITY: allowed`
+// while the grant defaults edit to true when the field is absent under
+// `MODE: write` — so this brief, which the parser accepts without complaint,
+// produced a writer that no lease ever covered.
+assert.equal(
+	writerScopeFromCreateAgent({
+		initialPrompt: writeBrief("src/auth").replace("EDIT_AUTHORITY: allowed\n", ""),
+	}),
+	"src/auth",
+	"a write brief with EDIT_AUTHORITY omitted still staffs a writer, so it still needs a lease",
+);
 assert.equal(
 	writerScopeFromCreateAgent({ initialPrompt: writeBrief("src/auth").replace("MODE: write", "MODE: read-only") }),
 	null,

--- a/test/scope-lease.test.mts
+++ b/test/scope-lease.test.mts
@@ -1,0 +1,322 @@
+// scope-lease.test.mts — the rule that keeps two Leads off one moving scope.
+//
+// Until now "one writer per moving scope" held by accident: there was exactly
+// one Lead. With several, nothing structural stops two of them from putting a
+// writer on the same files, and the failure is a corrupted working tree rather
+// than an error message.
+//
+// The ledger lives in a chat room, which gives a total order by server
+// timestamp but NO compare-and-swap (measured: four concurrent posts all
+// succeeded). So arbitration happens on read, and this file is where that
+// arbitration is pinned — it must be pure, so a lease decision never depends on
+// a daemon being reachable at test time.
+
+import assert from "node:assert/strict";
+import {
+	leaseBlockReason,
+	leaseHolderFor,
+	normalizeScope,
+	parseLeaseRecord,
+	resolveLeases,
+	scopeConflicts,
+	writerScopeFromCreateAgent,
+} from "../extensions/paseo-team-core/policy-core.ts";
+
+const LEAD_A = "aaaaaaaa-1111-4111-8111-111111111111";
+const LEAD_B = "bbbbbbbb-2222-4222-8222-222222222222";
+const HOUR = 3_600_000;
+
+// --- scope normalization -----------------------------------------------------
+// Scopes are compared, so their spelling must not decide who wins.
+assert.equal(normalizeScope("src/auth"), "src/auth");
+assert.equal(normalizeScope("./src/auth"), "src/auth");
+assert.equal(normalizeScope("src\\auth"), "src/auth", "a Windows Lead and a POSIX Lead claim the same thing");
+assert.equal(normalizeScope("src/auth/"), "src/auth");
+assert.equal(normalizeScope("  src//auth  "), "src/auth");
+assert.equal(normalizeScope("SRC/Auth"), "SRC/Auth", "case is preserved: paths are case-sensitive where it matters");
+assert.equal(normalizeScope(""), null);
+assert.equal(normalizeScope("   "), null);
+assert.equal(normalizeScope(null), null);
+assert.equal(normalizeScope("../escape"), null, "a scope is a repo-relative path, never an escape");
+assert.equal(normalizeScope("a".repeat(600)), null, "and it is bounded");
+
+// --- conflict is containment, not equality -----------------------------------
+// This is the whole point: claiming `src/auth` must exclude a writer on
+// `src/auth/login`, or the invariant means nothing.
+assert.equal(scopeConflicts("src/auth", "src/auth"), true);
+assert.equal(scopeConflicts("src/auth", "src/auth/login"), true, "a parent scope covers its children");
+assert.equal(scopeConflicts("src/auth/login", "src/auth"), true, "and the check is symmetric");
+assert.equal(scopeConflicts("src/auth", "src/authz"), false, "a shared prefix is not containment");
+assert.equal(scopeConflicts("src/auth", "src/billing"), false);
+assert.equal(scopeConflicts(".", "anything/at/all"), true, "the repo root covers everything");
+assert.equal(scopeConflicts("src/auth", null), false);
+
+// --- record parsing ----------------------------------------------------------
+{
+	const body = ["LEASE_V1", "ACTION: claim", "SCOPE: src/auth", "TTL_MS: 3600000"].join("\n");
+	const record = parseLeaseRecord(body);
+	assert.equal(record.action, "claim");
+	assert.equal(record.scope, "src/auth");
+	assert.equal(record.ttlMs, HOUR);
+}
+// Fail closed: a half-record is not a lease. Treating one as a claim would let
+// a malformed message hold a scope hostage; treating one as a release would
+// hand the scope to a second writer.
+assert.equal(parseLeaseRecord("LEASE_V1\nACTION: claim"), null, "no scope");
+assert.equal(parseLeaseRecord("LEASE_V1\nACTION: seize\nSCOPE: x\nTTL_MS: 1"), null, "unknown action");
+assert.equal(parseLeaseRecord("LEASE_V1\nACTION: claim\nSCOPE: ../x\nTTL_MS: 1"), null, "invalid scope");
+assert.equal(parseLeaseRecord("LEASE_V1\nACTION: claim\nSCOPE: x\nTTL_MS: nope"), null);
+assert.equal(parseLeaseRecord("LEASE_V1\nACTION: claim\nSCOPE: x\nTTL_MS: 0"), null, "a zero TTL is not a lease");
+assert.equal(parseLeaseRecord("no marker"), null);
+assert.equal(parseLeaseRecord(null), null);
+// A release needs no TTL.
+assert.equal(parseLeaseRecord("LEASE_V1\nACTION: release\nSCOPE: src/auth")?.action, "release");
+
+// --- ledger resolution -------------------------------------------------------
+function entry(author, action, scope, ts, ttlMs = HOUR) {
+	const lines = ["LEASE_V1", `ACTION: ${action}`, `SCOPE: ${scope}`];
+	if (action !== "release") lines.push(`TTL_MS: ${ttlMs}`);
+	return { author, createdAt: new Date(ts).toISOString(), body: lines.join("\n") };
+}
+
+{
+	// Two Leads race for the same scope. The room gave them a total order; the
+	// earlier claim wins, and the later one is simply not the holder.
+	const leases = resolveLeases(
+		[entry(LEAD_A, "claim", "src/auth", 1000), entry(LEAD_B, "claim", "src/auth", 1050)],
+		{ now: 2000 },
+	);
+	assert.equal(leaseHolderFor(leases, "src/auth")?.agentId, LEAD_A);
+	assert.equal(leaseHolderFor(leases, "src/auth/login")?.agentId, LEAD_A, "the holder covers children too");
+	assert.equal(leaseHolderFor(leases, "src/billing"), null);
+}
+
+{
+	// The holder is the message AUTHOR, stamped by the daemon — never a field
+	// inside the body, which the sender controls.
+	const forged = entry(LEAD_B, "claim", "src/auth", 1000);
+	forged.body += "\nAGENT_ID: " + LEAD_A;
+	const leases = resolveLeases([forged], { now: 2000 });
+	assert.equal(leaseHolderFor(leases, "src/auth")?.agentId, LEAD_B, "a self-asserted id in the body is ignored");
+}
+
+{
+	// Expiry frees the scope without anyone acting — a Lead that dies holding a
+	// lease must not block the repo forever.
+	const leases = resolveLeases([entry(LEAD_A, "claim", "src/auth", 1000, 500)], { now: 1600 });
+	assert.equal(leaseHolderFor(leases, "src/auth"), null);
+}
+
+{
+	// Renew extends from the renew, not from the original claim.
+	const leases = resolveLeases(
+		[entry(LEAD_A, "claim", "src/auth", 1000, 500), entry(LEAD_A, "renew", "src/auth", 1400, 500)],
+		{ now: 1700 },
+	);
+	assert.equal(leaseHolderFor(leases, "src/auth")?.agentId, LEAD_A);
+}
+
+{
+	// Only the holder can release. Otherwise any Lead could evict another and
+	// the lease would be advice, not a rule.
+	const stolen = resolveLeases(
+		[entry(LEAD_A, "claim", "src/auth", 1000), entry(LEAD_B, "release", "src/auth", 1100)],
+		{ now: 1200 },
+	);
+	assert.equal(leaseHolderFor(stolen, "src/auth")?.agentId, LEAD_A, "a non-holder release is ignored");
+
+	const released = resolveLeases(
+		[entry(LEAD_A, "claim", "src/auth", 1000), entry(LEAD_A, "release", "src/auth", 1100)],
+		{ now: 1200 },
+	);
+	assert.equal(leaseHolderFor(released, "src/auth"), null);
+}
+
+{
+	// After a release the next claim wins — including one that lost the first race.
+	const leases = resolveLeases(
+		[
+			entry(LEAD_A, "claim", "src/auth", 1000),
+			entry(LEAD_B, "claim", "src/auth", 1050),
+			entry(LEAD_A, "release", "src/auth", 1100),
+			entry(LEAD_B, "claim", "src/auth", 1150),
+		],
+		{ now: 1200 },
+	);
+	assert.equal(leaseHolderFor(leases, "src/auth")?.agentId, LEAD_B);
+}
+
+{
+	// A claim that LOSES must not be recorded as a lease under its own key.
+	// Caught live: LEAD-2 claimed `src/auth/login` while LEAD-1 held `src/auth`,
+	// lost as expected — and then inherited the scope the moment LEAD-1 released,
+	// because the losing claim had been stored under a different map key and was
+	// merely being masked on read. A conflict at claim time is a rejection, not a
+	// second lease waiting for its turn.
+	const entries = [
+		entry(LEAD_A, "claim", "src/auth", 1000),
+		entry(LEAD_B, "claim", "src/auth/login", 1050),
+		entry(LEAD_A, "release", "src/auth", 1100),
+	];
+	const leases = resolveLeases(entries, { now: 1200 });
+	assert.equal(leaseHolderFor(leases, "src/auth/login"), null, "a rejected claim does not become a lease later");
+	assert.equal(leaseHolderFor(leases, "src/auth"), null, "and the released parent is genuinely free");
+	assert.equal(leases.size, 0);
+
+	// LEAD-B has to ask again, and then it wins.
+	const after = resolveLeases([...entries, entry(LEAD_B, "claim", "src/auth/login", 1150)], { now: 1200 });
+	assert.equal(leaseHolderFor(after, "src/auth/login")?.agentId, LEAD_B);
+}
+
+{
+	// The mirror case: a child is held, and a parent claim must lose rather than
+	// quietly cover it.
+	const leases = resolveLeases(
+		[entry(LEAD_A, "claim", "src/auth/login", 1000), entry(LEAD_B, "claim", "src/auth", 1050)],
+		{ now: 1200 },
+	);
+	assert.equal(leases.size, 1);
+	assert.equal(leaseHolderFor(leases, "src/auth")?.agentId, LEAD_A, "the narrower, earlier lease keeps the ground");
+}
+
+// Junk in the room is not a lease and must not disturb the ones that are.
+{
+	const leases = resolveLeases(
+		[{ author: LEAD_B, createdAt: "nonsense", body: "hello" }, entry(LEAD_A, "claim", "src/auth", 1000)],
+		{ now: 1100 },
+	);
+	assert.equal(leaseHolderFor(leases, "src/auth")?.agentId, LEAD_A);
+}
+assert.deepEqual([...resolveLeases(null, { now: 0 }).keys()], []);
+
+// --- which create_agent calls even need a lease ------------------------------
+// Only a writer takes a scope. Read-only researchers, scouts and reviewers run
+// in parallel on the same tree by design, and gating them would make the lease
+// a bottleneck instead of a safety rule.
+const writeBrief = (scope: string) =>
+	[
+		"PASEO_TEAM_TASK_V3_BEGIN",
+		"TASK_ID: T-1",
+		"DISPOSITION: engineer",
+		"MODE: write",
+		`OWNED_SCOPE: ${scope}`,
+		"EDIT_AUTHORITY: allowed",
+		"PASEO_TEAM_TASK_V3_END",
+	].join("\n");
+
+assert.equal(writerScopeFromCreateAgent({ initialPrompt: writeBrief("src/auth") }), "src/auth");
+assert.equal(
+	writerScopeFromCreateAgent({ initialPrompt: writeBrief("src/auth").replace("MODE: write", "MODE: read-only") }),
+	null,
+	"a read-only peer needs no lease",
+);
+assert.equal(
+	writerScopeFromCreateAgent({
+		initialPrompt: writeBrief("src/auth").replace("EDIT_AUTHORITY: allowed", "EDIT_AUTHORITY: denied"),
+	}),
+	null,
+	"write mode without edit authority is not a writer",
+);
+assert.equal(writerScopeFromCreateAgent({ initialPrompt: "just a prompt" }), null);
+assert.equal(writerScopeFromCreateAgent({}), null);
+assert.equal(writerScopeFromCreateAgent(null), null);
+// A write brief with no scope is the dangerous case: it writes *somewhere* and
+// says nothing about where. Treat it as claiming the whole repo.
+assert.equal(
+	writerScopeFromCreateAgent({
+		initialPrompt: writeBrief("src/auth").replace("OWNED_SCOPE: src/auth\n", ""),
+	}),
+	".",
+	"an unscoped writer is a repo-wide writer, not an exempt one",
+);
+
+// --- the guard ---------------------------------------------------------------
+const ledgerWith = (...entries: any[]) => resolveLeases(entries, { now: 2000 });
+
+{
+	// The happy path: the Lead holds the scope it is about to staff.
+	const reason = leaseBlockReason({
+		role: "lead",
+		args: { initialPrompt: writeBrief("src/auth") },
+		leases: ledgerWith(entry(LEAD_A, "claim", "src/auth", 1000)),
+		selfAgentId: LEAD_A,
+	});
+	assert.equal(reason, null);
+}
+
+{
+	// Someone else holds it. This is the case the whole PR exists for.
+	const reason = leaseBlockReason({
+		role: "lead",
+		args: { initialPrompt: writeBrief("src/auth/login") },
+		leases: ledgerWith(entry(LEAD_A, "claim", "src/auth", 1000)),
+		selfAgentId: LEAD_B,
+	});
+	assert.match(String(reason), /SCOPE_LEASE_HELD/);
+	assert.match(String(reason), /aaaaaaaa/, "the report names the holder so the Lead can go ask it");
+}
+
+{
+	// Nobody holds it: a Lead must claim before it staffs, or the ledger is
+	// decoration that only the polite Leads use.
+	const reason = leaseBlockReason({
+		role: "lead",
+		args: { initialPrompt: writeBrief("src/auth") },
+		leases: ledgerWith(),
+		selfAgentId: LEAD_A,
+	});
+	assert.match(String(reason), /SCOPE_LEASE_MISSING/);
+}
+
+{
+	// Read-only creation is never gated.
+	assert.equal(
+		leaseBlockReason({
+			role: "lead",
+			args: { initialPrompt: writeBrief("src/auth").replace("MODE: write", "MODE: read-only") },
+			leases: ledgerWith(entry(LEAD_B, "claim", "src/auth", 1000)),
+			selfAgentId: LEAD_A,
+		}),
+		null,
+	);
+}
+
+{
+	// The Supervisor's one create_agent is lead recovery, which staffs no scope
+	// and is already gated by its own argument guard.
+	assert.equal(
+		leaseBlockReason({
+			role: "supervisor",
+			args: { initialPrompt: writeBrief("src/auth") },
+			leases: ledgerWith(),
+			selfAgentId: LEAD_A,
+		}),
+		null,
+	);
+}
+
+{
+	// Fail-closed when the ledger could not be read at all. A Lead that cannot
+	// create a writer is a visible incident; two writers are not.
+	const reason = leaseBlockReason({
+		role: "lead",
+		args: { initialPrompt: writeBrief("src/auth") },
+		leases: null,
+		selfAgentId: LEAD_A,
+	});
+	assert.match(String(reason), /LEASE_UNVERIFIABLE/);
+}
+
+{
+	// And fail-closed when we do not know who we are: an unknown self can never
+	// match a holder, so silently allowing would defeat the check.
+	const reason = leaseBlockReason({
+		role: "lead",
+		args: { initialPrompt: writeBrief("src/auth") },
+		leases: ledgerWith(entry(LEAD_A, "claim", "src/auth", 1000)),
+		selfAgentId: null,
+	});
+	assert.match(String(reason), /LEASE_UNVERIFIABLE/);
+}
+
+console.log("scope-lease tests passed");

--- a/test/team-chat.test.mjs
+++ b/test/team-chat.test.mjs
@@ -18,6 +18,7 @@ import {
 	parseTeamMessage,
 	postTeamMessage,
 	roomAllowed,
+	cliErrorMessage,
 	validateTeamMessage,
 } from "../scripts/team-chat.mjs";
 
@@ -268,6 +269,20 @@ await assert.rejects(
 	const posted = calls.find((c) => c[0] === "chat" && c[1] === "post");
 	assert.ok(!posted[3].startsWith("@"), "and the body carries no mention head");
 	assert.ok(posted[3].startsWith("TEAM_MESSAGE_V1"));
+}
+
+// --- a CLI failure has to say something usable ------------------------------
+// Paseo prints structured errors, so taking "the first non-empty line" of the
+// output yielded exactly `{` — a message that tells the Lead nothing and sends
+// it looking in the wrong place. Observed on a missing chat room.
+{
+	assert.match(cliErrorMessage('{\n  "error": { "message": "chat room not found" }\n}'), /chat room not found/);
+	assert.match(cliErrorMessage('{"message":"boom"}'), /boom/);
+	assert.match(cliErrorMessage("plain failure text"), /plain failure text/);
+	assert.match(cliErrorMessage("\n\n  spaced failure  \n"), /spaced failure/);
+	// Unparseable JSON still beats a lone brace: return something a human can act on.
+	assert.ok(cliErrorMessage("{\n  not json at all").length > 1);
+	assert.ok(cliErrorMessage("").length > 0, "even an empty failure gets a name");
 }
 
 console.log("team-chat tests passed");

--- a/test/team-chat.test.mjs
+++ b/test/team-chat.test.mjs
@@ -237,4 +237,37 @@ await assert.rejects(
 	);
 }
 
+// --- a record is not a request ---------------------------------------------
+// The scope-lease ledger posts into a room, but nobody has to wake up for a
+// bookkeeping entry. Without this, a lease event would have to mention someone
+// — either pulling a Lead out of its work for nothing, or mentioning itself and
+// being woken by its own record.
+{
+	const v = validateTeamMessage({ room: "leases", kind: "claim", topic: "T-1", message: "LEASE", notify: false });
+	assert.equal(v.notify, false);
+	assert.deepEqual(v.to, [], "a record needs no recipients");
+
+	// The default is unchanged: a message without `notify` still requires an
+	// audience, so nothing becomes silently undeliverable by omission.
+	assert.throws(() => validateTeamMessage({ room: "leases", kind: "claim", topic: "T-1", message: "x" }), /to must be/i);
+	assert.throws(
+		() => validateTeamMessage({ ...base, notify: false, to: [OTHER] }),
+		/notify/i,
+		"a record with recipients is a contradiction, not a convenience",
+	);
+}
+{
+	const calls = [];
+	const result = await postTeamMessage(
+		{ room: "leases", kind: "claim", topic: "T-1", message: "LEASE_V1", notify: false },
+		{ selfAgentId: SELF, role: "lead", runPaseo: async (args) => { calls.push(args); return { id: "m", author: SELF }; } },
+	);
+	assert.equal(result.ok, true);
+	assert.deepEqual(result.mentions, []);
+	assert.ok(!calls.some((c) => c[0] === "ls"), "a record resolves no recipients, so it costs no lookup");
+	const posted = calls.find((c) => c[0] === "chat" && c[1] === "post");
+	assert.ok(!posted[3].startsWith("@"), "and the body carries no mention head");
+	assert.ok(posted[3].startsWith("TEAM_MESSAGE_V1"));
+}
+
 console.log("team-chat tests passed");

--- a/test/team-lease.test.mjs
+++ b/test/team-lease.test.mjs
@@ -1,0 +1,172 @@
+/**
+ * team-lease.test.mjs — the I/O half of the scope lease.
+ *
+ * The arbitration itself is pure and lives in scope-lease.test.mts. What is
+ * tested here is the part that talks to the room: that a lease event is posted
+ * as a RECORD (no mention, so no Lead is woken for bookkeeping), that the caller
+ * is told whether it actually won rather than merely that the post succeeded,
+ * and — the one that matters most — that an unreadable ledger is reported as
+ * "unknown" and never as "empty".
+ */
+import assert from "node:assert/strict";
+import {
+	DEFAULT_TTL_MS,
+	LEASE_ROOM,
+	MAX_TTL_MS,
+	claimScope,
+	fetchLeases,
+	leaseStatus,
+	releaseScope,
+	renewScope,
+} from "../scripts/team-lease.mjs";
+
+const SELF = "11111111-1111-4111-8111-111111111111";
+const OTHER = "22222222-2222-4222-8222-222222222222";
+const NOW = 10_000_000;
+
+function record(author, action, scope, at, ttlMs = DEFAULT_TTL_MS) {
+	const lines = ["LEASE_V1", `ACTION: ${action}`, `SCOPE: ${scope}`];
+	if (action !== "release") lines.push(`TTL_MS: ${ttlMs}`);
+	return { id: `m-${at}`, author, createdAt: new Date(at).toISOString(), body: lines.join("\n") };
+}
+
+/** A fake daemon: `chat read` returns the given ledger, `chat post` appends. */
+function fakeRoom(initial = []) {
+	const messages = [...initial];
+	const calls = [];
+	return {
+		messages,
+		calls,
+		run: async (args) => {
+			calls.push(args);
+			if (args[0] === "chat" && args[1] === "read") return messages;
+			if (args[0] === "chat" && args[1] === "post") {
+				const posted = { id: `m-${messages.length}`, author: SELF, createdAt: new Date(NOW - 1).toISOString(), body: args[3] };
+				messages.push(posted);
+				return posted;
+			}
+			throw new Error(`unexpected argv: ${args.join(" ")}`);
+		},
+	};
+}
+
+const opts = (room, extra = {}) => ({
+	runPaseo: room.run,
+	selfAgentId: SELF,
+	role: "lead",
+	now: NOW,
+	...extra,
+});
+
+// --- an unreadable ledger is not an empty one --------------------------------
+// This is the whole safety argument: "nobody holds it" and "we could not find
+// out" must never collapse into the same answer, because the guard treats them
+// as opposite.
+{
+	const result = await fetchLeases({
+		runPaseo: async () => { throw Object.assign(new Error("daemon down"), { code: "CLI_ERROR" }); },
+		selfAgentId: SELF,
+		role: "lead",
+		now: NOW,
+	});
+	assert.equal(result.ok, false);
+	assert.equal(result.leases, null, "null, never an empty map");
+	assert.match(String(result.message), /daemon down/);
+}
+
+// --- claiming a free scope ---------------------------------------------------
+{
+	const room = fakeRoom();
+	const result = await claimScope({ scope: "./src/auth/" }, opts(room));
+	assert.equal(result.ok, true);
+	assert.equal(result.scope, "src/auth", "the scope is normalized before it reaches the ledger");
+	assert.equal(result.granted, true);
+	assert.equal(result.holder.agentId, SELF);
+	assert.equal(result.ttlMs, DEFAULT_TTL_MS);
+
+	const posted = room.calls.find((c) => c[1] === "post");
+	assert.ok(posted[3].includes("LEASE_V1"));
+	assert.ok(posted[3].includes("ACTION: claim"));
+	assert.ok(posted[3].includes("SCOPE: src/auth"));
+	assert.equal(posted[2], LEASE_ROOM);
+	// A record wakes nobody: no mention head, and no recipient lookup was needed.
+	assert.ok(!posted[3].startsWith("@"), "a bookkeeping entry must not pull a Lead out of its work");
+	assert.ok(!room.calls.some((c) => c[0] === "ls"));
+}
+
+// --- losing the race ---------------------------------------------------------
+// The post still succeeds — the room has no compare-and-swap — so the caller
+// must be told who actually holds the scope rather than that the write worked.
+{
+	const room = fakeRoom([record(OTHER, "claim", "src/auth", NOW - 1000)]);
+	const result = await claimScope({ scope: "src/auth/login" }, opts(room));
+	assert.equal(result.ok, true, "posting an intent is not an error");
+	assert.equal(result.granted, false, "but it did not win");
+	assert.equal(result.holder.agentId, OTHER);
+	assert.equal(result.holder.scope, "src/auth", "and the report names the covering scope, not the requested one");
+}
+
+// --- release and renew -------------------------------------------------------
+{
+	const room = fakeRoom([record(SELF, "claim", "src/auth", NOW - 1000)]);
+	const released = await releaseScope({ scope: "src/auth" }, opts(room));
+	assert.equal(released.granted, false, "after releasing, we no longer hold it");
+	assert.equal(released.holder, null);
+	assert.equal(released.ttlMs, null, "a release carries no TTL");
+	assert.ok(room.calls.find((c) => c[1] === "post")[3].includes("ACTION: release"));
+}
+{
+	const room = fakeRoom([record(SELF, "claim", "src/auth", NOW - 1000, 2000)]);
+	const renewed = await renewScope({ scope: "src/auth", ttlMs: 60_000 }, opts(room));
+	assert.equal(renewed.granted, true);
+	assert.ok(renewed.holder.expiresAt > NOW, "the renew pushed the expiry past now");
+}
+
+// --- status ------------------------------------------------------------------
+{
+	const room = fakeRoom([
+		record(OTHER, "claim", "src/billing", NOW - 3000),
+		record(SELF, "claim", "src/auth", NOW - 1000),
+	]);
+	const status = await leaseStatus({}, opts(room));
+	assert.equal(status.ok, true);
+	assert.equal(status.count, 2);
+	assert.deepEqual(status.leases.map((l) => l.scope), ["src/billing", "src/auth"], "oldest claim first");
+	assert.match(status.leases[0].expiresAtIso, /^\d{4}-/, "expiry is readable, not a bare epoch");
+
+	const scoped = await leaseStatus({ scope: "src/auth/login" }, opts(room));
+	assert.equal(scoped.holder.agentId, SELF, "asking about a child scope answers with its covering lease");
+}
+{
+	// An unreadable ledger must be visible in status too, not rendered as "no
+	// leases held" — that reading is what would invite a second writer.
+	const status = await leaseStatus({}, {
+		runPaseo: async () => { throw Object.assign(new Error("nope"), { code: "CLI_ERROR" }); },
+		selfAgentId: SELF,
+		role: "lead",
+		now: NOW,
+	});
+	assert.equal(status.ok, false);
+	assert.equal(status.leases, null);
+}
+
+// --- input validation --------------------------------------------------------
+{
+	const room = fakeRoom();
+	await assert.rejects(claimScope({ scope: "../outside" }, opts(room)), /scope must be/i);
+	await assert.rejects(claimScope({ scope: "" }, opts(room)), /scope must be/i);
+	await assert.rejects(claimScope({}, opts(room)), /scope must be/i);
+	await assert.rejects(claimScope({ scope: "src", ttlMs: 0 }, opts(room)), /ttlMs/);
+	await assert.rejects(claimScope({ scope: "src", ttlMs: MAX_TTL_MS + 1 }, opts(room)), /ttlMs/);
+	await assert.rejects(claimScope({ scope: "src", ttlMs: 1.5 }, opts(room)), /ttlMs/);
+	assert.equal(room.calls.length, 0, "nothing invalid ever reached the room");
+}
+
+// Only Lead and Supervisor hold the chat channel at all, so a Peer cannot post
+// a lease either — the check lives in team-chat and is inherited here.
+{
+	const room = fakeRoom();
+	await assert.rejects(claimScope({ scope: "src" }, opts(room, { role: "peer" })), /ROLE_NOT_ALLOWED/);
+}
+
+console.log("team-lease tests passed");

--- a/test/team-lease.test.mjs
+++ b/test/team-lease.test.mjs
@@ -19,6 +19,7 @@ import {
 	releaseScope,
 	renewScope,
 } from "../scripts/team-lease.mjs";
+import { LEASE_MAX_TTL_MS } from "../extensions/paseo-team-core/policy-core.ts";
 
 const SELF = "11111111-1111-4111-8111-111111111111";
 const OTHER = "22222222-2222-4222-8222-222222222222";
@@ -212,6 +213,51 @@ const opts = (room, extra = {}) => ({
 		/room not found/,
 		"the caller is told what actually failed, not what the recovery attempt failed at",
 	);
+}
+
+// --- the read window must not be able to hide a live lease ------------------
+// Reading "the last N messages" made a live claim invisible once the room moved
+// past it: the scope then read as FREE, which is the silent two-writer outcome
+// this whole mechanism exists to prevent — and any Lead could force it by
+// posting cheap records until a victim's claim fell off the end.
+//
+// The window is therefore time-based, and the bound is the one fact that makes
+// it safe: no lease can outlive LEASE_MAX_TTL_MS, so nothing live can sit
+// outside a window that covers it.
+{
+	let since = null;
+	const run = async (args) => {
+		if (args[0] === "chat" && args[1] === "read") {
+			const index = args.indexOf("--since");
+			since = index >= 0 ? args[index + 1] : null;
+			return [];
+		}
+		throw new Error(`unexpected argv: ${args.join(" ")}`);
+	};
+	const result = await fetchLeases({ runPaseo: run, selfAgentId: SELF, role: "lead", now: NOW });
+	assert.equal(result.ok, true);
+	assert.ok(since, "the ledger is read by time, not by message count");
+	const windowMs = NOW - Date.parse(since);
+	assert.ok(
+		windowMs >= LEASE_MAX_TTL_MS,
+		`the window (${windowMs}ms) must cover the longest possible lease (${LEASE_MAX_TTL_MS}ms)`,
+	);
+}
+
+{
+	// If the daemon still returns a full page, the read may have been cut short
+	// and the board is not known to be complete. Report it as UNREADABLE — a
+	// truncated board that reads as "free" is exactly the failure being fixed.
+	const full = Array.from({ length: 2000 }, (_, i) => record(OTHER, "claim", `src/s${i}`, NOW - 1000));
+	const result = await fetchLeases({
+		runPaseo: async () => full,
+		selfAgentId: SELF,
+		role: "lead",
+		now: NOW,
+	});
+	assert.equal(result.ok, false, "a possibly-truncated read is not a board");
+	assert.equal(result.leases, null);
+	assert.match(String(result.code), /TRUNCATED/);
 }
 
 console.log("team-lease tests passed");

--- a/test/team-lease.test.mjs
+++ b/test/team-lease.test.mjs
@@ -169,4 +169,49 @@ const opts = (room, extra = {}) => ({
 	await assert.rejects(claimScope({ scope: "src" }, opts(room, { role: "peer" })), /ROLE_NOT_ALLOWED/);
 }
 
+// --- the ledger room does not exist yet -------------------------------------
+// First run on a fresh machine: nobody has created the room. Making that the
+// operator's problem would mean the very first claim fails with a CLI error and
+// the Lead has no idea it was supposed to run a setup step.
+{
+	let created = 0;
+	let postAttempts = 0;
+	const messages = [];
+	const run = async (args) => {
+		if (args[0] === "chat" && args[1] === "create") {
+			created += 1;
+			return { id: "room-1", name: args[2] };
+		}
+		if (args[0] === "chat" && args[1] === "post") {
+			postAttempts += 1;
+			if (created === 0) throw Object.assign(new Error("chat room not found"), { code: "CLI_ERROR" });
+			const posted = { id: "m1", author: SELF, createdAt: new Date(NOW - 1).toISOString(), body: args[3] };
+			messages.push(posted);
+			return posted;
+		}
+		if (args[0] === "chat" && args[1] === "read") return messages;
+		throw new Error(`unexpected argv: ${args.join(" ")}`);
+	};
+
+	const result = await claimScope({ scope: "src/auth" }, { runPaseo: run, selfAgentId: SELF, role: "lead", now: NOW });
+	assert.equal(result.granted, true, "the first claim on a fresh machine succeeds");
+	assert.equal(created, 1, "the ledger room is created on demand");
+	assert.equal(postAttempts, 2, "created only after the post showed it was missing — the happy path stays one call");
+}
+
+{
+	// A create that fails for any other reason must not be retried forever, and
+	// the original post error is what the caller needs to see.
+	const run = async (args) => {
+		if (args[0] === "chat" && args[1] === "create") throw Object.assign(new Error("permission denied"), { code: "CLI_ERROR" });
+		if (args[0] === "chat" && args[1] === "post") throw Object.assign(new Error("chat room not found"), { code: "CLI_ERROR" });
+		return [];
+	};
+	await assert.rejects(
+		claimScope({ scope: "src/auth" }, { runPaseo: run, selfAgentId: SELF, role: "lead", now: NOW }),
+		/room not found/,
+		"the caller is told what actually failed, not what the recovery attempt failed at",
+	);
+}
+
 console.log("team-lease tests passed");

--- a/test/watchdog.test.mjs
+++ b/test/watchdog.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { classifyStaleAgents, DEFAULT_GLOBAL_DEADLINE_MS, DEFAULT_INSPECT_CONCURRENCY } from "../scripts/watchdog.mjs";
+import { classifyLeases, classifyStaleAgents, DEFAULT_GLOBAL_DEADLINE_MS, DEFAULT_INSPECT_CONCURRENCY } from "../scripts/watchdog.mjs";
 
 const now = Date.parse("2026-08-08T12:00:00.000Z");
 const result = classifyStaleAgents(
@@ -58,6 +58,39 @@ assert.equal(DEFAULT_GLOBAL_DEADLINE_MS, 30_000);
   });
   assert.equal(capped.agents.length, 2);
   assert.equal(capped.partial, true, "maxAgents cap is reported as partial");
+}
+
+// --- lease board: the second way a scope gets stuck --------------------------
+// A held scope blocks every other Lead, so the two ways it goes wrong deserve an
+// operator's attention: the holder disappeared, or the lease lapsed under a
+// holder that is still running. Neither is something the watchdog may fix —
+// reclaiming ground from a Lead that might be mid-write is exactly how a second
+// writer appears.
+{
+	const now = 10_000_000;
+	const ALIVE = "aaaaaaaa-1111-4111-8111-111111111111";
+	const GONE = "bbbbbbbb-2222-4222-8222-222222222222";
+	const leases = new Map([
+		["src/ok", { agentId: ALIVE, scope: "src/ok", claimedAt: now - 1000, expiresAt: now + 1000 }],
+		["src/orphan", { agentId: GONE, scope: "src/orphan", claimedAt: now - 1000, expiresAt: now + 1000 }],
+		["src/lapsed", { agentId: ALIVE, scope: "src/lapsed", claimedAt: now - 5000, expiresAt: now - 1 }],
+	]);
+	const rows = classifyLeases(leases, [{ id: ALIVE }], { now });
+
+	assert.equal(rows.length, 2, "a healthy lease is not reported — noise would train the operator to skim");
+	const orphan = rows.find((row) => row.scope === "src/orphan");
+	assert.equal(orphan.holderListed, false);
+	assert.equal(orphan.expired, false);
+	assert.match(orphan.suspicion, /not in the agent listing/);
+
+	const lapsed = rows.find((row) => row.scope === "src/lapsed");
+	assert.equal(lapsed.holderListed, true);
+	assert.equal(lapsed.expired, true);
+	assert.match(lapsed.suspicion, /refused/, "the Lead is told what will happen, not merely that it is late");
+
+	// Nothing to report, and nothing to throw, when the board is empty or absent.
+	assert.deepEqual(classifyLeases(new Map(), [{ id: ALIVE }], { now }), []);
+	assert.deepEqual(classifyLeases(null, null, { now }), []);
 }
 
 console.log("watchdog tests passed");


### PR DESCRIPTION
PR-C from `docs/multi-supervisor-topology.md`. **Stacked on #21** — merge that
first; the base here is its head, not `main`.

"One writer per moving scope" is the oldest invariant in this pack, and it has
been holding for a reason that stops being true the moment a second Lead exists:
there was only ever one Lead, so nobody could contend. With several, two Leads
can staff engineers on the same files, and that failure does not announce
itself — it turns up later as a tangled tree or a lost commit. This is the piece
that has to land **before** multi-lead is switched on, which is why the plan put
it ahead of PR-D and PR-E.

## The ledger is evidence, not a lock

The room gives a total order by server timestamp and a daemon-stamped author on
every entry (both measured). What it does not give is compare-and-swap: every
`CLAIM` post succeeds, including the one that loses. So the room is append-only
evidence and **arbitration happens on read**, in a pure fold in `policy-core`.
`scripts/team-lease.mjs` only fetches and posts.

That split is deliberate: the part that decides who owns what has no I/O, so it
is fully testable without a daemon, and the Pi and Claude adapters cannot reach
different conclusions about the same ledger.

Because a claim can lose, the result reports **`granted`**, not merely `ok`. A
Lead that branches on `ok` has learned only that its intent was written down.

## Conflict is containment, not equality

Holding `src/auth` excludes a writer on `src/auth/login`. Equality-only matching
would bind exactly those Leads that happen to spell the scope the same way,
which is not an invariant. Scopes are normalized first, so a Windows Lead and a
POSIX Lead contend for the same ground, and `src/auth` does not swallow
`src/authz`.

## Enforcement, not etiquette

Both adapters gate a Lead's `create_agent`. If the call staffs a writer —
decided from the same V3 brief the Peer will be held to, so the gate and the
grant cannot disagree — it needs a live lease held by that Lead covering the
writer's `OWNED_SCOPE`. Read-only dispositions are never gated; they share a
tree by design and gating them would make the lease a bottleneck rather than a
safety rule.

The gate sits outside the pure `mcpBlockReason` because it must read the room, a
~3s round trip that `create_agent` can afford. **An unreadable ledger is fatal**
(`LEASE_UNVERIFIABLE`) by explicit decision: a Lead that cannot start a writer is
a visible incident with an error message, while two writers on one scope is a
silent one discovered in the git history.

`prompts/lead.md` and step 0 of the Lead skill carry the rule, because a guard
without instructions is a trap — otherwise the first thing a Lead learns about
leases is a refused `create_agent`.

## What running it found that reasoning did not

Two Leads on the real daemon, contending for one scope:

1. LEAD-1 claims `src/auth` → granted.
2. LEAD-2 claims `src/auth/login` → refused, correctly.
3. LEAD-1 releases `src/auth` → **LEAD-2 is suddenly the holder of a scope it
   never won.**

The fold keyed live leases by exact scope string, so the losing claim was stored
under its own key and merely *masked* on read by the live parent; releasing the
parent unmasked it. The unit suite missed it because its "after a release the
next claim wins" case used the same scope string on both claims. Conflicts are
now checked when a claim is **written**, not only when the board is read, and
both the unit case and the live scenario cover it.

Two smaller ones, also only visible by running it: the ledger room had to be
created by hand (the first claim on a fresh machine failed with nothing telling
the Lead a setup step existed), and that failure arrived as the message `{`,
because Paseo answers with pretty-printed JSON and "first non-empty line" stops
being a good heuristic when the first line is a brace.

## Watchdog

The lease board reports exactly two situations, both observation-only: a scope
held by an agent no longer in the listing, and a lease that lapsed under a
still-running holder. A healthy lease is not reported — noise trains the
operator to skim. Nothing is ever reclaimed automatically: taking ground back
from a Lead that might be mid-write is precisely how the second writer appears.

## Verification

- 28/28 suites green, `tsc` clean.
- Pure logic: `test/scope-lease.test.mts` — normalization, containment edges,
  forged holder in the body, expiry, renew, release-by-non-holder, the
  losing-claim regression, and every fail-closed path.
- I/O: `test/team-lease.test.mjs` — record semantics, `granted` vs `ok`,
  unreadable-≠-empty, first-run room creation.
- Wiring on **both** runtimes (`policy.test.mts` drives the real Pi extension
  handler with a stubbed ledger; `claude-policy.test.mjs` covers the Claude
  decision path) — deleting either gate fails a test. That check exists because
  the previous two review rounds each caught a rule wired into only one runtime.
- Live: the two-Lead contention scenario above, the first-run auto-create, and
  the watchdog finding an orphaned lease held by a dead agent.

## Review

One independent round on the first candidate returned **CHANGES_REQUIRED** with
two blockers and five required findings. All nine findings are closed; the four
that mattered are worth naming, because each was a hole in a claim this PR makes
about itself:

- **The gate and the grant disagreed.** The gate demanded a literal
  `EDIT_AUTHORITY: allowed`; the grant defaults edit to true when the field is
  absent under `MODE: write`. A brief the parser accepts without complaint
  produced a writer no lease covered. The gate now asks the same question the
  grant answers.
- **The brief could arrive after creation.** Authority is recomputed per turn,
  so create-then-`send_agent_prompt` walked past a gate that only watched
  `create_agent`. Both calls carry the brief; both are gated now, on both
  runtimes.
- **`mcp_script` was an unguarded path on Pi.** A script's arguments cannot be
  statically verified — the codebase already says so for the Supervisor — and
  the lease gate works by inspecting arguments. `create_agent` and
  `send_agent_prompt` are no longer reachable from a Lead's script surface.
- **The Claude hook never fetched the ledger,** so every writer creation on that
  runtime was refused while the docs claimed the rule worked. It failed closed,
  which is why nothing caught it: the test supplied `leases` itself and so
  proved the decision function, not the hook. The test now drives the hook.

Also fixed: interior `.` segments (`src/./auth` did not conflict with
`src/auth`), case-sensitive comparison on the platforms where those are the same
files, an unbounded TTL in the fold (one smuggled record could lock the repo),
and a Claude Supervisor being able to claim scopes a Pi Supervisor is refused.

The last one was going to be deferred and should not have been: the ledger was
read as "the most recent 300 messages", so a live claim pushed out of the window
by ordinary traffic — or deliberately, since records are cheap — read as absent,
and absent means free. The window is now time-based and bounded by the maximum
lease lifetime, with the message cap kept as a truncation detector that fails
closed.

**This branch has not been re-reviewed since those fixes.** The verdict above
covers the first candidate; four correction commits followed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
