### PR TITLE
chore: ignore the agent tool directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@ node_modules/
 # cluster-routing.local.json, so they are not listed separately.
 *.local.json
 auth.json
+
+# Per-session scratch written by the coding agents that work in this repo:
+# `.zcode/plans/` holds one plan file per session, `.claude/worktrees/` holds
+# throwaway worktrees. Both are machine- and session-local, and neither is
+# project content. `.claude/` is listed even though it is currently invisible
+# to `git status` — git skips EMPTY directories, so it stays quiet only until
+# the next session drops a file in it.
+.zcode/
+.claude/


### PR DESCRIPTION
`.zcode/plans/` (một file plan mỗi phiên) và `.claude/worktrees/` (worktree tạm) là scratch cục bộ theo máy và theo phiên, không phải nội dung dự án. `.zcode/` đã nằm trong `git status` như rác untracked một thời gian.

`.claude/` cũng được thêm dù hiện **không** hiện trong `git status`: git bỏ qua thư mục **rỗng**, và các worktree trong đó vừa được dọn sạch — nó im lặng do tình cờ, và sẽ hiện lại ngay khi phiên sau ghi file vào.

Đã kiểm tra: `git ls-files .zcode .claude` trống ⇒ không giấu đi thứ gì đang được git theo dõi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
