### PR TITLE
fix(patch-paseo-mcp): patch both dist builds, all-or-nothing, with a regex that survives the template literal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paseo-pi-team",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paseo-pi-team",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "UNLICENSED",
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paseo-pi-team",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "description": "Paseo multi-agent role pack — one rule core, two runtimes (pi extension + Claude Code hooks), role prompts, support scripts.",
   "type": "module",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -128,7 +128,7 @@ Write-Host "  support default -> `$env:PI_CODING_AGENT_DIR\extensions\paseo-team
 Write-Host "  env override is optional; no user-profile mutation is required"
 Write-Host ""
 Write-Host "Next steps:"
-Write-Host "  1. The installer checked/installed OCR (capability-probed; >= v1.8.10 kept as-is, pinned v1.9.2 when repairing) and registered the paseo-team MCP server for every installed runtime (Pi mcp.json, and ~/.claude.json when claude is present). The browser is the runtime''s own: Paseo Browser Control on every seat, Claude in Chrome on Claude seats."
+Write-Host "  1. The installer checked/installed OCR (capability-probed; >= v1.8.10 kept as-is, pinned v1.9.2 when repairing) and registered the paseo-team MCP server for every installed runtime (Pi mcp.json, and ~/.claude.json when claude is present). The browser is the runtime's own: Paseo Browser Control on every seat, Claude in Chrome on Claude seats."
 Write-Host "  2. Verify OCR if needed: Get-Command ocr; ocr version"
 Write-Host "  3. Install the MCP adapter (PINNED version - Paseo tools depend on it):"
 Write-Host "     pi install npm:pi-mcp-adapter@2.19.0"

--- a/scripts/patch-paseo-mcp.mjs
+++ b/scripts/patch-paseo-mcp.mjs
@@ -55,22 +55,45 @@ export const PATCH_TARGETS = [
 ];
 
 /**
- * The exact condition the SDK ships. Matched literally rather than by regex:
- * if a future SDK rewords it, this script must FAIL LOUDLY rather than patch
- * something it did not recognise.
+ * The condition the SDK ships, anchored on its full text so that a reworded
+ * upstream check FAILS LOUDLY instead of being patched blind.
+ *
+ * The one thing that legitimately varies is how the constant is referenced:
+ * the ESM build names it bare, the CJS build namespaces it through tsc's
+ * import alias (`types_js_1.SUPPORTED_PROTOCOL_VERSIONS`), and that alias is a
+ * generated name nobody should hardcode. So the qualifier is CAPTURED and
+ * replayed rather than matched literally — a literal match is what let this
+ * script patch the ESM build and then fail on the CJS one, which is worse than
+ * either patching both or refusing both.
  */
-const ORIGINAL_CONDITION =
-	"if (protocolVersion !== null && !SUPPORTED_PROTOCOL_VERSIONS.includes(protocolVersion)) {";
+const CONDITION_RE =
+	/if \(protocolVersion !== null && !((?:[A-Za-z_$][\w$]*\.)?)SUPPORTED_PROTOCOL_VERSIONS\.includes\(protocolVersion\)\) \{/g;
+
+/**
+ * The same shape once patched, for revert. PATCH_MARKER is interpolated raw:
+ * it is a fixed literal with no regex metacharacter in it (`-` is only special
+ * inside a character class). A test pins that, so a marker later edited to
+ * contain one cannot slip through unnoticed.
+ */
+const PATCHED_RE = new RegExp(
+	String.raw`if \(protocolVersion !== null && !((?:[A-Za-z_$][\w$]*\.)?)SUPPORTED_PROTOCOL_VERSIONS\.includes\(protocolVersion\) && !\(/\* ` +
+		PATCH_MARKER +
+		String.raw` \*/ /\^\\d\{4\}-\\d\{2\}-\\d\{2\}\$/\.test\(protocolVersion\) && protocolVersion > (?:[A-Za-z_$][\w$]*\.)?SUPPORTED_PROTOCOL_VERSIONS\[0\]\)\) \{`,
+	"g",
+);
+
+const originalCondition = (qualifier) =>
+	`if (protocolVersion !== null && !${qualifier}SUPPORTED_PROTOCOL_VERSIONS.includes(protocolVersion)) {`;
 
 /**
  * `> SUPPORTED_PROTOCOL_VERSIONS[0]` is a string compare, which is exactly
  * right for zero-padded YYYY-MM-DD: element 0 is LATEST_PROTOCOL_VERSION in
  * every published build of this SDK.
  */
-const PATCHED_CONDITION =
-	"if (protocolVersion !== null && !SUPPORTED_PROTOCOL_VERSIONS.includes(protocolVersion)" +
+const patchedCondition = (qualifier) =>
+	`if (protocolVersion !== null && !${qualifier}SUPPORTED_PROTOCOL_VERSIONS.includes(protocolVersion)` +
 	` && !(/* ${PATCH_MARKER} */ /^\\d{4}-\\d{2}-\\d{2}$/.test(protocolVersion)` +
-	" && protocolVersion > SUPPORTED_PROTOCOL_VERSIONS[0])) {";
+	` && protocolVersion > ${qualifier}SUPPORTED_PROTOCOL_VERSIONS[0])) {`;
 
 export class PatchError extends Error {
 	constructor(code, message) {
@@ -81,6 +104,23 @@ export class PatchError extends Error {
 }
 
 /**
+ * Exactly one match, or refuse: zero means the check moved or was reworded,
+ * and more than one means this file has a shape the patch was never designed
+ * for and guessing which occurrence to rewrite is not a decision a script gets
+ * to make.
+ */
+function soleMatch(source, re, what) {
+	const matches = [...source.matchAll(re)];
+	if (matches.length === 1) return matches[0];
+	throw new PatchError(
+		"PATTERN_NOT_FOUND",
+		matches.length === 0
+			? `${what} does not look the way this patch expects — refusing to guess. Report it rather than editing by hand: the check may have moved, or upstream may have fixed it, in which case this script is no longer needed`
+			: `${what} matched ${matches.length} times in one file; this patch rewrites exactly one occurrence and will not choose between them`,
+	);
+}
+
+/**
  * Rewrite one file's source. Pure, so the transform is testable without a
  * Paseo install on disk.
  *
@@ -88,14 +128,16 @@ export class PatchError extends Error {
  */
 export function patchSource(source) {
 	if (source.includes(PATCH_MARKER)) return { source, state: "already" };
-	if (!source.includes(ORIGINAL_CONDITION)) {
-		throw new PatchError(
-			"PATTERN_NOT_FOUND",
-			"the SDK's protocol-version check does not look the way this patch expects — refusing to guess. Report it rather than editing by hand: the check may have moved, or upstream may have fixed it, in which case this script is no longer needed",
-		);
-	}
+	const [, qualifier] = soleMatch(
+		source,
+		CONDITION_RE,
+		"the SDK's protocol-version check",
+	);
 	return {
-		source: source.replace(ORIGINAL_CONDITION, PATCHED_CONDITION),
+		source: source.replace(
+			originalCondition(qualifier),
+			patchedCondition(qualifier),
+		),
 		state: "patched",
 	};
 }
@@ -103,14 +145,16 @@ export function patchSource(source) {
 /** Undo patchSource. Returns the source unchanged when it was never patched. */
 export function revertSource(source) {
 	if (!source.includes(PATCH_MARKER)) return { source, state: "already" };
-	if (!source.includes(PATCHED_CONDITION)) {
-		throw new PatchError(
-			"PATTERN_NOT_FOUND",
-			"the file carries this patch's marker but not the text it writes — it was edited by something else. Reinstall Paseo instead of reverting blind",
-		);
-	}
+	const [, qualifier] = soleMatch(
+		source,
+		PATCHED_RE,
+		"this patch's own marker, but the text around it,",
+	);
 	return {
-		source: source.replace(PATCHED_CONDITION, ORIGINAL_CONDITION),
+		source: source.replace(
+			patchedCondition(qualifier),
+			originalCondition(qualifier),
+		),
 		state: "reverted",
 	};
 }
@@ -163,7 +207,13 @@ export function runPatch({ sdkDir, mode = "apply" } = {}) {
 			`no MCP SDK at ${sdkDir} — is @getpaseo/cli installed globally? Pass --sdk-dir <dir> if it lives elsewhere`,
 		);
 	}
-	const files = [];
+	// TWO PHASES, and the split is the point. The ESM and CJS builds of this SDK
+	// spell the same check differently, so transforming-and-writing in one pass
+	// let a first file be rewritten and a second one throw — leaving the daemon
+	// with one build patched and one not, which is a worse state than either
+	// end and a silent one. Every transform is computed first; nothing is
+	// written unless all of them succeeded.
+	const planned = [];
 	for (const relative of PATCH_TARGETS) {
 		const path = join(sdkDir, relative);
 		if (!existsSync(path)) {
@@ -174,7 +224,7 @@ export function runPatch({ sdkDir, mode = "apply" } = {}) {
 		}
 		const before = readFileSync(path, "utf8");
 		if (mode === "verify") {
-			files.push({
+			planned.push({
 				file: relative,
 				state: before.includes(PATCH_MARKER) ? "already" : "unpatched",
 			});
@@ -182,13 +232,21 @@ export function runPatch({ sdkDir, mode = "apply" } = {}) {
 		}
 		const { source, state } =
 			mode === "revert" ? revertSource(before) : patchSource(before);
-		if (source !== before) {
-			const backup = `${path}.paseo-team-backup`;
-			if (mode === "apply" && !existsSync(backup)) copyFileSync(path, backup);
-			writeFileSync(path, source);
-		}
-		files.push({ file: relative, state });
+		planned.push({ file: relative, state, path, before, source });
 	}
+	if (mode !== "verify") {
+		for (const entry of planned) {
+			if (entry.source === entry.before) continue;
+			const backup = `${entry.path}.paseo-team-backup`;
+			// Only on the first real write: a second apply must not overwrite the
+			// pristine copy with an already-patched one.
+			if (mode === "apply" && !existsSync(backup)) {
+				copyFileSync(entry.path, backup);
+			}
+			writeFileSync(entry.path, entry.source);
+		}
+	}
+	const files = planned.map(({ file, state }) => ({ file, state }));
 	const patched = files.every((entry) => entry.state !== "unpatched");
 	return { ok: mode !== "verify" || patched, sdkDir, mode, files, patched };
 }

--- a/test/patch-paseo-mcp.test.mjs
+++ b/test/patch-paseo-mcp.test.mjs
@@ -32,6 +32,15 @@ const ORIGINAL = `    validateProtocolVersion(req) {
     }
 `;
 
+// The SAME check from the CJS build of the same version, where tsc namespaces
+// the constant through its generated import alias. Live-run finding: matching
+// the ESM spelling literally patched dist/esm and then threw on dist/cjs,
+// leaving the daemon with one build patched and one not.
+const ORIGINAL_CJS = ORIGINAL.replace(
+	"!SUPPORTED_PROTOCOL_VERSIONS.includes",
+	"!types_js_1.SUPPORTED_PROTOCOL_VERSIONS.includes",
+);
+
 const SUPPORTED = [
 	"2025-11-25",
 	"2025-06-18",
@@ -76,10 +85,44 @@ assert.equal(reverted.source, ORIGINAL);
 assert.equal(revertSource(ORIGINAL).state, "already");
 
 // An SDK whose guard we do not recognise must fail loudly rather than be
-// half-patched: the whole point of matching the condition literally.
+// half-patched: the whole point of anchoring on the condition's full text.
 assert.throws(
 	() => patchSource("function validateProtocolVersion() { return undefined; }"),
 	(err) => err instanceof PatchError && err.code === "PATTERN_NOT_FOUND",
+);
+// Two occurrences in one file is a shape this patch was not designed for, and
+// picking one is not a decision a script gets to make.
+assert.throws(
+	() => patchSource(ORIGINAL + ORIGINAL),
+	(err) => err instanceof PatchError && err.code === "PATTERN_NOT_FOUND",
+);
+
+// --- the CJS spelling of the very same check ----------------------------------
+
+const cjs = patchSource(ORIGINAL_CJS);
+assert.equal(cjs.state, "patched");
+assert.ok(cjs.source.includes(PATCH_MARKER));
+// The generated alias is replayed, never hardcoded and never dropped: writing
+// a bare SUPPORTED_PROTOCOL_VERSIONS into the CJS build would throw at runtime.
+assert.ok(
+	cjs.source.includes("types_js_1.SUPPORTED_PROTOCOL_VERSIONS[0]"),
+	"the captured qualifier must be replayed in the added clause",
+);
+// Every mention in the patched CJS source stays namespaced -- a bare one would
+// be a ReferenceError the moment the daemon served a request.
+assert.equal(
+	(cjs.source.match(/SUPPORTED_PROTOCOL_VERSIONS/g) ?? []).length,
+	(cjs.source.match(/types_js_1\.SUPPORTED_PROTOCOL_VERSIONS/g) ?? []).length,
+);
+assert.equal(revertSource(cjs.source).source, ORIGINAL_CJS);
+assert.equal(patchSource(cjs.source).state, "already");
+
+// PATCHED_RE interpolates the marker into a regex unescaped, which is only safe
+// while the marker carries no metacharacter.
+assert.equal(
+	/[.*+?^${}()|[\]\\]/.test(PATCH_MARKER),
+	false,
+	"PATCH_MARKER must stay free of regex metacharacters, or PATCHED_RE must escape it",
 );
 
 // --- the decision the patched condition makes ---------------------------------
@@ -159,6 +202,53 @@ assert.throws(
 	() => runPatch({ sdkDir: join(sdkDir, "nope"), mode: "verify" }),
 	(err) => err instanceof PatchError && err.code === "SDK_NOT_FOUND",
 );
+
+// --- all files, or none -------------------------------------------------------
+//
+// The two dist builds spell the check differently, so a transform that writes
+// as it goes can rewrite the first file and throw on the second, leaving one
+// build patched and one not. That is worse than either end, and silent.
+{
+	const mixed = mkdtempSync(join(tmpdir(), "paseo-mcp-mixed-"));
+	const [first, second] = PATCH_TARGETS;
+	mkdirSync(dirname(join(mixed, first)), { recursive: true });
+	mkdirSync(dirname(join(mixed, second)), { recursive: true });
+	writeFileSync(join(mixed, first), ORIGINAL);
+	writeFileSync(join(mixed, second), "nothing this patch recognises");
+
+	assert.throws(
+		() => runPatch({ sdkDir: mixed, mode: "apply" }),
+		(err) => err instanceof PatchError && err.code === "PATTERN_NOT_FOUND",
+	);
+	assert.equal(
+		readFileSync(join(mixed, first), "utf8"),
+		ORIGINAL,
+		"a file that COULD be patched must be left alone when a sibling cannot",
+	);
+	assert.ok(
+		!existsSync(join(mixed, `${first}.paseo-team-backup`)),
+		"and no backup is written for a write that never happened",
+	);
+}
+
+// A mixed ESM/CJS install — the real layout — patches both.
+{
+	const both = mkdtempSync(join(tmpdir(), "paseo-mcp-both-"));
+	const [esmTarget, cjsTarget] = PATCH_TARGETS;
+	mkdirSync(dirname(join(both, esmTarget)), { recursive: true });
+	mkdirSync(dirname(join(both, cjsTarget)), { recursive: true });
+	writeFileSync(join(both, esmTarget), ORIGINAL);
+	writeFileSync(join(both, cjsTarget), ORIGINAL_CJS);
+
+	assert.equal(runPatch({ sdkDir: both, mode: "apply" }).patched, true);
+	assert.equal(runPatch({ sdkDir: both, mode: "verify" }).patched, true);
+	assert.ok(
+		readFileSync(join(both, cjsTarget), "utf8").includes("types_js_1.SUPPORTED_PROTOCOL_VERSIONS[0]"),
+	);
+	runPatch({ sdkDir: both, mode: "revert" });
+	assert.equal(readFileSync(join(both, esmTarget), "utf8"), ORIGINAL);
+	assert.equal(readFileSync(join(both, cjsTarget), "utf8"), ORIGINAL_CJS);
+}
 
 // --- locating the SDK ---------------------------------------------------------
 


### PR DESCRIPTION
Found by running v3.0.0's own script against a real Paseo install while updating a machine. Three bugs, each of which made the patch worse than not having one.

**1. The CJS build spells the check differently.** tsc namespaces the constant through its generated import alias:

```js
// dist/esm
if (protocolVersion !== null && !SUPPORTED_PROTOCOL_VERSIONS.includes(protocolVersion)) {
// dist/cjs
if (protocolVersion !== null && !types_js_1.SUPPORTED_PROTOCOL_VERSIONS.includes(protocolVersion)) {
```

The literal match only knew the ESM spelling. The qualifier is now **captured and replayed**, so the added clause references the same binding the file already uses — writing a bare name into the CJS build would have been a `ReferenceError` on the first request the daemon served. The alias is a generated name, so it is matched by shape (`(?:[A-Za-z_$][\w$]*\.)?`) rather than hardcoded.

**2. The apply was not atomic across files.** It transformed-and-wrote in one pass, so the ESM build was rewritten and the CJS build then threw — leaving the SDK with one build patched and one not, which is a worse state than either end and a silent one. That is exactly what the live run produced. Every transform is now computed first; nothing is written unless all of them succeeded.

**3. The emitted patch's own regex was dead.** Moving `patchedCondition` into a template literal turned `\d` into `\d`, and `\d` in a template literal is an unknown escape that collapses to `d`. So the patch wrote:

```js
/^d{4}-d{2}-d{2}$/.test(protocolVersion)
```

which matches the literal text `d{4}-d{2}-d{2}` and nothing else. The clause was always false — **the patch applied, reported success, and changed no behaviour at all.**

## Why the tests did not catch it

Worth dwelling on. The existing test evaluated the patched *condition* rather than asserting on its text, which is the right instinct — but it built its fixture from the ESM shape only and fed it into both target paths, so the two dialects never differed and the atomicity gap could not appear. Bug 3 slipped through the same hole: a single fixture, patched and evaluated, with no assertion that the *file on disk* would behave.

Now pinned:

- the CJS spelling verbatim, with every mention asserted to stay namespaced after patching;
- a mixed ESM/CJS install patches both, round-trips both, and reverts both;
- an install where one file is unpatchable leaves the other **untouched** and writes no backup;
- two occurrences in one file is a refusal, not a guess;
- `PATCH_MARKER` is asserted free of regex metacharacters, because `PATCHED_RE` interpolates it raw.

## Verified on the live install

```
--revert   reverted / already      (cleaning up the half-patched state)
--verify   unpatched / unpatched
--apply    patched  / patched
--verify   already  / already
```

and on disk, each build with its own qualifier:

```
protocolVersion > SUPPORTED_PROTOCOL_VERSIONS[0]
protocolVersion > types_js_1.SUPPORTED_PROTOCOL_VERSIONS[0]
```

Condition behaviour, evaluated against both dialects: `2026-07-28` passes, `2025-11-25` passes, `latest` still rejected.

Also fixes a doubled apostrophe in `install.ps1`'s closing notes — `''` is only an escape inside a *single*-quoted PowerShell string, so the double-quoted one printed it literally.

`136/136` tests, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErLWykvCwksrcozLjMeZs5
